### PR TITLE
refactor: Decouple darnit framework from implementations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,212 @@
+# Darnit Project Guidelines
+
+This document provides architectural guidelines and development rules for the darnit project.
+
+## Architecture Overview
+
+Darnit is an AI-powered compliance auditing framework with a plugin architecture that separates the core framework from compliance implementations.
+
+### Package Structure
+
+```
+packages/
+├── darnit/                  # Core framework (MUST NOT import implementations)
+│   └── src/darnit/
+│       ├── core/            # Plugin system, discovery, logging
+│       ├── sieve/           # 4-phase verification pipeline
+│       ├── config/          # Configuration loading and merging
+│       ├── tools/           # MCP tool implementations
+│       └── server/          # MCP server setup
+│
+├── darnit-baseline/         # OpenSSF Baseline implementation
+│   └── src/darnit_baseline/
+│       ├── controls/        # Python-defined control checks
+│       ├── checks/          # Legacy check functions
+│       ├── remediation/     # Auto-fix actions
+│       └── rules/           # SARIF rule catalog
+│
+└── darnit-testchecks/       # Test implementation (for testing)
+```
+
+## Separation Rules
+
+### Rule 1: Framework MUST NOT Import Implementations
+
+The `darnit` package must never directly import implementation packages.
+
+```python
+# ❌ WRONG - Creates hard dependency
+import darnit_baseline
+from darnit_baseline.controls import level1
+
+# ✅ CORRECT - Use plugin discovery
+from darnit.core.discovery import get_default_implementation
+impl = get_default_implementation()
+if impl:
+    controls = impl.get_all_controls()
+```
+
+### Rule 2: Implementations MAY Import Framework
+
+Implementation packages can freely import from the framework.
+
+```python
+# ✅ OK - Implementation importing framework
+from darnit.core.plugin import ComplianceImplementation, ControlSpec
+from darnit.sieve import register_control
+```
+
+### Rule 3: Use Protocol Methods for Cross-Package Communication
+
+All framework-to-implementation communication must go through the `ComplianceImplementation` protocol.
+
+```python
+# Protocol methods available:
+impl.name                        # str: Implementation identifier
+impl.display_name                # str: Human-readable name
+impl.version                     # str: Implementation version
+impl.spec_version                # str: Spec version implemented
+impl.get_all_controls()          # List[ControlSpec]: All controls
+impl.get_controls_by_level(n)    # List[ControlSpec]: Controls at level n
+impl.get_check_functions()       # Dict: Legacy check functions
+impl.get_rules_catalog()         # Dict: SARIF rule definitions
+impl.get_remediation_registry()  # Dict: Auto-fix mappings
+impl.get_framework_config_path() # Path | None: TOML config location
+impl.register_controls()         # None: Register Python controls
+```
+
+## Plugin System
+
+### Entry Points
+
+Implementations register via Python entry points in `pyproject.toml`:
+
+```toml
+[project.entry-points."darnit.implementations"]
+openssf-baseline = "darnit_baseline:register"
+```
+
+### Creating a New Implementation
+
+1. Create a new package with the implementation class:
+
+```python
+# my_framework/implementation.py
+from pathlib import Path
+from darnit.core.plugin import ComplianceImplementation, ControlSpec
+
+class MyFrameworkImplementation:
+    @property
+    def name(self) -> str:
+        return "my-framework"
+
+    @property
+    def display_name(self) -> str:
+        return "My Compliance Framework"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    @property
+    def spec_version(self) -> str:
+        return "MySpec v1.0"
+
+    def get_all_controls(self) -> list[ControlSpec]:
+        # Return your control definitions
+        ...
+
+    def get_framework_config_path(self) -> Path | None:
+        return Path(__file__).parent / "my-framework.toml"
+
+    def register_controls(self) -> None:
+        from .controls import checks  # noqa: F401
+```
+
+2. Add the registration function:
+
+```python
+# my_framework/__init__.py
+def register():
+    from .implementation import MyFrameworkImplementation
+    return MyFrameworkImplementation()
+```
+
+3. Register via entry point:
+
+```toml
+[project.entry-points."darnit.implementations"]
+my-framework = "my_framework:register"
+```
+
+## Sieve Pattern
+
+The verification pipeline follows a 4-phase pattern:
+
+```
+DETERMINISTIC → PATTERN → LLM → MANUAL
+     ↓              ↓        ↓       ↓
+  Exact checks   Heuristics  AI    Human
+  (high conf)    (med conf)  eval  review
+```
+
+Each control can define passes at each phase. The orchestrator stops at the first conclusive result.
+
+## Development Guidelines
+
+### Adding New Controls
+
+1. Define the control in the framework TOML file
+2. Optionally add Python pass definitions in `controls/level*.py`
+3. Register using the `@register_control` decorator
+
+### Testing
+
+```bash
+# Run all tests
+uv run pytest tests/ -v
+
+# Run only framework tests
+uv run pytest tests/darnit/ -v
+
+# Run only implementation tests
+uv run pytest tests/darnit_baseline/ -v
+```
+
+### Linting
+
+```bash
+# Check for issues
+uv run ruff check .
+
+# Auto-fix issues
+uv run ruff check --fix .
+
+# Format code
+uv run ruff format .
+```
+
+## Common Patterns
+
+### Checking for Protocol Methods
+
+Use `hasattr()` for backward compatibility when adding new protocol methods:
+
+```python
+impl = get_default_implementation()
+if impl and hasattr(impl, "new_method"):
+    impl.new_method()
+```
+
+### Graceful Degradation
+
+Always handle missing implementations gracefully:
+
+```python
+impl = get_default_implementation()
+if impl:
+    result = impl.get_all_controls()
+else:
+    logger.warning("No implementation found")
+    result = []
+```

--- a/packages/darnit-baseline/src/darnit_baseline/__init__.py
+++ b/packages/darnit-baseline/src/darnit_baseline/__init__.py
@@ -23,16 +23,17 @@ __version__ = "0.1.0"
 from pathlib import Path
 
 
-def get_framework_path() -> Path:
+def get_framework_path() -> Path | None:
     """Get the path to the OpenSSF Baseline framework TOML file.
 
-    This function is called by darnit's plugin registry via entry points
-    to locate the framework definition file.
+    This delegates to the implementation's get_framework_config_path() method
+    to avoid duplicate path logic.
 
     Returns:
-        Path: Absolute path to openssf-baseline.toml.
+        Path: Absolute path to openssf-baseline.toml, or None if not found.
     """
-    return Path(__file__).parent.parent.parent / "openssf-baseline.toml"
+    from .implementation import OSPSBaselineImplementation
+    return OSPSBaselineImplementation().get_framework_config_path()
 
 
 def register():

--- a/packages/darnit-baseline/src/darnit_baseline/implementation.py
+++ b/packages/darnit-baseline/src/darnit_baseline/implementation.py
@@ -4,6 +4,7 @@ This module provides the OSPSBaselineImplementation class that implements
 the darnit ComplianceImplementation protocol for OpenSSF Baseline (OSPS v2025.10.10).
 """
 
+from pathlib import Path
 from typing import Any
 
 from darnit.core.plugin import ControlSpec
@@ -83,6 +84,23 @@ class OSPSBaselineImplementation:
         """Get the remediation registry for auto-fixes."""
         from .remediation.registry import REMEDIATION_REGISTRY
         return REMEDIATION_REGISTRY
+
+    def get_framework_config_path(self) -> Path | None:
+        """Get path to the OpenSSF Baseline framework TOML file.
+
+        Returns:
+            Path to openssf-baseline.toml in the package root.
+        """
+        # Navigate from implementation.py to package root:
+        # implementation.py -> darnit_baseline -> src -> darnit-baseline -> openssf-baseline.toml
+        return Path(__file__).parent.parent.parent / "openssf-baseline.toml"
+
+    def register_controls(self) -> None:
+        """Register Python-defined controls with the sieve registry.
+
+        This imports the control modules which register controls via decorators.
+        """
+        from .controls import level1, level2, level3  # noqa: F401
 
 
 __all__ = ["OSPSBaselineImplementation"]

--- a/packages/darnit/src/darnit/core/plugin.py
+++ b/packages/darnit/src/darnit/core/plugin.py
@@ -7,6 +7,7 @@ Implementations register via Python entry points under 'darnit.implementations'.
 """
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 
@@ -99,6 +100,38 @@ class ComplianceImplementation(Protocol):
 
     def get_remediation_registry(self) -> dict[str, Any]:
         """Get the remediation registry for auto-fixes."""
+        ...
+
+    def get_framework_config_path(self) -> Path | None:
+        """Get path to the framework configuration file (e.g., TOML).
+
+        This method enables the framework to locate implementation-specific
+        configuration files without hardcoding paths or importing implementation
+        packages directly.
+
+        Returns:
+            Path to the framework config file, or None if not applicable.
+
+        Example:
+            # In openssf-baseline implementation:
+            def get_framework_config_path(self) -> Path | None:
+                return Path(__file__).parent.parent.parent / "openssf-baseline.toml"
+        """
+        ...
+
+    def register_controls(self) -> None:
+        """Register this implementation's Python-defined controls.
+
+        Implementations should import their control modules here to trigger
+        registration via decorators (e.g., @register_control). This allows
+        the framework to load controls without knowing implementation-specific
+        module paths.
+
+        Example:
+            # In openssf-baseline implementation:
+            def register_controls(self) -> None:
+                from .controls import level1, level2, level3  # noqa: F401
+        """
         ...
 
 

--- a/packages/darnit/src/darnit/tools/audit.py
+++ b/packages/darnit/src/darnit/tools/audit.py
@@ -128,33 +128,28 @@ _effective_config_cache: dict[str, Any] = {}
 
 
 def _get_framework_config_path() -> Path | None:
-    """Get path to the framework TOML file from the installed package.
+    """Get path to the framework TOML file via plugin discovery.
+
+    This uses the ComplianceImplementation protocol to get the framework
+    config path, avoiding direct imports of implementation packages.
 
     Returns:
-        Path to openssf-baseline.toml or None if not found
+        Path to framework TOML file or None if not found
     """
     try:
-        import darnit_baseline
-        # darnit_baseline.__file__ is like:
-        # .../packages/darnit-baseline/src/darnit_baseline/__init__.py
-        # We need: .../packages/darnit-baseline/openssf-baseline.toml
-        init_path = Path(darnit_baseline.__file__)
-        # Go up: __init__.py -> darnit_baseline -> src -> darnit-baseline
-        package_root = init_path.parent.parent.parent
+        from darnit.core.discovery import get_default_implementation
 
-        # Try standard locations
-        candidates = [
-            package_root / "openssf-baseline.toml",
-            init_path.parent / "openssf-baseline.toml",  # Inside package
-            package_root / "src" / "openssf-baseline.toml",
-        ]
+        impl = get_default_implementation()
+        if impl and hasattr(impl, "get_framework_config_path"):
+            path = impl.get_framework_config_path()
+            if path and path.exists():
+                return path
+            logger.debug(f"Framework config path from {impl.name} does not exist: {path}")
+        elif impl:
+            logger.debug(f"Implementation {impl.name} does not provide get_framework_config_path()")
+        else:
+            logger.debug("No compliance implementation found")
 
-        for candidate in candidates:
-            if candidate.exists():
-                return candidate
-
-    except ImportError:
-        logger.debug("darnit_baseline not installed")
     except Exception as e:
         logger.debug(f"Error locating framework config: {e}")
 
@@ -467,14 +462,20 @@ def _run_sieve_checks(
     SieveOrchestrator = sieve["SieveOrchestrator"]
     CheckContext = sieve["CheckContext"]
 
-    # Register Python-defined controls first
+    # Register Python-defined controls first via plugin system
     # These take priority over TOML definitions for the same control_id
     try:
-        import darnit_baseline.controls.level1  # noqa: F401
-        import darnit_baseline.controls.level2  # noqa: F401
-        import darnit_baseline.controls.level3  # noqa: F401
-        logger.debug("Registered Python control definitions")
-    except ImportError as e:
+        from darnit.core.discovery import get_default_implementation
+
+        impl = get_default_implementation()
+        if impl and hasattr(impl, "register_controls"):
+            impl.register_controls()
+            logger.debug(f"Registered Python control definitions from {impl.name}")
+        elif impl:
+            logger.debug(f"Implementation {impl.name} does not provide register_controls()")
+        else:
+            logger.debug("No compliance implementation found for control registration")
+    except Exception as e:
         logger.debug(f"Python control modules not available: {e}")
 
     # Register controls from TOML framework definition

--- a/tests/darnit/core/test_plugin.py
+++ b/tests/darnit/core/test_plugin.py
@@ -1,5 +1,6 @@
 """Tests for darnit.core.plugin module."""
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -97,6 +98,12 @@ class MockImplementation:
 
     def get_remediation_registry(self) -> dict[str, Any]:
         return {}
+
+    def get_framework_config_path(self) -> Path | None:
+        return None
+
+    def register_controls(self) -> None:
+        pass
 
 
 class TestComplianceImplementation:


### PR DESCRIPTION
## Summary

- Remove hard dependencies on `darnit-baseline` from the core `darnit` framework
- Extend `ComplianceImplementation` protocol with two new methods for plugin discovery
- Add `CLAUDE.md` documenting architectural boundaries and separation rules

## Changes

### Protocol Extension (`darnit/core/plugin.py`)
- Added `get_framework_config_path() -> Path | None` - Returns path to framework TOML config
- Added `register_controls() -> None` - Registers Python-defined controls with sieve

### Implementation Updates (`darnit-baseline`)
- Implemented new protocol methods in `OSPSBaselineImplementation`
- Delegated `get_framework_path()` in `__init__.py` to implementation

### Framework Decoupling (`darnit/tools/audit.py`)
- Replaced `import darnit_baseline` with plugin discovery via `get_default_implementation()`
- Replaced direct control module imports with `impl.register_controls()`

### Documentation
- Created `CLAUDE.md` with architectural guidelines, separation rules, and plugin system docs

## Why This Matters

This enables:
- Using darnit with other compliance frameworks (ISO 27001, SOC2, NIST)
- Installing darnit without darnit-baseline
- True separation of concerns between framework and implementations

## Test plan

- [x] All 551 tests pass
- [x] Verified zero `import darnit_baseline` statements in framework package
- [x] Verified plugin discovery works with new methods
- [x] Verified CLAUDE.md documents the architectural boundaries

🤖 Generated with [Claude Code](https://claude.ai/code)