### PR TITLE
feat: Enable TOML to reference Python check functions

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -566,13 +566,10 @@ project_path = "documentation.changelog"
 discover = ["CHANGELOG.md", "CHANGES.md", "HISTORY.md", "NEWS.md"]
 kind = "file"
 
-[controls."OSPS-BR-04.01".passes]
-deterministic = { file_must_exist = [
-    "CHANGELOG.md",
-    "CHANGES.md",
-    "HISTORY.md",
-    "NEWS.md",
-]}
+# Check order: config_check (GitHub releases API) runs first; file_must_exist is fallback
+[controls."OSPS-BR-04.01".passes.deterministic]
+config_check = "darnit_baseline.controls.level2:_create_changelog_check"
+file_must_exist = ["CHANGELOG.md", "CHANGES.md", "HISTORY.md", "NEWS.md"]
 
 [controls."OSPS-BR-04.01".passes.manual]
 steps = [

--- a/packages/darnit-baseline/src/darnit_baseline/controls/level2.py
+++ b/packages/darnit-baseline/src/darnit_baseline/controls/level2.py
@@ -56,6 +56,7 @@ def _gh_api(endpoint: str) -> dict | None:
 def _file_exists(local_path: str, *patterns: str) -> bool:
     """Check if any of the given file patterns exist."""
     import glob as glob_module
+
     for pattern in patterns:
         if "*" in pattern:
             matches = glob_module.glob(os.path.join(local_path, pattern), recursive=True)
@@ -72,7 +73,7 @@ def _read_file(local_path: str, filename: str) -> str | None:
     filepath = os.path.join(local_path, filename)
     if os.path.exists(filepath):
         try:
-            with open(filepath, encoding='utf-8', errors='ignore') as f:
+            with open(filepath, encoding="utf-8", errors="ignore") as f:
                 return f.read()
         except OSError as e:
             logger.debug(f"Could not read {filepath}: {type(e).__name__}")
@@ -133,10 +134,10 @@ def _create_permissions_check() -> Callable[[CheckContext], PassResult]:
 
         for root, _, files in os.walk(workflow_dir):
             for file in files:
-                if file.endswith(('.yml', '.yaml')):
+                if file.endswith((".yml", ".yaml")):
                     workflows_checked.append(file)
                     content = _read_file(root, file) or ""
-                    if re.search(r'^permissions:', content, re.MULTILINE):
+                    if re.search(r"^permissions:", content, re.MULTILINE):
                         has_permissions_defined = True
 
         if has_permissions_defined:
@@ -157,23 +158,25 @@ def _create_permissions_check() -> Callable[[CheckContext], PassResult]:
     return check
 
 
-register_control(ControlSpec(
-    control_id="OSPS-AC-04.01",
-    level=2,
-    domain="AC",
-    name="CICDLowestPermissions",
-    description="CI/CD pipelines default to lowest permissions",
-    passes=[
-        DeterministicPass(config_check=_create_permissions_check()),
-        ManualPass(
-            verification_steps=[
-                "Check GitHub Actions workflows for 'permissions:' block",
-                "Verify permissions are set to minimum required",
-                "Consider adding 'permissions: {}' at workflow level",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-AC-04.01",
+        level=2,
+        domain="AC",
+        name="CICDLowestPermissions",
+        description="CI/CD pipelines default to lowest permissions",
+        passes=[
+            DeterministicPass(config_check=_create_permissions_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check GitHub Actions workflows for 'permissions:' block",
+                    "Verify permissions are set to minimum required",
+                    "Consider adding 'permissions: {}' at workflow level",
+                ],
+            ),
+        ],
+    )
+)
 
 
 # =============================================================================
@@ -224,17 +227,37 @@ def _create_releases_check() -> Callable[[CheckContext], PassResult]:
 
 
 def _create_changelog_check() -> Callable[[CheckContext], PassResult]:
-    """Check release contains changelog (OSPS-BR-04.01)."""
+    """Check release contains changelog (OSPS-BR-04.01).
+
+    Returns:
+    - PASS (N/A) if has_releases=false in project context
+    - PASS if releases have release notes
+    - FAIL if releases exist but lack notes
+    - INCONCLUSIVE if no releases found (to allow file_must_exist fallback to run)
+    """
 
     def check(ctx: CheckContext) -> PassResult:
+        # Check if user has confirmed they don't make releases
+        if is_context_confirmed(ctx.local_path, "has_releases"):
+            has_releases = get_context_value(ctx.local_path, "has_releases")
+            if has_releases is False:
+                return PassResult(
+                    phase=VerificationPhase.DETERMINISTIC,
+                    outcome=PassOutcome.PASS,  # N/A
+                    message="Project does not make releases (confirmed in .project.yaml)",
+                    evidence={"has_releases": False, "source": ".project.yaml"},
+                )
+
         try:
             releases = _gh_api(f"/repos/{ctx.owner}/{ctx.repo}/releases?per_page=5")
 
             if not releases:
+                # Return INCONCLUSIVE so file_must_exist fallback can check for CHANGELOG.md
                 return PassResult(
                     phase=VerificationPhase.DETERMINISTIC,
-                    outcome=PassOutcome.PASS,  # N/A
-                    message="No releases found",
+                    outcome=PassOutcome.INCONCLUSIVE,
+                    message="No releases found - checking for changelog file",
+                    evidence={"has_releases": False},
                 )
 
             latest = releases[0]
@@ -265,10 +288,19 @@ def _create_changelog_check() -> Callable[[CheckContext], PassResult]:
 
 
 LOCKFILE_PATTERNS = [
-    "package-lock.json", "yarn.lock", "pnpm-lock.yaml",
-    "Pipfile.lock", "poetry.lock", "pdm.lock", "uv.lock",
-    "Gemfile.lock", "go.sum", "Cargo.lock",
-    "composer.lock", "mix.lock", "pubspec.lock",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Pipfile.lock",
+    "poetry.lock",
+    "pdm.lock",
+    "uv.lock",
+    "Gemfile.lock",
+    "go.sum",
+    "Cargo.lock",
+    "composer.lock",
+    "mix.lock",
+    "pubspec.lock",
 ]
 
 
@@ -311,13 +343,9 @@ def _create_signed_releases_check() -> Callable[[CheckContext], PassResult]:
 
             latest = releases[0]
             assets = latest.get("assets", [])
-            has_signature = any(
-                a.get("name", "").endswith((".sig", ".asc", ".gpg"))
-                for a in assets
-            )
+            has_signature = any(a.get("name", "").endswith((".sig", ".asc", ".gpg")) for a in assets)
             has_checksum = any(
-                a.get("name", "").endswith((".sha256", ".sha512", "checksums.txt", "SHASUMS"))
-                for a in assets
+                a.get("name", "").endswith((".sha256", ".sha512", "checksums.txt", "SHASUMS")) for a in assets
             )
 
             if has_signature or has_checksum:
@@ -346,77 +374,66 @@ def _create_signed_releases_check() -> Callable[[CheckContext], PassResult]:
     return check
 
 
-register_control(ControlSpec(
-    control_id="OSPS-BR-02.01",
-    level=2,
-    domain="BR",
-    name="UniqueVersions",
-    description="Releases have unique version identifiers",
-    passes=[
-        DeterministicPass(config_check=_create_releases_check()),
-        ManualPass(
-            verification_steps=[
-                "Check release tags in repository",
-                "Verify each release has a unique version number",
-                "Use semantic versioning (semver.org)",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-BR-02.01",
+        level=2,
+        domain="BR",
+        name="UniqueVersions",
+        description="Releases have unique version identifiers",
+        passes=[
+            DeterministicPass(config_check=_create_releases_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check release tags in repository",
+                    "Verify each release has a unique version number",
+                    "Use semantic versioning (semver.org)",
+                ],
+            ),
+        ],
+    )
+)
 
-register_control(ControlSpec(
-    control_id="OSPS-BR-04.01",
-    level=2,
-    domain="BR",
-    name="ReleaseChangelog",
-    description="Releases contain changelog/release notes",
-    passes=[
-        DeterministicPass(config_check=_create_changelog_check()),
-        DeterministicPass(
-            file_must_exist=["CHANGELOG.md", "CHANGELOG", "HISTORY.md", "NEWS.md"]
-        ),
-        ManualPass(
-            verification_steps=[
-                "Check release notes on GitHub releases",
-                "Verify CHANGELOG.md exists and is updated",
-            ],
-        ),
-    ],
-))
+# OSPS-BR-04.01 is now defined in openssf-baseline.toml with config_check reference
+# to _create_changelog_check(). The TOML is the single source of truth.
 
-register_control(ControlSpec(
-    control_id="OSPS-BR-05.01",
-    level=2,
-    domain="BR",
-    name="StandardizedDependencyTooling",
-    description="Uses standardized dependency tooling with lockfiles",
-    passes=[
-        DeterministicPass(config_check=_create_lockfile_check()),
-        ManualPass(
-            verification_steps=[
-                "Check for package-lock.json, yarn.lock, poetry.lock, etc.",
-                "Verify dependencies are pinned to specific versions",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-BR-05.01",
+        level=2,
+        domain="BR",
+        name="StandardizedDependencyTooling",
+        description="Uses standardized dependency tooling with lockfiles",
+        passes=[
+            DeterministicPass(config_check=_create_lockfile_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check for package-lock.json, yarn.lock, poetry.lock, etc.",
+                    "Verify dependencies are pinned to specific versions",
+                ],
+            ),
+        ],
+    )
+)
 
-register_control(ControlSpec(
-    control_id="OSPS-BR-06.01",
-    level=2,
-    domain="BR",
-    name="SignedReleases",
-    description="Releases are signed or have checksums",
-    passes=[
-        DeterministicPass(config_check=_create_signed_releases_check()),
-        ManualPass(
-            verification_steps=[
-                "Check release assets for .sig, .asc, or checksum files",
-                "Verify signatures can be validated",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-BR-06.01",
+        level=2,
+        domain="BR",
+        name="SignedReleases",
+        description="Releases are signed or have checksums",
+        passes=[
+            DeterministicPass(config_check=_create_signed_releases_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check release assets for .sig, .asc, or checksum files",
+                    "Verify signatures can be validated",
+                ],
+            ),
+        ],
+    )
+)
 
 
 # =============================================================================
@@ -424,31 +441,31 @@ register_control(ControlSpec(
 # =============================================================================
 
 
-register_control(ControlSpec(
-    control_id="OSPS-DO-06.01",
-    level=2,
-    domain="DO",
-    name="DependencyManagementDocs",
-    description="Dependency management process is documented",
-    passes=[
-        DeterministicPass(
-            file_must_exist=["DEPENDENCIES.md", "docs/DEPENDENCIES.md", "docs/dependencies.md"]
-        ),
-        PatternPass(
-            file_patterns=["README.md", "CONTRIBUTING.md"],
-            content_patterns={
-                "dependency_docs": r"(dependenc|package|install|requirements)",
-            },
-            pass_if_any_match=True,
-        ),
-        ManualPass(
-            verification_steps=[
-                "Check README for dependency installation instructions",
-                "Verify CONTRIBUTING.md mentions dependency management",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-DO-06.01",
+        level=2,
+        domain="DO",
+        name="DependencyManagementDocs",
+        description="Dependency management process is documented",
+        passes=[
+            DeterministicPass(file_must_exist=["DEPENDENCIES.md", "docs/DEPENDENCIES.md", "docs/dependencies.md"]),
+            PatternPass(
+                file_patterns=["README.md", "CONTRIBUTING.md"],
+                content_patterns={
+                    "dependency_docs": r"(dependenc|package|install|requirements)",
+                },
+                pass_if_any_match=True,
+            ),
+            ManualPass(
+                verification_steps=[
+                    "Check README for dependency installation instructions",
+                    "Verify CONTRIBUTING.md mentions dependency management",
+                ],
+            ),
+        ],
+    )
+)
 
 
 # =============================================================================
@@ -457,8 +474,13 @@ register_control(ControlSpec(
 
 
 GOVERNANCE_FILES = [
-    "GOVERNANCE.md", "MAINTAINERS.md", "MAINTAINERS", "CODEOWNERS",
-    ".github/CODEOWNERS", "docs/GOVERNANCE.md", "OWNERS.md",
+    "GOVERNANCE.md",
+    "MAINTAINERS.md",
+    "MAINTAINERS",
+    "CODEOWNERS",
+    ".github/CODEOWNERS",
+    "docs/GOVERNANCE.md",
+    "OWNERS.md",
 ]
 
 
@@ -484,65 +506,69 @@ def _create_governance_check() -> Callable[[CheckContext], PassResult]:
     return check
 
 
-register_control(ControlSpec(
-    control_id="OSPS-GV-01.01",
-    level=2,
-    domain="GV",
-    name="SensitiveAccessList",
-    description="List of members with sensitive access is documented",
-    passes=[
-        DeterministicPass(config_check=_create_governance_check()),
-        ManualPass(
-            verification_steps=[
-                "Check for MAINTAINERS.md or CODEOWNERS",
-                "Verify list of people with commit/admin access",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-GV-01.01",
+        level=2,
+        domain="GV",
+        name="SensitiveAccessList",
+        description="List of members with sensitive access is documented",
+        passes=[
+            DeterministicPass(config_check=_create_governance_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check for MAINTAINERS.md or CODEOWNERS",
+                    "Verify list of people with commit/admin access",
+                ],
+            ),
+        ],
+    )
+)
 
-register_control(ControlSpec(
-    control_id="OSPS-GV-01.02",
-    level=2,
-    domain="GV",
-    name="RolesAndResponsibilities",
-    description="Roles and responsibilities are documented",
-    passes=[
-        DeterministicPass(config_check=_create_governance_check()),
-        ManualPass(
-            verification_steps=[
-                "Check GOVERNANCE.md for role definitions",
-                "Verify responsibilities are clearly defined",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-GV-01.02",
+        level=2,
+        domain="GV",
+        name="RolesAndResponsibilities",
+        description="Roles and responsibilities are documented",
+        passes=[
+            DeterministicPass(config_check=_create_governance_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check GOVERNANCE.md for role definitions",
+                    "Verify responsibilities are clearly defined",
+                ],
+            ),
+        ],
+    )
+)
 
-register_control(ControlSpec(
-    control_id="OSPS-GV-03.02",
-    level=2,
-    domain="GV",
-    name="ContributionRequirements",
-    description="Contribution requirements are documented",
-    passes=[
-        DeterministicPass(
-            file_must_exist=["CONTRIBUTING.md", ".github/CONTRIBUTING.md"]
-        ),
-        PatternPass(
-            file_patterns=["CONTRIBUTING.md", ".github/CONTRIBUTING.md"],
-            content_patterns={
-                "requirements": r"(requirement|guideline|standard|convention|must|should)",
-            },
-            pass_if_any_match=True,
-        ),
-        ManualPass(
-            verification_steps=[
-                "Check CONTRIBUTING.md for specific requirements",
-                "Verify coding standards are documented",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-GV-03.02",
+        level=2,
+        domain="GV",
+        name="ContributionRequirements",
+        description="Contribution requirements are documented",
+        passes=[
+            DeterministicPass(file_must_exist=["CONTRIBUTING.md", ".github/CONTRIBUTING.md"]),
+            PatternPass(
+                file_patterns=["CONTRIBUTING.md", ".github/CONTRIBUTING.md"],
+                content_patterns={
+                    "requirements": r"(requirement|guideline|standard|convention|must|should)",
+                },
+                pass_if_any_match=True,
+            ),
+            ManualPass(
+                verification_steps=[
+                    "Check CONTRIBUTING.md for specific requirements",
+                    "Verify coding standards are documented",
+                ],
+            ),
+        ],
+    )
+)
 
 
 # =============================================================================
@@ -575,7 +601,7 @@ def _create_dco_check() -> Callable[[CheckContext], PassResult]:
         if os.path.exists(workflow_dir):
             for root, _, files in os.walk(workflow_dir):
                 for file in files:
-                    if file.endswith(('.yml', '.yaml')):
+                    if file.endswith((".yml", ".yaml")):
                         content = _read_file(root, file) or ""
                         if any(kw in content.lower() for kw in ["dco", "cla", "signed-off-by"]):
                             return PassResult(
@@ -587,10 +613,15 @@ def _create_dco_check() -> Callable[[CheckContext], PassResult]:
         # Check CONTRIBUTING.md
         contributing = _read_file(ctx.local_path, "CONTRIBUTING.md") or ""
         dco_markers = [
-            "signed-off-by", "sign-off", "signoff",
-            "developer certificate of origin", "dco",
-            "git commit -s", "commit -s -m",
-            "contributor license agreement", "cla"
+            "signed-off-by",
+            "sign-off",
+            "signoff",
+            "developer certificate of origin",
+            "dco",
+            "git commit -s",
+            "commit -s -m",
+            "contributor license agreement",
+            "cla",
         ]
         if any(marker in contributing.lower() for marker in dco_markers):
             return PassResult(
@@ -608,23 +639,25 @@ def _create_dco_check() -> Callable[[CheckContext], PassResult]:
     return check
 
 
-register_control(ControlSpec(
-    control_id="OSPS-LE-01.01",
-    level=2,
-    domain="LE",
-    name="DCOCLARequirement",
-    description="DCO or CLA is required for contributions",
-    passes=[
-        DeterministicPass(config_check=_create_dco_check()),
-        ManualPass(
-            verification_steps=[
-                "Check for DCO.md or CLA.md file",
-                "Verify CONTRIBUTING.md mentions sign-off requirement",
-                "Check if DCO GitHub App is installed",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-LE-01.01",
+        level=2,
+        domain="LE",
+        name="DCOCLARequirement",
+        description="DCO or CLA is required for contributions",
+        passes=[
+            DeterministicPass(config_check=_create_dco_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check for DCO.md or CLA.md file",
+                    "Verify CONTRIBUTING.md mentions sign-off requirement",
+                    "Check if DCO GitHub App is installed",
+                ],
+            ),
+        ],
+    )
+)
 
 
 # =============================================================================
@@ -637,9 +670,7 @@ def _create_status_checks_check() -> Callable[[CheckContext], PassResult]:
 
     def check(ctx: CheckContext) -> PassResult:
         try:
-            protection = _gh_api(
-                f"/repos/{ctx.owner}/{ctx.repo}/branches/{ctx.default_branch}/protection"
-            )
+            protection = _gh_api(f"/repos/{ctx.owner}/{ctx.repo}/branches/{ctx.default_branch}/protection")
 
             if protection and protection.get("required_status_checks"):
                 contexts = protection["required_status_checks"].get("contexts", [])
@@ -680,8 +711,16 @@ def _detect_test_files(local_path: str) -> dict | None:
     test_patterns = {
         "go": ["*_test.go", "**/*_test.go"],
         "python": ["test_*.py", "*_test.py", "tests/*.py", "tests/**/*.py"],
-        "javascript": ["*.test.js", "*.spec.js", "**/*.test.js", "**/*.spec.js",
-                      "*.test.ts", "*.spec.ts", "**/*.test.ts", "**/*.spec.ts"],
+        "javascript": [
+            "*.test.js",
+            "*.spec.js",
+            "**/*.test.js",
+            "**/*.spec.js",
+            "*.test.ts",
+            "*.spec.ts",
+            "**/*.test.ts",
+            "**/*.spec.ts",
+        ],
         "ruby": ["*_spec.rb", "**/*_spec.rb", "*_test.rb", "**/*_test.rb"],
         "rust": ["**/tests/*.rs"],
         "java": ["**/src/test/**/*.java", "**/*Test.java"],
@@ -720,20 +759,30 @@ def _create_automated_tests_check() -> Callable[[CheckContext], PassResult]:
         }
 
         test_command_patterns = [
-            r'npm\s+test', r'yarn\s+test', r'pnpm\s+test',
-            r'pytest', r'python\s+-m\s+pytest', r'uv\s+run\s+pytest',
-            r'jest', r'mocha', r'vitest',
-            r'go\s+test', r'cargo\s+test',
-            r'rspec', r'bundle\s+exec\s+rspec',
-            r'mvn\s+test', r'gradle\s+test',
-            r'dotnet\s+test', r'mix\s+test',
+            r"npm\s+test",
+            r"yarn\s+test",
+            r"pnpm\s+test",
+            r"pytest",
+            r"python\s+-m\s+pytest",
+            r"uv\s+run\s+pytest",
+            r"jest",
+            r"mocha",
+            r"vitest",
+            r"go\s+test",
+            r"cargo\s+test",
+            r"rspec",
+            r"bundle\s+exec\s+rspec",
+            r"mvn\s+test",
+            r"gradle\s+test",
+            r"dotnet\s+test",
+            r"mix\s+test",
         ]
 
         # First, check GitHub Actions
         if os.path.exists(workflow_dir):
             for root, _, files in os.walk(workflow_dir):
                 for file in files:
-                    if file.endswith(('.yml', '.yaml')):
+                    if file.endswith((".yml", ".yaml")):
                         content = _read_file(root, file) or ""
                         for pattern in test_command_patterns:
                             if re.search(pattern, content, re.IGNORECASE):
@@ -765,9 +814,7 @@ def _create_automated_tests_check() -> Callable[[CheckContext], PassResult]:
             # Has test files - this is strong evidence tests exist,
             # but we should verify CI runs them
             if os.path.exists(workflow_dir) or any(
-                os.path.exists(os.path.join(ctx.local_path, c))
-                for configs in ci_configs.values()
-                for c in configs
+                os.path.exists(os.path.join(ctx.local_path, c)) for configs in ci_configs.values() for c in configs
             ):
                 # Has CI config + test files - likely tests run in CI
                 return PassResult(
@@ -822,39 +869,43 @@ def _create_automated_tests_check() -> Callable[[CheckContext], PassResult]:
     return check
 
 
-register_control(ControlSpec(
-    control_id="OSPS-QA-03.01",
-    level=2,
-    domain="QA",
-    name="RequiredStatusChecks",
-    description="Status checks must pass before merging",
-    passes=[
-        DeterministicPass(config_check=_create_status_checks_check()),
-        ManualPass(
-            verification_steps=[
-                "Check branch protection settings",
-                "Verify required status checks are configured",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-QA-03.01",
+        level=2,
+        domain="QA",
+        name="RequiredStatusChecks",
+        description="Status checks must pass before merging",
+        passes=[
+            DeterministicPass(config_check=_create_status_checks_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check branch protection settings",
+                    "Verify required status checks are configured",
+                ],
+            ),
+        ],
+    )
+)
 
-register_control(ControlSpec(
-    control_id="OSPS-QA-06.01",
-    level=2,
-    domain="QA",
-    name="AutomatedTestSuite",
-    description="Automated test suite runs in CI",
-    passes=[
-        DeterministicPass(config_check=_create_automated_tests_check()),
-        ManualPass(
-            verification_steps=[
-                "Check GitHub Actions for test commands",
-                "Verify tests run on pull requests",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-QA-06.01",
+        level=2,
+        domain="QA",
+        name="AutomatedTestSuite",
+        description="Automated test suite runs in CI",
+        passes=[
+            DeterministicPass(config_check=_create_automated_tests_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check GitHub Actions for test commands",
+                    "Verify tests run on pull requests",
+                ],
+            ),
+        ],
+    )
+)
 
 
 # =============================================================================
@@ -863,37 +914,54 @@ register_control(ControlSpec(
 
 
 DESIGN_DOCS = [
-    "ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "docs/DESIGN.md",
-    "docs/architecture/", "docs/design/", "doc/architecture.md",
+    "ARCHITECTURE.md",
+    "DESIGN.md",
+    "docs/ARCHITECTURE.md",
+    "docs/DESIGN.md",
+    "docs/architecture/",
+    "docs/design/",
+    "doc/architecture.md",
 ]
 
 API_DOCS = [
-    "API.md", "docs/API.md", "docs/api/", "openapi.yaml", "openapi.json",
-    "swagger.yaml", "swagger.json", "api-docs/",
+    "API.md",
+    "docs/API.md",
+    "docs/api/",
+    "openapi.yaml",
+    "openapi.json",
+    "swagger.yaml",
+    "swagger.json",
+    "api-docs/",
 ]
 
 # Files that commonly contain API/interface documentation inline
 DOCS_WITH_API_SECTIONS = [
-    "README.md", "README.rst", "README.txt", "README",
-    "docs/README.md", "USAGE.md", "docs/USAGE.md",
-    "docs/index.md", "docs/getting-started.md",
+    "README.md",
+    "README.rst",
+    "README.txt",
+    "README",
+    "docs/README.md",
+    "USAGE.md",
+    "docs/USAGE.md",
+    "docs/index.md",
+    "docs/getting-started.md",
 ]
 
 # Patterns that indicate API/interface documentation sections
 API_SECTION_PATTERNS = [
     # Markdown headings for API documentation
-    r'^#+\s*(API|Interface|External\s+Interface|Public\s+Interface)',
-    r'^#+\s*(Usage|How\s+to\s+Use)',
-    r'^#+\s*(Methods|Functions|Endpoints)',
-    r'^#+\s*(CLI|Command[s]?|Command[\s-]Line)',
-    r'^#+\s*(Reference|API\s+Reference)',
-    r'^#+\s*(Parameters|Arguments|Options)',
+    r"^#+\s*(API|Interface|External\s+Interface|Public\s+Interface)",
+    r"^#+\s*(Usage|How\s+to\s+Use)",
+    r"^#+\s*(Methods|Functions|Endpoints)",
+    r"^#+\s*(CLI|Command[s]?|Command[\s-]Line)",
+    r"^#+\s*(Reference|API\s+Reference)",
+    r"^#+\s*(Parameters|Arguments|Options)",
     # Code blocks with function/method definitions
-    r'```[a-z]*\s*\n[^`]*def\s+\w+\s*\([^)]*\)',  # Python functions
-    r'```[a-z]*\s*\n[^`]*function\s+\w+\s*\([^)]*\)',  # JS functions
-    r'```[a-z]*\s*\n[^`]*func\s+\w+\s*\([^)]*\)',  # Go functions
+    r"```[a-z]*\s*\n[^`]*def\s+\w+\s*\([^)]*\)",  # Python functions
+    r"```[a-z]*\s*\n[^`]*function\s+\w+\s*\([^)]*\)",  # JS functions
+    r"```[a-z]*\s*\n[^`]*func\s+\w+\s*\([^)]*\)",  # Go functions
     # API-related keywords in context
-    r'(endpoint|route|method|parameter|return|response)s?\s*:',
+    r"(endpoint|route|method|parameter|return|response)s?\s*:",
 ]
 
 
@@ -902,7 +970,7 @@ def _has_api_documentation_section(content: str) -> bool:
     content_lower = content.lower()
 
     # Quick check: must have some API-related keywords
-    api_keywords = ['api', 'usage', 'interface', 'method', 'function', 'endpoint', 'cli', 'command']
+    api_keywords = ["api", "usage", "interface", "method", "function", "endpoint", "cli", "command"]
     if not any(kw in content_lower for kw in api_keywords):
         return False
 
@@ -978,65 +1046,69 @@ def _create_api_docs_check() -> Callable[[CheckContext], PassResult]:
     return check
 
 
-register_control(ControlSpec(
-    control_id="OSPS-SA-01.01",
-    level=2,
-    domain="SA",
-    name="DesignDocumentation",
-    description="Architecture/design documentation exists",
-    passes=[
-        DeterministicPass(config_check=_create_design_docs_check()),
-        ManualPass(
-            verification_steps=[
-                "Check for ARCHITECTURE.md or DESIGN.md",
-                "Verify docs/ folder contains architecture documentation",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-SA-01.01",
+        level=2,
+        domain="SA",
+        name="DesignDocumentation",
+        description="Architecture/design documentation exists",
+        passes=[
+            DeterministicPass(config_check=_create_design_docs_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check for ARCHITECTURE.md or DESIGN.md",
+                    "Verify docs/ folder contains architecture documentation",
+                ],
+            ),
+        ],
+    )
+)
 
-register_control(ControlSpec(
-    control_id="OSPS-SA-02.01",
-    level=2,
-    domain="SA",
-    name="ExternalInterfaceDocs",
-    description="External interface documentation exists",
-    passes=[
-        DeterministicPass(config_check=_create_api_docs_check()),
-        ManualPass(
-            verification_steps=[
-                "Check for API.md or openapi.yaml",
-                "Verify API documentation is complete",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-SA-02.01",
+        level=2,
+        domain="SA",
+        name="ExternalInterfaceDocs",
+        description="External interface documentation exists",
+        passes=[
+            DeterministicPass(config_check=_create_api_docs_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check for API.md or openapi.yaml",
+                    "Verify API documentation is complete",
+                ],
+            ),
+        ],
+    )
+)
 
-register_control(ControlSpec(
-    control_id="OSPS-SA-03.01",
-    level=2,
-    domain="SA",
-    name="SecurityAssessment",
-    description="Security assessment documentation exists",
-    passes=[
-        PatternPass(
-            file_patterns=["SECURITY.md", ".github/SECURITY.md"],
-            content_patterns={
-                "threat_assessment": r"(threat|risk|assessment|vulnerability|attack)",
-            },
-            pass_if_any_match=True,
-        ),
-        DeterministicPass(
-            file_must_exist=["SECURITY.md", ".github/SECURITY.md", "docs/security/"]
-        ),
-        ManualPass(
-            verification_steps=[
-                "Check SECURITY.md for threat modeling",
-                "Verify security considerations are documented",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-SA-03.01",
+        level=2,
+        domain="SA",
+        name="SecurityAssessment",
+        description="Security assessment documentation exists",
+        passes=[
+            PatternPass(
+                file_patterns=["SECURITY.md", ".github/SECURITY.md"],
+                content_patterns={
+                    "threat_assessment": r"(threat|risk|assessment|vulnerability|attack)",
+                },
+                pass_if_any_match=True,
+            ),
+            DeterministicPass(file_must_exist=["SECURITY.md", ".github/SECURITY.md", "docs/security/"]),
+            ManualPass(
+                verification_steps=[
+                    "Check SECURITY.md for threat modeling",
+                    "Verify security considerations are documented",
+                ],
+            ),
+        ],
+    )
+)
 
 
 # =============================================================================
@@ -1044,55 +1116,57 @@ register_control(ControlSpec(
 # =============================================================================
 
 
-register_control(ControlSpec(
-    control_id="OSPS-VM-01.01",
-    level=2,
-    domain="VM",
-    name="CVDPolicy",
-    description="Coordinated vulnerability disclosure policy with timeframe",
-    passes=[
-        PatternPass(
-            file_patterns=["SECURITY.md", ".github/SECURITY.md"],
-            content_patterns={
-                "disclosure_policy": r"(disclosure|response|timeframe|\d+\s*days)",
-            },
-            pass_if_any_match=True,
-        ),
-        DeterministicPass(
-            file_must_exist=["SECURITY.md", ".github/SECURITY.md"]
-        ),
-        ManualPass(
-            verification_steps=[
-                "Check SECURITY.md for disclosure timeline",
-                "Verify response timeframe is documented",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-VM-01.01",
+        level=2,
+        domain="VM",
+        name="CVDPolicy",
+        description="Coordinated vulnerability disclosure policy with timeframe",
+        passes=[
+            PatternPass(
+                file_patterns=["SECURITY.md", ".github/SECURITY.md"],
+                content_patterns={
+                    "disclosure_policy": r"(disclosure|response|timeframe|\d+\s*days)",
+                },
+                pass_if_any_match=True,
+            ),
+            DeterministicPass(file_must_exist=["SECURITY.md", ".github/SECURITY.md"]),
+            ManualPass(
+                verification_steps=[
+                    "Check SECURITY.md for disclosure timeline",
+                    "Verify response timeframe is documented",
+                ],
+            ),
+        ],
+    )
+)
 
-register_control(ControlSpec(
-    control_id="OSPS-VM-03.01",
-    level=2,
-    domain="VM",
-    name="PrivateVulnerabilityReporting",
-    description="Private vulnerability reporting mechanism exists",
-    passes=[
-        PatternPass(
-            file_patterns=["SECURITY.md", ".github/SECURITY.md"],
-            content_patterns={
-                "private_reporting": r"(private|confidential|email|pgp|gpg|security@|privately)",
-            },
-            pass_if_any_match=True,
-        ),
-        ManualPass(
-            verification_steps=[
-                "Check SECURITY.md for private contact method",
-                "Verify email or PGP key is provided",
-                "Check if GitHub private vulnerability reporting is enabled",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-VM-03.01",
+        level=2,
+        domain="VM",
+        name="PrivateVulnerabilityReporting",
+        description="Private vulnerability reporting mechanism exists",
+        passes=[
+            PatternPass(
+                file_patterns=["SECURITY.md", ".github/SECURITY.md"],
+                content_patterns={
+                    "private_reporting": r"(private|confidential|email|pgp|gpg|security@|privately)",
+                },
+                pass_if_any_match=True,
+            ),
+            ManualPass(
+                verification_steps=[
+                    "Check SECURITY.md for private contact method",
+                    "Verify email or PGP key is provided",
+                    "Check if GitHub private vulnerability reporting is enabled",
+                ],
+            ),
+        ],
+    )
+)
 
 
 def _create_advisories_check() -> Callable[[CheckContext], PassResult]:
@@ -1142,19 +1216,21 @@ def _create_advisories_check() -> Callable[[CheckContext], PassResult]:
     return check
 
 
-register_control(ControlSpec(
-    control_id="OSPS-VM-04.01",
-    level=2,
-    domain="VM",
-    name="PublicVulnerabilityData",
-    description="Public vulnerability data via security advisories",
-    passes=[
-        DeterministicPass(config_check=_create_advisories_check()),
-        ManualPass(
-            verification_steps=[
-                "Check if GitHub Security Advisories are enabled",
-                "Verify Issues are enabled (required for advisories)",
-            ],
-        ),
-    ],
-))
+register_control(
+    ControlSpec(
+        control_id="OSPS-VM-04.01",
+        level=2,
+        domain="VM",
+        name="PublicVulnerabilityData",
+        description="Public vulnerability data via security advisories",
+        passes=[
+            DeterministicPass(config_check=_create_advisories_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check if GitHub Security Advisories are enabled",
+                    "Verify Issues are enabled (required for advisories)",
+                ],
+            ),
+        ],
+    )
+)

--- a/packages/darnit/src/darnit/config/control_loader.py
+++ b/packages/darnit/src/darnit/config/control_loader.py
@@ -18,7 +18,9 @@ Example:
         register_control(control)
 """
 
+import importlib
 from collections.abc import Callable
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Any
 
@@ -49,8 +51,149 @@ logger = get_logger("config.control_loader")
 
 
 # =============================================================================
+# Module Import Security
+# =============================================================================
+
+# Base whitelist - always allowed
+_BASE_ALLOWED_PREFIXES = (
+    "darnit.",
+    "darnit_baseline.",
+    "darnit_plugins.",
+    "darnit_testchecks.",
+)
+
+# Cache for dynamically discovered prefixes
+_discovered_prefixes: set[str] | None = None
+
+
+def _get_allowed_module_prefixes() -> tuple[str, ...]:
+    """Get allowed module prefixes, including registered plugins.
+
+    Combines the base whitelist with prefixes from all registered
+    entry points in darnit.* groups. This allows third-party plugins
+    to register their modules as trusted.
+
+    Returns:
+        Tuple of allowed module prefixes (e.g., ("darnit.", "darnit_baseline."))
+    """
+    global _discovered_prefixes
+
+    if _discovered_prefixes is None:
+        _discovered_prefixes = set(_BASE_ALLOWED_PREFIXES)
+
+        # Discover prefixes from registered entry points
+        for group in (
+            "darnit.implementations",
+            "darnit.frameworks",
+            "darnit.check_adapters",
+            "darnit.remediation_adapters",
+        ):
+            try:
+                eps = entry_points(group=group)
+                for ep in eps:
+                    # Entry point value is "package.module:function"
+                    module_path = ep.value.split(":")[0]
+                    package_name = module_path.split(".")[0]
+                    _discovered_prefixes.add(f"{package_name}.")
+            except Exception:
+                pass  # Entry point group might not exist
+
+    return tuple(_discovered_prefixes)
+
+
+def _is_module_allowed(module_path: str) -> bool:
+    """Check if a module path is in the allowed whitelist.
+
+    Args:
+        module_path: Full module path (e.g., "darnit_baseline.controls.level2")
+
+    Returns:
+        True if the module is allowed to be imported
+    """
+    allowed = _get_allowed_module_prefixes()
+    return module_path.startswith(allowed)
+
+
+# =============================================================================
 # Pass Converters
 # =============================================================================
+
+
+def _resolve_check_function(reference: str) -> Callable | None:
+    """Resolve a 'module:function' reference to a callable.
+
+    Supports two patterns:
+    1. Factory functions that return a callable: module:factory_func
+       - The factory is called, and its return value is used as the check
+    2. Direct check functions: module:check_func
+       - The function itself is used as the check
+
+    Security: Only allows loading modules from whitelisted prefixes
+    to prevent arbitrary code execution from malicious TOML files.
+    The whitelist includes base darnit packages plus any packages
+    registered via entry points.
+
+    Args:
+        reference: String like "darnit_baseline.controls.level2:_create_changelog_check"
+
+    Returns:
+        The resolved function, or None if resolution fails
+    """
+    if not reference or ":" not in reference:
+        logger.warning(f"Invalid check function reference (missing ':'): {reference}")
+        return None
+
+    module_path, func_name = reference.rsplit(":", 1)
+
+    # Security: Validate module path against whitelist
+    if not _is_module_allowed(module_path):
+        logger.warning(
+            f"Blocked import of '{module_path}': not in allowed module prefixes. "
+            f"Register your plugin via entry points to allow imports."
+        )
+        return None
+
+    try:
+        module = importlib.import_module(module_path)
+        func = getattr(module, func_name)
+
+        if not callable(func):
+            logger.warning(f"Reference {reference} is not callable")
+            return None
+
+        # Try calling the function to see if it's a factory
+        # Factory functions have no required parameters and return a callable
+        try:
+            import inspect
+
+            sig = inspect.signature(func)
+            # Check if all parameters have defaults (i.e., can be called with no args)
+            can_call_no_args = all(
+                p.default is not inspect.Parameter.empty
+                or p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+                for p in sig.parameters.values()
+            )
+
+            if can_call_no_args:
+                result = func()
+                if callable(result):
+                    logger.debug(f"Resolved factory function {reference} -> {result}")
+                    return result
+
+            # Not a factory, return the function itself
+            logger.debug(f"Resolved direct function {reference}")
+            return func
+
+        except (TypeError, ValueError):
+            # If we can't inspect or call, just return the function
+            return func
+
+    except ImportError as e:
+        logger.warning(f"Could not import module for check function {reference}: {e}")
+        return None
+    except AttributeError as e:
+        logger.warning(f"Function not found in module for {reference}: {e}")
+        return None
 
 
 def _convert_deterministic_pass(config: DeterministicPassConfig) -> DeterministicPass:
@@ -62,13 +205,15 @@ def _convert_deterministic_pass(config: DeterministicPassConfig) -> Deterministi
     Returns:
         Executable DeterministicPass
     """
-    # For now, we support file_must_exist and file_must_not_exist directly
-    # api_check and config_check require function resolution (advanced)
+    # Resolve function references for api_check and config_check
+    api_check = _resolve_check_function(config.api_check) if config.api_check else None
+    config_check = _resolve_check_function(config.config_check) if config.config_check else None
+
     return DeterministicPass(
         file_must_exist=config.file_must_exist,
         file_must_not_exist=config.file_must_not_exist,
-        # Note: api_check and config_check are function references
-        # These would need adapter resolution for full support
+        api_check=api_check,
+        config_check=config_check,
     )
 
 
@@ -422,6 +567,7 @@ def register_controls_from_config(
     """
     if registry_func is None:
         from darnit.sieve.registry import register_control
+
         registry_func = register_control
 
     controls = load_controls_from_effective(config)

--- a/packages/darnit/src/darnit/sieve/passes.py
+++ b/packages/darnit/src/darnit/sieve/passes.py
@@ -54,9 +54,7 @@ def _read_file(local_path: str, filename: str) -> str | None:
     return None
 
 
-def _file_contains(
-    local_path: str, file_patterns: list[str], content_pattern: str
-) -> bool:
+def _file_contains(local_path: str, file_patterns: list[str], content_pattern: str) -> bool:
     """Check if any matching file contains the content pattern."""
     for file_pattern in file_patterns:
         content = _read_file(local_path, file_pattern)
@@ -69,9 +67,7 @@ def _file_contains(
 class DeterministicPass:
     """Pass 1: Deterministic checks (file existence, API booleans, config)."""
 
-    phase: VerificationPhase = field(
-        default=VerificationPhase.DETERMINISTIC, init=False
-    )
+    phase: VerificationPhase = field(default=VerificationPhase.DETERMINISTIC, init=False)
 
     # Configurable checks
     file_must_exist: list[str] | None = None  # Any of these patterns
@@ -129,7 +125,49 @@ class DeterministicPass:
     def execute(self, context: CheckContext) -> PassResult:
         checks_performed = []
 
-        # File existence checks
+        # API check first (most authoritative)
+        if self.api_check:
+            checks_performed.append("api_check()")
+            try:
+                result = self.api_check(context.owner, context.repo)
+                # Only return if conclusive (PASS/FAIL), continue to fallbacks if INCONCLUSIVE
+                if result.outcome in (PassOutcome.PASS, PassOutcome.FAIL):
+                    return result
+                # Store evidence for potential later use
+                context.gathered_evidence["api_check_result"] = {
+                    "outcome": result.outcome.value,
+                    "message": result.message,
+                }
+            except (RuntimeError, ValueError, TypeError, KeyError, AttributeError, OSError) as e:
+                return PassResult(
+                    phase=self.phase,
+                    outcome=PassOutcome.ERROR,
+                    message=f"API check failed: {str(e)}",
+                    evidence={"error": str(e)},
+                )
+
+        # Config check second (also authoritative)
+        if self.config_check:
+            checks_performed.append("config_check()")
+            try:
+                result = self.config_check(context)
+                # Only return if conclusive (PASS/FAIL), continue to fallbacks if INCONCLUSIVE
+                if result.outcome in (PassOutcome.PASS, PassOutcome.FAIL):
+                    return result
+                # Store evidence for potential later use
+                context.gathered_evidence["config_check_result"] = {
+                    "outcome": result.outcome.value,
+                    "message": result.message,
+                }
+            except (RuntimeError, ValueError, TypeError, KeyError, AttributeError, OSError) as e:
+                return PassResult(
+                    phase=self.phase,
+                    outcome=PassOutcome.ERROR,
+                    message=f"Config check failed: {str(e)}",
+                    evidence={"error": str(e)},
+                )
+
+        # File existence checks (fallback when api_check/config_check are not set or inconclusive)
         if self.file_must_exist:
             checks_performed.append(f"file_exists({self.file_must_exist})")
 
@@ -175,32 +213,6 @@ class DeterministicPass:
                     outcome=PassOutcome.FAIL,
                     message=f"Prohibited file found: {os.path.basename(found)}",
                     evidence={"file_found": found},
-                )
-
-        # API check
-        if self.api_check:
-            checks_performed.append("api_check()")
-            try:
-                return self.api_check(context.owner, context.repo)
-            except (RuntimeError, ValueError, TypeError, KeyError, AttributeError, OSError) as e:
-                return PassResult(
-                    phase=self.phase,
-                    outcome=PassOutcome.ERROR,
-                    message=f"API check failed: {str(e)}",
-                    evidence={"error": str(e)},
-                )
-
-        # Config check
-        if self.config_check:
-            checks_performed.append("config_check()")
-            try:
-                return self.config_check(context)
-            except (RuntimeError, ValueError, TypeError, KeyError, AttributeError, OSError) as e:
-                return PassResult(
-                    phase=self.phase,
-                    outcome=PassOutcome.ERROR,
-                    message=f"Config check failed: {str(e)}",
-                    evidence={"error": str(e)},
                 )
 
         # No deterministic check configured - inconclusive
@@ -255,9 +267,7 @@ class PatternPass:
                     message=f"Pattern matches found: {matches_found}",
                     evidence={"patterns_matched": matches_found},
                 )
-            elif not self.pass_if_any_match and len(matches_found) == len(
-                self.content_patterns
-            ):
+            elif not self.pass_if_any_match and len(matches_found) == len(self.content_patterns):
                 return PassResult(
                     phase=self.phase,
                     outcome=PassOutcome.PASS,
@@ -272,9 +282,7 @@ class PatternPass:
                     message=f"Partial pattern matches: {matches_found}",
                     evidence={
                         "patterns_matched": matches_found,
-                        "patterns_missing": list(
-                            set(self.content_patterns.keys()) - set(matches_found)
-                        ),
+                        "patterns_missing": list(set(self.content_patterns.keys()) - set(matches_found)),
                     },
                 )
             else:
@@ -316,9 +324,7 @@ class PatternPass:
     def describe(self) -> str:
         parts = []
         if self.content_patterns:
-            parts.append(
-                f"Pattern match in {self.file_patterns}: {list(self.content_patterns.keys())}"
-            )
+            parts.append(f"Pattern match in {self.file_patterns}: {list(self.content_patterns.keys())}")
         if self.custom_analyzer:
             parts.append("Custom content analyzer")
         return "; ".join(parts) or "No pattern checks"
@@ -348,8 +354,7 @@ class LLMPass:
                     # Truncate long content
                     if len(content) > self.max_file_content_length:
                         content = (
-                            content[: self.max_file_content_length]
-                            + f"\n... [truncated, {len(content)} total chars]"
+                            content[: self.max_file_content_length] + f"\n... [truncated, {len(content)} total chars]"
                         )
                     gathered_context[f"file:{pattern}"] = content
 

--- a/tests/darnit/config/test_control_loader.py
+++ b/tests/darnit/config/test_control_loader.py
@@ -10,6 +10,9 @@ from darnit.config.control_loader import (
     _convert_exec_pass,
     _convert_manual_pass,
     _convert_pattern_pass,
+    _get_allowed_module_prefixes,
+    _is_module_allowed,
+    _resolve_check_function,
     control_from_framework,
     load_controls_from_framework,
 )
@@ -428,6 +431,66 @@ class TestFrameworkSchemaValidation:
             security_severity=7.5,
         )
         assert control.security_severity == 7.5
+
+
+class TestModuleImportSecurity:
+    """Test security whitelist for dynamic module imports."""
+
+    def test_base_prefixes_always_allowed(self):
+        """Test that base darnit prefixes are always allowed."""
+        assert _is_module_allowed("darnit.core.plugin")
+        assert _is_module_allowed("darnit_baseline.controls.level1")
+        assert _is_module_allowed("darnit_plugins.custom")
+        assert _is_module_allowed("darnit_testchecks.fixtures")
+
+    def test_blocks_standard_library(self):
+        """Test that standard library modules are blocked."""
+        assert not _is_module_allowed("os")
+        assert not _is_module_allowed("subprocess")
+        assert not _is_module_allowed("sys")
+        assert not _is_module_allowed("importlib")
+
+    def test_blocks_arbitrary_packages(self):
+        """Test that arbitrary third-party packages are blocked."""
+        assert not _is_module_allowed("requests")
+        assert not _is_module_allowed("flask.app")
+        assert not _is_module_allowed("malicious_package.evil")
+
+    def test_resolve_blocks_unauthorized_modules(self):
+        """Test that _resolve_check_function blocks unauthorized modules."""
+        # These should return None and log a warning
+        assert _resolve_check_function("os:system") is None
+        assert _resolve_check_function("subprocess:run") is None
+        assert _resolve_check_function("malicious:payload") is None
+
+    def test_resolve_allows_registered_modules(self):
+        """Test that _resolve_check_function allows registered modules."""
+        # This test requires darnit_baseline to be installed
+        result = _resolve_check_function(
+            "darnit_baseline.controls.level2:_create_changelog_check"
+        )
+        # Should be callable (the factory returns a check function)
+        assert callable(result)
+
+    def test_resolve_invalid_reference_format(self):
+        """Test that invalid references are rejected."""
+        assert _resolve_check_function("") is None
+        assert _resolve_check_function("no_colon_here") is None
+        assert _resolve_check_function(None) is None  # type: ignore
+
+    def test_get_allowed_prefixes_includes_base(self):
+        """Test that base prefixes are in allowed list."""
+        prefixes = _get_allowed_module_prefixes()
+        assert "darnit." in prefixes
+        assert "darnit_baseline." in prefixes
+        assert "darnit_plugins." in prefixes
+        assert "darnit_testchecks." in prefixes
+
+    def test_prefix_matching_is_strict(self):
+        """Test that prefix matching requires the dot."""
+        # These should be blocked - they look similar but aren't valid prefixes
+        assert not _is_module_allowed("darnit_malicious.evil")
+        assert not _is_module_allowed("darnitfake.payload")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `_resolve_check_function()` to resolve `module:function` references in TOML to Python callables
- Reorders `DeterministicPass.execute()` to run api_check/config_check first, with file checks as fallback
- Updates OSPS-BR-04.01 to use config_check reference with file fallback
- Adds `has_releases` context check to return N/A when project doesn't make releases

## Test plan

- [x] All 560 tests pass
- [x] Verified function resolution works for factory functions
- [x] Verified control flow: releases with notes → PASS, no releases + CHANGELOG → PASS (fallback)

🤖 Generated with [Claude Code](https://claude.ai/code)