### PR TITLE
feat: Add CNCF .project/ specification integration

### DIFF
--- a/openspec/changes/toml-schema-v2/.openspec.yaml
+++ b/openspec/changes/toml-schema-v2/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-04

--- a/openspec/changes/toml-schema-v2/design.md
+++ b/openspec/changes/toml-schema-v2/design.md
@@ -1,0 +1,181 @@
+## Context
+
+The darnit framework currently uses a TOML schema that has grown organically, with custom fields for each check type (`pass_if_json_path`, `pass_if_json_value`, `file_must_exist`, etc.). This makes extending the framework verbose and inconsistent.
+
+**Current state:**
+- Checks defined in `openssf-baseline.toml` with bespoke fields per pass type
+- No integration with external project metadata standards
+- Context for remediation gathered ad-hoc
+- Plugins wired manually via handler references
+
+**Constraints:**
+- Must remain TOML-based (human-readable, AI-editable)
+- Security-sensitive (plugins run arbitrary code)
+- .project/ spec is alpha and evolving
+
+## Goals / Non-Goals
+
+**Goals:**
+- Align with CNCF .project/ spec for project metadata
+- Simplify policy expressions via CEL
+- Formalize context collection flow
+- Secure, auto-registering plugin system
+- Incremental migration path (4 phases)
+
+**Non-Goals:**
+- Full OPA/Rego policy engine (too complex)
+- GUI for TOML editing
+- Support for non-TOML config formats
+- Backward compatibility with pre-1.0 configs (breaking changes acceptable)
+
+## Decisions
+
+### Decision 1: CEL for Policy Expressions
+
+**Choice**: Use CEL (Common Expression Language) for pass/fail conditions
+
+**Rationale**:
+- Non-Turing-complete → safe, predictable execution
+- Kubernetes ecosystem alignment (ValidatingAdmissionPolicy uses CEL)
+- Fast evaluation (nanoseconds to microseconds)
+- Good Python support via `celpy`
+
+**Alternatives considered**:
+- **CUE**: More powerful but steeper learning curve, better for schema validation than policy
+- **Starlark**: Python-like but Turing-complete, harder to sandbox
+- **Expr**: Simpler than CEL but less ecosystem adoption
+- **Custom DSL**: Maintenance burden, reinventing the wheel
+
+**TODO**: Evaluate alternatives before Phase 3 implementation. CEL is the starting point.
+
+### Decision 2: .project/ as Primary Context Source
+
+**Choice**: Read .project/project.yaml as the authoritative source for project metadata
+
+**Rationale**:
+- CNCF standard gaining adoption
+- Structured format for maintainers, security contacts, governance
+- Extension mechanism (PR #131) allows tool-specific config
+- Single source of truth reduces drift
+
+**Implementation**:
+```
+.project/
+├── project.yaml      # Main metadata (CNCF spec)
+├── maintainers.yaml  # Maintainer roster
+└── extensions/       # Tool-specific configs (future)
+    └── darnit.yaml
+```
+
+### Decision 3: Write-Back After Remediation
+
+**Choice**: Update .project/ files when remediation creates relevant artifacts
+
+**Rationale**:
+- Keep .project/ in sync with actual project state
+- E.g., after creating SECURITY.md, update `security.policy.path`
+- Reduces manual maintenance
+
+**Implementation**:
+- Remediation actions can declare `.project/` updates
+- YAML writer preserves comments and formatting where possible
+- Changes staged for user review (not auto-committed)
+
+### Decision 4: Plugin Auto-Registration with Signing
+
+**Choice**: Plugins declare capabilities in their package metadata; framework auto-discovers
+
+**Rationale**:
+- Reduces boilerplate in TOML configs
+- Entry points already used for plugin discovery
+- Signing via Sigstore adds trust without key management
+
+**Security model**:
+```
+[plugins]
+# Explicit trust for unsigned plugins
+allow_unsigned = false
+
+# Trusted publishers (PyPI attestations)
+trusted_publishers = ["openssf", "kusari-oss"]
+
+# Specific plugin versions
+[plugins.darnit-baseline]
+version = ">=1.0.0"
+```
+
+### Decision 5: Phased Rollout
+
+**Choice**: 4 incremental phases, each independently valuable
+
+**Rationale**:
+- Reduces risk of big-bang migration
+- Earlier phases unblock later phases
+- Users can adopt incrementally
+
+**Phase dependencies**:
+```
+Phase 1 (.project/) ──┬──> Phase 2 (Context)
+                      │
+                      └──> Phase 3 (CEL) ──> Phase 4 (Plugins)
+```
+
+## Risks / Trade-offs
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| .project/ spec changes upstream | Schema drift, broken parsing | Weekly CI check of `types.go` hash; tolerant reader for unknown fields |
+| CEL learning curve | User confusion | Good docs, examples, fallback to old syntax during transition |
+| Plugin signing adoption | Users may not sign plugins | Allow unsigned with explicit opt-in + warning; sign our own plugins |
+| YAML comment preservation | Complex to implement | Use `ruamel.yaml` which preserves comments; accept some edge cases |
+| Sigstore availability | Verification failures if service down | Cache verification results; graceful degradation to warning |
+
+## Migration Plan
+
+### Phase 1 → 2 → 3 → 4 Rollout
+
+**Phase 1 (.project/ integration)**:
+1. Add .project/ reader module
+2. Inject .project/ data into sieve context
+3. Add write-back capability to remediation
+4. Release as minor version (non-breaking)
+
+**Phase 2 (Context collection)**:
+1. Add `[context]` schema to framework_schema.py
+2. Implement prompt UI in MCP tools
+3. Wire context into remediation variables
+4. Release as minor version (non-breaking)
+
+**Phase 3 (CEL expressions)**:
+1. Add `celpy` dependency
+2. Implement CEL evaluator with sandboxing
+3. Add `expr` field to pass schemas
+4. Deprecate old fields with warnings
+5. Release as major version (breaking)
+
+**Phase 4 (Plugin system)**:
+1. Define plugin manifest schema
+2. Implement auto-registration from entry points
+3. Add Sigstore verification (optional)
+4. Migrate darnit-baseline to new system
+5. Release as major version (breaking)
+
+### Rollback Strategy
+
+Each phase is independently reversible:
+- Phase 1: Remove .project/ reader, context continues from heuristics
+- Phase 2: Remove `[context]` section, remediation uses defaults
+- Phase 3: Revert to old field syntax (keep both during transition)
+- Phase 4: Revert to manual handler wiring
+
+## Open Questions
+
+1. **CEL library choice**: `celpy` vs `cel-python` vs other? Need to evaluate maturity and maintenance status.
+
+2. **Sigstore integration depth**: Full SLSA provenance or just signature verification? Start simple.
+
+3. **.project/ extension namespace**: Should we use `extensions.darnit` or propose a standard `extensions.security-baseline`?
+
+4. **Comment preservation scope**: How much effort to preserve YAML comments? ruamel.yaml handles most cases but edge cases exist.
+
+5. **Upstream tracking automation**: GitHub Action vs Dependabot-style bot for .project/ spec changes?

--- a/openspec/changes/toml-schema-v2/proposal.md
+++ b/openspec/changes/toml-schema-v2/proposal.md
@@ -1,0 +1,113 @@
+## Why
+
+The current TOML schema has grown organically with custom fields for each check type, making it harder to extend and maintain. We need a more robust, extensible schema that:
+1. Aligns with the emerging [CNCF .project/ specification](https://github.com/cncf/automation/tree/main/utilities/dot-project) for project metadata
+2. Simplifies policy expressions using an established language (CEL) instead of proliferating custom fields
+3. Provides a cleaner plugin registration mechanism
+4. Formalizes the context gathering flow for remediations that need user input
+
+## What Changes
+
+This is a significant evolution split into **4 incremental phases**:
+
+### Phase 1: .project/ Integration
+- Read and honor `.project/` YAML files following CNCF spec
+- Support the [proposed extension mechanism](https://github.com/cncf/automation/pull/131) for tool-specific config
+- Map `.project/` sections (security, governance, documentation) to check context
+- **Write-back**: Update .project/ files after remediation (e.g., add security.policy path after creating SECURITY.md)
+- Fallback chain: `.project/` → heuristic detection (existing behavior)
+- **Non-breaking**: Additive capability, existing checks continue to work
+
+### Phase 2: Context Collection
+- Formalize `[context]` section for interactive context collection
+- Define prompt schemas for user input (e.g., "who are your maintainers?")
+- Support pointing to existing files as context sources (e.g., `source = "MAINTAINERS.md"`)
+- Context flows into remediation as variables
+- **Non-breaking**: New section, opt-in usage
+
+### Phase 3: CEL Expressions
+- Add `expr` field for pass/fail conditions using [CEL (Common Expression Language)](https://cel.dev/)
+- Support data extraction from command outputs and API responses
+- Simplify check definitions: instead of `pass_if_json_path` + `pass_if_json_value`, use `expr = "output.status == 'pass'"`
+- **Breaking**: Old fields deprecated, CEL becomes preferred
+- **TODO**: Explore CUE, Expr, and other alternatives before finalizing
+
+### Phase 4: Plugin System
+- New `[plugins]` section for declaring plugin dependencies
+- Plugins auto-register their handlers, templates, and passes when loaded
+- Secure by default: whitelist-based module loading, no arbitrary code paths
+- **Breaking**: New plugin declaration syntax
+
+## Security Considerations
+
+The plugin system inherently runs code, so we minimize attack surface:
+
+| Risk | Mitigation |
+|------|------------|
+| Arbitrary code execution | Whitelist allowed module prefixes (`darnit.`, `darnit_baseline.`, registered entry points) |
+| Path traversal | Validate all file paths are within repo root |
+| Command injection | Commands executed as arrays, not shell strings; no user-controlled interpolation |
+| Malicious plugins | Explore Sigstore signing; unsigned plugins require explicit opt-in with warning |
+| CEL injection | CEL is non-Turing-complete and sandboxed; no filesystem/network access |
+| .project/ write-back | Only write to .project/ files, validate YAML structure, preserve comments where possible |
+
+**Documentation requirements:**
+- Clear warning that plugins execute arbitrary code
+- Guidance on vetting third-party plugins
+- Security model explanation in framework docs
+
+## Capabilities
+
+### New Capabilities
+- `dot-project-integration`: Reading and using .project/ metadata as check context (Phase 1)
+- `context-collection`: Interactive context gathering with user prompts and file sources (Phase 2)
+- `cel-expressions`: CEL-based policy expressions for check pass/fail conditions (Phase 3)
+- `plugin-registry`: Declarative plugin registration and auto-discovery (Phase 4)
+
+### Modified Capabilities
+- `framework-design`: Schema changes to `[controls]`, new `[plugins]` and `[context]` sections, CEL expression support in passes
+
+## Impact
+
+### Code Changes (by phase)
+
+**Phase 1:**
+- New: `packages/darnit/src/darnit/context/dot_project.py` - .project/ parser
+- Modify: `packages/darnit/src/darnit/sieve/orchestrator.py` - inject .project/ context
+
+**Phase 2:**
+- New: `packages/darnit/src/darnit/context/collection.py` - context prompts
+- Modify: `packages/darnit/src/darnit/config/framework_schema.py` - `[context]` schema
+
+**Phase 3:**
+- New: `packages/darnit/src/darnit/sieve/cel_evaluator.py` - CEL evaluation
+- Modify: `packages/darnit/src/darnit/sieve/passes.py` - CEL expression support
+- Modify: `packages/darnit/src/darnit/config/framework_schema.py` - `expr` field
+
+**Phase 4:**
+- Modify: `packages/darnit/src/darnit/core/plugin.py` - auto-registration
+- Modify: `packages/darnit/src/darnit/config/framework_schema.py` - `[plugins]` schema
+
+### Dependencies
+- Phase 1: `pyyaml` (likely already present)
+- Phase 3: `cel-python` or `celpy` for CEL evaluation
+
+### Migration
+- Phases 1-2: No migration needed (additive)
+- Phases 3-4: Deprecation warnings, then removal in next major version
+
+## Open Questions
+
+- **CEL alternatives**: Before Phase 3 implementation, evaluate CUE, Expr, Starlark as alternatives. CEL chosen initially for Kubernetes ecosystem alignment and safety guarantees.
+- **.project/ spec compliance**:
+  - Implement strict compliance with CNCF .project/ spec, not a loose interpretation
+  - Add CI job to periodically check upstream [cncf/automation](https://github.com/cncf/automation/tree/main/utilities/dot-project) for schema changes
+  - Subscribe to/watch the repo for updates; consider GitHub Actions workflow that checks `types.go` hash weekly
+  - Reader should be tolerant of unknown fields (forward compatibility) but validate known fields strictly
+  - Document which spec version we target and maintain a compatibility matrix
+- **Plugin signing**: Explore [Sigstore](https://www.sigstore.dev/) for plugin signature verification. Options to investigate:
+  - `sigstore-python` for verifying plugin signatures
+  - Keyless signing via Fulcio (no key management burden)
+  - Rekor transparency log for audit trail
+  - Integration with PyPI trusted publishing
+  - Fallback: allow unsigned plugins with explicit user opt-in and warning

--- a/openspec/changes/toml-schema-v2/specs/cel-expressions/spec.md
+++ b/openspec/changes/toml-schema-v2/specs/cel-expressions/spec.md
@@ -1,0 +1,131 @@
+# CEL Expressions Specification
+
+## ADDED Requirements
+
+### Requirement: CEL expression field for passes
+The framework SHALL support an `expr` field in pass definitions for CEL-based pass/fail evaluation.
+
+#### Scenario: Simple boolean expression
+- **WHEN** pass definition contains `expr = "output.status == 'pass'"`
+- **THEN** the framework SHALL evaluate the CEL expression against the pass context
+- **AND** SHALL return PASS if expression evaluates to true
+
+#### Scenario: Expression evaluates to false
+- **WHEN** CEL expression evaluates to `false`
+- **THEN** the framework SHALL return FAIL for that pass
+
+#### Scenario: Expression error
+- **WHEN** CEL expression has a syntax error or runtime error
+- **THEN** the framework SHALL return ERROR status
+- **AND** SHALL include the error message in the result
+
+### Requirement: CEL context variables
+The framework SHALL provide standard variables in the CEL evaluation context.
+
+#### Scenario: Output variable for exec pass
+- **WHEN** an exec pass runs a command
+- **THEN** the CEL context SHALL include:
+  - `output.stdout` (string)
+  - `output.stderr` (string)
+  - `output.exit_code` (int)
+  - `output.json` (parsed JSON if output is valid JSON, else null)
+
+#### Scenario: File context for pattern pass
+- **WHEN** a pattern pass searches files
+- **THEN** the CEL context SHALL include:
+  - `files` (list of matched file paths)
+  - `matches` (list of match objects with file, line, content)
+
+#### Scenario: API response context
+- **WHEN** an API check receives a response
+- **THEN** the CEL context SHALL include:
+  - `response.status_code` (int)
+  - `response.body` (parsed JSON)
+  - `response.headers` (map)
+
+#### Scenario: Project context available
+- **WHEN** any CEL expression is evaluated
+- **THEN** the CEL context SHALL include:
+  - `project` (from .project/ integration)
+  - `context` (from context collection)
+  - `repo.path` (repository root path)
+  - `repo.owner` (GitHub owner if detectable)
+  - `repo.name` (GitHub repo name if detectable)
+
+### Requirement: CEL standard functions
+The framework SHALL provide standard CEL functions plus security-focused extensions.
+
+#### Scenario: String functions
+- **WHEN** CEL expression uses `contains()`, `startsWith()`, `endsWith()`
+- **THEN** the framework SHALL evaluate them per CEL specification
+
+#### Scenario: List functions
+- **WHEN** CEL expression uses `size()`, `exists()`, `all()`, `filter()`, `map()`
+- **THEN** the framework SHALL evaluate them per CEL specification
+
+#### Scenario: Custom file_exists function
+- **WHEN** CEL expression uses `file_exists("SECURITY.md")`
+- **THEN** the framework SHALL check if the file exists in the repository
+- **AND** SHALL return boolean result
+
+#### Scenario: Custom json_path function
+- **WHEN** CEL expression uses `json_path(output.json, "$.status")`
+- **THEN** the framework SHALL extract the value at that JSONPath
+- **AND** SHALL return the extracted value or null
+
+### Requirement: CEL sandboxing
+The framework SHALL sandbox CEL evaluation to prevent security issues.
+
+#### Scenario: No filesystem access
+- **WHEN** CEL expression attempts direct filesystem access
+- **THEN** the framework SHALL deny the operation
+- **AND** SHALL only allow access through provided functions like `file_exists()`
+
+#### Scenario: No network access
+- **WHEN** CEL expression attempts network access
+- **THEN** the framework SHALL deny the operation
+
+#### Scenario: Execution timeout
+- **WHEN** CEL expression takes longer than 1 second to evaluate
+- **THEN** the framework SHALL terminate evaluation
+- **AND** SHALL return ERROR status with timeout message
+
+#### Scenario: Memory limit
+- **WHEN** CEL expression attempts to allocate excessive memory
+- **THEN** the framework SHALL terminate evaluation
+- **AND** SHALL return ERROR status
+
+### Requirement: Backward compatibility with old fields
+The framework SHALL support both old-style fields and CEL expressions during transition.
+
+#### Scenario: Old fields still work
+- **WHEN** pass definition uses `pass_if_json_path` and `pass_if_json_value`
+- **THEN** the framework SHALL evaluate them as before
+- **AND** SHALL log a deprecation warning
+
+#### Scenario: CEL takes precedence
+- **WHEN** pass definition contains both `expr` and old-style fields
+- **THEN** the framework SHALL use the `expr` field
+- **AND** SHALL ignore old-style fields
+- **AND** SHALL log a warning about redundant configuration
+
+### Requirement: CEL expression validation
+The framework SHALL validate CEL expressions at config load time.
+
+#### Scenario: Syntax validation
+- **WHEN** TOML config is loaded
+- **THEN** the framework SHALL parse all CEL expressions
+- **AND** SHALL report syntax errors with line numbers
+
+#### Scenario: Type checking
+- **WHEN** CEL expression references unknown variables
+- **THEN** the framework SHALL report the error at config load time
+- **AND** SHALL list available variables
+
+### Requirement: CEL expression examples in errors
+The framework SHALL provide helpful error messages with examples.
+
+#### Scenario: Migration hint
+- **WHEN** user uses old-style `pass_if_json_path` + `pass_if_json_value`
+- **THEN** deprecation warning SHALL include equivalent CEL expression
+- **Example**: `Migrate to: expr = "json_path(output.json, '$.status') == 'pass'"`

--- a/openspec/changes/toml-schema-v2/specs/context-collection/spec.md
+++ b/openspec/changes/toml-schema-v2/specs/context-collection/spec.md
@@ -1,0 +1,120 @@
+# Context Collection Specification
+
+## ADDED Requirements
+
+### Requirement: Define context schema in TOML
+The framework SHALL support a `[context]` section in the TOML config for defining context variables that may require user input.
+
+#### Scenario: Context definition with prompt
+- **WHEN** TOML contains:
+  ```toml
+  [context.maintainers]
+  description = "List of project maintainers"
+  type = "list[string]"
+  prompt = "Who are the maintainers of this project?"
+  ```
+- **THEN** the framework SHALL recognize this as a context variable that may need user input
+
+#### Scenario: Context definition with file source
+- **WHEN** TOML contains:
+  ```toml
+  [context.maintainers]
+  description = "List of project maintainers"
+  type = "list[string]"
+  source = "MAINTAINERS.md"
+  parser = "markdown_list"
+  ```
+- **THEN** the framework SHALL attempt to parse maintainers from that file
+
+### Requirement: Context resolution priority
+The framework SHALL resolve context values in a defined priority order.
+
+#### Scenario: .project/ provides value
+- **WHEN** a context variable can be resolved from `.project/project.yaml`
+- **THEN** that value SHALL be used without prompting the user
+
+#### Scenario: File source provides value
+- **WHEN** a context variable has a `source` file that exists and can be parsed
+- **THEN** that value SHALL be used without prompting the user
+
+#### Scenario: Fallback to user prompt
+- **WHEN** a context variable cannot be resolved from .project/ or file sources
+- **AND** the variable has a `prompt` defined
+- **THEN** the framework SHALL prompt the user for the value
+
+#### Scenario: No value available
+- **WHEN** a context variable cannot be resolved and has no prompt
+- **THEN** the framework SHALL set the variable to `null`
+- **AND** SHALL log a debug message
+
+### Requirement: Context types
+The framework SHALL support typed context variables.
+
+#### Scenario: String type
+- **WHEN** context type is `string`
+- **THEN** the value SHALL be stored as a string
+
+#### Scenario: List type
+- **WHEN** context type is `list[string]`
+- **THEN** the value SHALL be stored as a list of strings
+- **AND** user prompts SHALL accept comma-separated or multi-line input
+
+#### Scenario: Boolean type
+- **WHEN** context type is `boolean`
+- **THEN** the value SHALL be stored as true/false
+- **AND** user prompts SHALL accept yes/no/true/false
+
+#### Scenario: Email type
+- **WHEN** context type is `email`
+- **THEN** the value SHALL be validated as an email address
+
+### Requirement: Context flows to remediation
+Context variables SHALL be available as template variables in remediation actions.
+
+#### Scenario: Use context in template
+- **WHEN** remediation uses template with `$maintainers` variable
+- **AND** `context.maintainers` has been resolved
+- **THEN** the template SHALL substitute the maintainers list
+
+#### Scenario: Missing context blocks remediation
+- **WHEN** remediation requires a context variable that is `null`
+- **AND** the variable is marked `required = true`
+- **THEN** the remediation SHALL fail with a clear error message
+
+### Requirement: User confirmation for auto-detected context
+The framework SHALL allow user confirmation of auto-detected context values.
+
+#### Scenario: Confirm auto-detected maintainers
+- **WHEN** maintainers are auto-detected from CODEOWNERS
+- **AND** context definition has `confirm = true`
+- **THEN** the framework SHALL show the detected value and ask for confirmation
+
+#### Scenario: User overrides auto-detected value
+- **WHEN** user is prompted to confirm an auto-detected value
+- **AND** user provides a different value
+- **THEN** the user-provided value SHALL be used
+
+### Requirement: Persist collected context
+The framework SHALL persist user-provided context to avoid repeated prompts.
+
+#### Scenario: Save to .project/
+- **WHEN** user provides context via prompt
+- **AND** the context can be represented in .project/ format
+- **THEN** the framework SHALL offer to save it to `.project/project.yaml`
+
+#### Scenario: Save to .baseline.toml
+- **WHEN** user provides context that is darnit-specific
+- **THEN** the framework SHALL save it to `.baseline.toml` under `[context]`
+
+### Requirement: Context validation
+The framework SHALL validate context values against defined constraints.
+
+#### Scenario: Required context missing
+- **WHEN** a context variable is marked `required = true`
+- **AND** the value cannot be resolved
+- **THEN** the framework SHALL report an error
+
+#### Scenario: Pattern validation
+- **WHEN** context definition includes `pattern = "^@[\\w-]+$"`
+- **AND** user provides a value not matching the pattern
+- **THEN** the framework SHALL reject the value and re-prompt

--- a/openspec/changes/toml-schema-v2/specs/dot-project-integration/spec.md
+++ b/openspec/changes/toml-schema-v2/specs/dot-project-integration/spec.md
@@ -1,0 +1,101 @@
+# .project/ Integration Specification
+
+## ADDED Requirements
+
+### Requirement: Read .project/ metadata
+The framework SHALL read project metadata from `.project/project.yaml` following the CNCF .project/ specification.
+
+#### Scenario: Valid .project/ file exists
+- **WHEN** a repository contains `.project/project.yaml`
+- **THEN** the framework SHALL parse it and make all fields available in the sieve context
+
+#### Scenario: No .project/ file exists
+- **WHEN** a repository does not contain `.project/project.yaml`
+- **THEN** the framework SHALL continue with heuristic-based context detection
+- **AND** SHALL NOT fail or error
+
+#### Scenario: Invalid .project/ file
+- **WHEN** `.project/project.yaml` exists but contains invalid YAML
+- **THEN** the framework SHALL log a warning
+- **AND** SHALL continue with heuristic-based context detection
+
+### Requirement: Map .project/ sections to check context
+The framework SHALL map .project/ sections to standardized context variables for use in checks.
+
+#### Scenario: Security section mapping
+- **WHEN** `.project/project.yaml` contains a `security` section with `policy.path`
+- **THEN** the context variable `project.security.policy_path` SHALL contain that path
+- **AND** checks for SECURITY.md SHALL use this path
+
+#### Scenario: Governance section mapping
+- **WHEN** `.project/project.yaml` contains a `governance` section
+- **THEN** the context SHALL include `project.governance.codeowners_path`, `project.governance.contributing_path`, etc.
+
+#### Scenario: Maintainers mapping
+- **WHEN** `.project/project.yaml` or `.project/maintainers.yaml` contains maintainer information
+- **THEN** the context variable `project.maintainers` SHALL contain the list of maintainers
+
+### Requirement: Tolerate unknown fields
+The .project/ reader SHALL tolerate unknown fields for forward compatibility with spec evolution.
+
+#### Scenario: Unknown top-level field
+- **WHEN** `.project/project.yaml` contains a field not in the known schema
+- **THEN** the framework SHALL parse successfully
+- **AND** SHALL preserve the unknown field in the parsed data
+
+#### Scenario: Unknown nested field
+- **WHEN** a known section contains an unknown nested field
+- **THEN** the framework SHALL parse successfully without error
+
+### Requirement: Support extension mechanism
+The framework SHALL support the .project/ extension mechanism for tool-specific configuration.
+
+#### Scenario: Darnit extension present
+- **WHEN** `.project/project.yaml` contains `extensions.darnit` section
+- **THEN** the framework SHALL read tool-specific configuration from that section
+- **AND** SHALL make it available as `project.extensions.darnit`
+
+#### Scenario: No extension present
+- **WHEN** `.project/project.yaml` does not contain an `extensions` section
+- **THEN** the framework SHALL use default configuration
+
+### Requirement: Write-back after remediation
+The framework SHALL update `.project/project.yaml` when remediation creates artifacts that should be tracked.
+
+#### Scenario: SECURITY.md created
+- **WHEN** remediation creates `SECURITY.md`
+- **THEN** the framework SHALL update `.project/project.yaml` to set `security.policy.path = "SECURITY.md"`
+- **AND** SHALL preserve existing content and comments
+
+#### Scenario: CODEOWNERS created
+- **WHEN** remediation creates `.github/CODEOWNERS`
+- **THEN** the framework SHALL update `.project/project.yaml` to set `governance.codeowners.path = ".github/CODEOWNERS"`
+
+#### Scenario: .project/ does not exist for write-back
+- **WHEN** remediation wants to write back but `.project/project.yaml` does not exist
+- **THEN** the framework SHALL create `.project/project.yaml` with the relevant fields
+- **AND** SHALL include `schema_version` field
+
+### Requirement: Validate against upstream schema
+The framework SHALL validate .project/ files against the CNCF specification.
+
+#### Scenario: Required fields missing
+- **WHEN** `.project/project.yaml` is missing required fields (name, repositories)
+- **THEN** the framework SHALL log a warning with specific missing fields
+- **AND** SHALL continue with available data
+
+#### Scenario: Valid file
+- **WHEN** `.project/project.yaml` contains all required fields with valid values
+- **THEN** the framework SHALL parse without warnings
+
+### Requirement: Track upstream spec changes
+The project SHALL monitor the upstream CNCF .project/ specification for changes.
+
+#### Scenario: CI check for spec changes
+- **WHEN** CI runs on a schedule (weekly)
+- **THEN** it SHALL check if `types.go` in cncf/automation has changed
+- **AND** SHALL create an issue if changes are detected
+
+#### Scenario: Document targeted spec version
+- **WHEN** the framework is released
+- **THEN** documentation SHALL specify which .project/ spec version is supported

--- a/openspec/changes/toml-schema-v2/specs/framework-design/spec.md
+++ b/openspec/changes/toml-schema-v2/specs/framework-design/spec.md
@@ -1,0 +1,132 @@
+# Framework Design - Delta Specification
+
+This delta modifies the `framework-design` spec to add new TOML schema sections.
+
+## MODIFIED Requirements
+
+### Requirement: TOML Root Structure
+The TOML schema root structure SHALL include new sections for plugins, context, and .project/ integration.
+
+```toml
+[metadata]
+name = "framework-name"           # REQUIRED: Framework identifier
+display_name = "Framework Name"   # REQUIRED: Human-readable name
+version = "0.1.0"                 # REQUIRED: Framework version
+schema_version = "1.0.0"          # REQUIRED: TOML schema version (bumped for breaking changes)
+spec_version = "Spec v1.0"        # OPTIONAL: Upstream spec version
+description = "..."               # OPTIONAL: Framework description
+url = "https://..."               # OPTIONAL: Spec URL
+
+[plugins]                         # NEW: Plugin dependencies
+allow_unsigned = false            # Whether to allow unsigned plugins
+trusted_publishers = []           # List of trusted Sigstore publishers
+
+[plugins.plugin-name]             # NEW: Specific plugin constraints
+version = ">=1.0.0"               # Version constraint
+
+[defaults]
+check_adapter = "builtin"         # Default check adapter
+remediation_adapter = "builtin"   # Default remediation adapter
+
+[context]                         # NEW: Context variable definitions
+# Context collection definitions
+
+[templates]
+# Reusable templates for remediation
+
+[controls]
+# Control definitions (main content)
+```
+
+#### Scenario: Schema version bump
+- **WHEN** config uses new schema features (plugins, context, CEL expressions)
+- **THEN** `schema_version` SHALL be `"1.0.0"` or higher
+
+#### Scenario: Backward compatible loading
+- **WHEN** config has `schema_version = "0.1.0-alpha"`
+- **THEN** the framework SHALL load it in compatibility mode
+- **AND** SHALL log deprecation warnings for old syntax
+
+### Requirement: Pass Definition with CEL Expression
+Pass definitions SHALL support an `expr` field for CEL-based evaluation.
+
+```toml
+[controls."OSPS-AC-03.01".passes.deterministic]
+# Old style (deprecated but supported):
+api_check = "darnit_baseline.checks:check_branch_protection"
+
+# New style with CEL:
+exec = ["gh", "api", "/repos/$OWNER/$REPO/branches/$BRANCH/protection"]
+expr = "response.body.required_pull_request_reviews != null"
+```
+
+#### Scenario: CEL expression in exec pass
+- **WHEN** exec pass has both `exec` command and `expr` field
+- **THEN** the framework SHALL run the command
+- **AND** SHALL evaluate `expr` against the command output
+
+#### Scenario: CEL expression standalone
+- **WHEN** pass has only `expr` field referencing context
+- **THEN** the framework SHALL evaluate against current context without running commands
+
+### Requirement: Context Variable Definition
+The `[context]` section SHALL define variables that may need user input.
+
+```toml
+[context.maintainers]
+description = "List of project maintainers"
+type = "list[string]"
+source = "MAINTAINERS.md"           # Try to parse from file first
+parser = "markdown_list"            # Parser for the source file
+prompt = "Who are the maintainers?" # Ask user if source fails
+required = true                     # Block remediation if not resolved
+confirm = true                      # Ask user to confirm auto-detected value
+
+[context.security_contact]
+description = "Security contact email"
+type = "email"
+source = ".project/project.yaml"
+source_path = "security.contact"    # JSONPath within the source
+prompt = "What email should security issues be reported to?"
+```
+
+#### Scenario: Context from .project/
+- **WHEN** context has `source = ".project/project.yaml"` and `source_path`
+- **THEN** the framework SHALL extract the value using the path
+
+#### Scenario: Context with parser
+- **WHEN** context has `source` file and `parser`
+- **THEN** the framework SHALL use the specified parser to extract values
+
+### Requirement: Remediation Write-Back
+Remediation actions SHALL support updating .project/ files.
+
+```toml
+[controls."OSPS-VM-02.01".remediation]
+[controls."OSPS-VM-02.01".remediation.file_create]
+path = "SECURITY.md"
+template = "security_policy_standard"
+
+[controls."OSPS-VM-02.01".remediation.project_update]
+set = { "security.policy.path" = "SECURITY.md" }
+```
+
+#### Scenario: project_update action
+- **WHEN** remediation includes `project_update` with `set`
+- **THEN** the framework SHALL update `.project/project.yaml` with those values
+- **AND** SHALL create the file if it doesn't exist
+
+## ADDED Requirements
+
+### Requirement: Plugin Declaration
+Controls MAY reference handlers by name without module paths when plugins are declared.
+
+#### Scenario: Handler by name
+- **WHEN** `[plugins.darnit-baseline]` is declared
+- **AND** control uses `handler = "create_security_policy"`
+- **THEN** the framework SHALL resolve the handler from the plugin's registered handlers
+
+#### Scenario: Explicit module path still works
+- **WHEN** control uses `handler = "darnit_baseline.remediation:create_security_policy"`
+- **THEN** the framework SHALL load from that explicit path
+- **AND** SHALL validate against allowed module prefixes

--- a/openspec/changes/toml-schema-v2/specs/plugin-registry/spec.md
+++ b/openspec/changes/toml-schema-v2/specs/plugin-registry/spec.md
@@ -1,0 +1,125 @@
+# Plugin Registry Specification
+
+## ADDED Requirements
+
+### Requirement: Plugins section in TOML
+The framework SHALL support a `[plugins]` section for declaring plugin dependencies.
+
+#### Scenario: Declare plugin dependency
+- **WHEN** TOML contains:
+  ```toml
+  [plugins.darnit-baseline]
+  version = ">=1.0.0"
+  ```
+- **THEN** the framework SHALL require that plugin to be installed
+- **AND** SHALL verify the version constraint
+
+#### Scenario: Plugin not installed
+- **WHEN** a declared plugin is not installed
+- **THEN** the framework SHALL report an error with installation instructions
+
+#### Scenario: Version mismatch
+- **WHEN** installed plugin version does not satisfy the constraint
+- **THEN** the framework SHALL report an error with required vs installed versions
+
+### Requirement: Plugin auto-registration
+Plugins SHALL auto-register their capabilities when loaded.
+
+#### Scenario: Plugin registers handlers
+- **WHEN** a plugin is loaded
+- **THEN** the framework SHALL discover and register all handlers decorated with `@register_handler`
+
+#### Scenario: Plugin registers passes
+- **WHEN** a plugin is loaded
+- **THEN** the framework SHALL discover and register all pass implementations decorated with `@register_pass`
+
+#### Scenario: Plugin registers templates
+- **WHEN** a plugin is loaded
+- **THEN** the framework SHALL discover and register all templates from the plugin's `templates/` directory
+
+#### Scenario: No manual wiring needed
+- **WHEN** a control references a handler by name (e.g., `handler = "create_security_policy"`)
+- **THEN** the framework SHALL resolve it from registered handlers
+- **AND** SHALL NOT require explicit module path
+
+### Requirement: Plugin manifest
+Plugins SHALL declare their capabilities in package metadata.
+
+#### Scenario: Entry point registration
+- **WHEN** a plugin is installed via pip
+- **THEN** it SHALL register via the `darnit.plugins` entry point group
+
+#### Scenario: Plugin metadata
+- **WHEN** a plugin is loaded
+- **THEN** its metadata SHALL include:
+  - `name` (plugin identifier)
+  - `version` (semantic version)
+  - `provides` (list of capabilities: handlers, passes, templates)
+  - `requires` (minimum darnit framework version)
+
+### Requirement: Plugin signing with Sigstore
+The framework SHALL support Sigstore-based plugin verification.
+
+#### Scenario: Signed plugin verification
+- **WHEN** a plugin has a Sigstore signature
+- **AND** `allow_unsigned = false` in config
+- **THEN** the framework SHALL verify the signature via Sigstore
+- **AND** SHALL load the plugin only if verification succeeds
+
+#### Scenario: Unsigned plugin with opt-in
+- **WHEN** a plugin does not have a signature
+- **AND** `allow_unsigned = true` in config
+- **THEN** the framework SHALL load the plugin
+- **AND** SHALL log a warning about unsigned plugin
+
+#### Scenario: Unsigned plugin blocked
+- **WHEN** a plugin does not have a signature
+- **AND** `allow_unsigned = false` in config
+- **THEN** the framework SHALL refuse to load the plugin
+- **AND** SHALL report an error
+
+#### Scenario: Trusted publishers
+- **WHEN** config contains `trusted_publishers = ["openssf", "kusari-oss"]`
+- **AND** plugin is signed by a key from those publishers
+- **THEN** the framework SHALL trust the plugin
+
+#### Scenario: Sigstore unavailable
+- **WHEN** Sigstore services are unreachable
+- **THEN** the framework SHALL use cached verification results if available
+- **AND** SHALL warn if no cached result exists
+
+### Requirement: Plugin isolation
+The framework SHALL isolate plugins to limit security impact.
+
+#### Scenario: Whitelist module prefixes
+- **WHEN** a plugin attempts to register a handler
+- **THEN** the handler module SHALL match allowed prefixes: `darnit.`, `darnit_*`, or registered plugin namespaces
+
+#### Scenario: Reject unknown modules
+- **WHEN** TOML references a handler in an unknown module (e.g., `handler = "malicious.code:exploit"`)
+- **THEN** the framework SHALL reject the reference
+- **AND** SHALL report a security error
+
+### Requirement: Plugin discovery
+The framework SHALL discover plugins from multiple sources.
+
+#### Scenario: Installed packages
+- **WHEN** a package with `darnit.plugins` entry point is installed
+- **THEN** the framework SHALL discover it automatically
+
+#### Scenario: Local plugins
+- **WHEN** repository contains `.darnit/plugins/` directory with Python modules
+- **THEN** the framework SHALL load plugins from that directory
+- **AND** SHALL treat them as unsigned
+
+### Requirement: Plugin documentation
+The framework SHALL provide clear documentation about plugin security.
+
+#### Scenario: Security warning in docs
+- **WHEN** documentation describes the plugin system
+- **THEN** it SHALL clearly state that plugins execute arbitrary code
+- **AND** SHALL advise users to only install trusted plugins
+
+#### Scenario: Signing guide
+- **WHEN** plugin developer reads documentation
+- **THEN** they SHALL find instructions for signing plugins with Sigstore

--- a/openspec/changes/toml-schema-v2/tasks.md
+++ b/openspec/changes/toml-schema-v2/tasks.md
@@ -1,0 +1,193 @@
+# Implementation Tasks
+
+## Pre-Commit Requirements
+
+**MANDATORY before every commit:**
+
+1. Run linting: `uv run ruff check .`
+2. Run tests: `uv run pytest tests/ --ignore=tests/integration/ -q`
+3. Fix any issues before committing
+
+This ensures CI will pass and prevents broken commits from being pushed.
+
+---
+
+## 1. Phase 1: .project/ Integration
+
+### 1.1 Core Parser
+
+- [x] 1.1.1 Create `packages/darnit/src/darnit/context/dot_project.py` module
+- [x] 1.1.2 Implement YAML parser for `.project/project.yaml` using ruamel.yaml
+- [x] 1.1.3 Define dataclass/Pydantic models matching CNCF types.go struct
+- [x] 1.1.4 Implement tolerant parsing (unknown fields preserved, not errored)
+- [x] 1.1.5 Add validation for required fields (name, repositories)
+
+### 1.2 Context Mapping
+
+- [x] 1.2.1 Create context mapping from .project/ sections to sieve context variables
+- [x] 1.2.2 Map `security` section → `project.security.*`
+- [x] 1.2.3 Map `governance` section → `project.governance.*`
+- [x] 1.2.4 Map maintainers → `project.maintainers`
+- [x] 1.2.5 Inject .project/ context into sieve orchestrator
+
+### 1.3 Write-Back
+
+- [x] 1.3.1 Implement YAML writer that preserves comments (ruamel.yaml round-trip)
+- [x] 1.3.2 Add `project_update` remediation action type
+- [x] 1.3.3 Implement write-back for `security.policy.path` after SECURITY.md creation
+- [x] 1.3.4 Implement write-back for `governance.codeowners.path` after CODEOWNERS creation
+- [x] 1.3.5 Create .project/ directory and project.yaml if not exists
+
+### 1.4 Upstream Tracking
+
+- [ ] 1.4.1 Create GitHub Action workflow for weekly .project/ spec check
+- [ ] 1.4.2 Implement hash comparison against cncf/automation types.go
+- [ ] 1.4.3 Auto-create issue when upstream changes detected
+- [ ] 1.4.4 Document targeted .project/ spec version in README
+
+### 1.5 Testing
+
+- [x] 1.5.1 Add unit tests for .project/ parser
+- [x] 1.5.2 Add unit tests for tolerant parsing of unknown fields
+- [x] 1.5.3 Add unit tests for write-back with comment preservation
+- [x] 1.5.4 Add integration test with real .project/ file
+
+## 2. Phase 2: Context Collection
+
+### 2.1 Schema Definition
+
+- [ ] 2.1.1 Add `[context]` section to framework_schema.py
+- [ ] 2.1.2 Define ContextVariable Pydantic model with all fields
+- [ ] 2.1.3 Support types: string, list[string], boolean, email
+- [ ] 2.1.4 Add validation for pattern constraints
+
+### 2.2 Resolution Logic
+
+- [ ] 2.2.1 Create `packages/darnit/src/darnit/context/collection.py`
+- [ ] 2.2.2 Implement resolution priority: .project/ → file source → prompt
+- [ ] 2.2.3 Implement file parsers: markdown_list, yaml_path, json_path
+- [ ] 2.2.4 Implement user confirmation flow for auto-detected values
+
+### 2.3 Prompt UI
+
+- [ ] 2.3.1 Add context prompt capability to MCP tools
+- [ ] 2.3.2 Implement multi-line input for list types
+- [ ] 2.3.3 Implement validation feedback (re-prompt on invalid input)
+- [ ] 2.3.4 Add --non-interactive flag to skip prompts
+
+### 2.4 Persistence
+
+- [ ] 2.4.1 Implement save-to-.project/ for collected context
+- [ ] 2.4.2 Implement save-to-.baseline.toml for darnit-specific context
+- [ ] 2.4.3 Add user prompt "Save this value for future runs?"
+
+### 2.5 Testing
+
+- [ ] 2.5.1 Add unit tests for context resolution priority
+- [ ] 2.5.2 Add unit tests for file parsers
+- [ ] 2.5.3 Add integration test for context flow into remediation
+
+## 3. Phase 3: CEL Expressions
+
+### 3.1 Dependencies
+
+- [ ] 3.1.1 Evaluate cel-python vs celpy libraries
+- [ ] 3.1.2 Add chosen CEL library to pyproject.toml
+- [ ] 3.1.3 Document CEL library choice and rationale
+
+### 3.2 CEL Evaluator
+
+- [ ] 3.2.1 Create `packages/darnit/src/darnit/sieve/cel_evaluator.py`
+- [ ] 3.2.2 Implement CEL expression parsing and validation
+- [ ] 3.2.3 Implement sandboxed evaluation with timeout (1s limit)
+- [ ] 3.2.4 Implement memory limiting
+
+### 3.3 Context Variables
+
+- [ ] 3.3.1 Define standard CEL context variables (output, files, response, project, context)
+- [ ] 3.3.2 Implement output.stdout, output.stderr, output.exit_code, output.json for exec
+- [ ] 3.3.3 Implement response.status_code, response.body, response.headers for API
+- [ ] 3.3.4 Implement files, matches for pattern pass
+
+### 3.4 Custom Functions
+
+- [ ] 3.4.1 Implement `file_exists(path)` function
+- [ ] 3.4.2 Implement `json_path(obj, path)` function
+- [ ] 3.4.3 Register custom functions in CEL environment
+
+### 3.5 Pass Integration
+
+- [ ] 3.5.1 Add `expr` field to pass schema
+- [ ] 3.5.2 Integrate CEL evaluator into exec pass
+- [ ] 3.5.3 Integrate CEL evaluator into pattern pass
+- [ ] 3.5.4 Integrate CEL evaluator into deterministic pass
+
+### 3.6 Backward Compatibility
+
+- [ ] 3.6.1 Keep old-style fields working (pass_if_json_path, etc.)
+- [ ] 3.6.2 Add deprecation warnings with migration hints
+- [ ] 3.6.3 Implement precedence: expr > old-style fields
+
+### 3.7 Testing
+
+- [ ] 3.7.1 Add unit tests for CEL expression parsing
+- [ ] 3.7.2 Add unit tests for CEL sandboxing (timeout, no filesystem)
+- [ ] 3.7.3 Add unit tests for custom functions
+- [ ] 3.7.4 Add integration test comparing old-style vs CEL expression
+
+## 4. Phase 4: Plugin System
+
+### 4.1 Schema
+
+- [ ] 4.1.1 Add `[plugins]` section to framework_schema.py
+- [ ] 4.1.2 Define PluginConfig model with version constraints
+- [ ] 4.1.3 Add allow_unsigned and trusted_publishers fields
+
+### 4.2 Auto-Registration
+
+- [ ] 4.2.1 Create `@register_handler` decorator
+- [ ] 4.2.2 Create `@register_pass` decorator
+- [ ] 4.2.3 Implement handler discovery on plugin load
+- [ ] 4.2.4 Implement template discovery from plugin templates/ directory
+- [ ] 4.2.5 Build handler registry keyed by short name
+
+### 4.3 Plugin Resolution
+
+- [ ] 4.3.1 Resolve handler references by short name from registry
+- [ ] 4.3.2 Validate explicit module paths against whitelist
+- [ ] 4.3.3 Add helpful error for missing handlers
+
+### 4.4 Sigstore Integration
+
+- [ ] 4.4.1 Add sigstore-python dependency
+- [ ] 4.4.2 Implement signature verification for installed packages
+- [ ] 4.4.3 Implement trusted_publishers verification
+- [ ] 4.4.4 Implement graceful degradation when Sigstore unavailable
+- [ ] 4.4.5 Cache verification results
+
+### 4.5 Migration
+
+- [ ] 4.5.1 Migrate darnit-baseline to use auto-registration
+- [ ] 4.5.2 Sign darnit-baseline package with Sigstore
+- [ ] 4.5.3 Update existing handler references to short names
+
+### 4.6 Documentation
+
+- [ ] 4.6.1 Document plugin security model
+- [ ] 4.6.2 Document signing process for plugin authors
+- [ ] 4.6.3 Add warning about arbitrary code execution
+
+### 4.7 Testing
+
+- [ ] 4.7.1 Add unit tests for auto-registration
+- [ ] 4.7.2 Add unit tests for handler resolution
+- [ ] 4.7.3 Add unit tests for Sigstore verification (mocked)
+- [ ] 4.7.4 Add integration test with darnit-baseline plugin
+
+## 5. Documentation & Cleanup
+
+- [ ] 5.1 Update CLAUDE.md with new TOML schema sections
+- [ ] 5.2 Update framework-design spec with final schema
+- [ ] 5.3 Regenerate docs/generated/ from updated spec
+- [ ] 5.4 Add migration guide for existing configs
+- [ ] 5.5 Update README with new features

--- a/packages/darnit/pyproject.toml
+++ b/packages/darnit/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pyyaml>=6.0.0",
     "pydantic[email]>=2.0.0",
+    "ruamel.yaml>=0.18.0",  # For .project/ round-trip YAML parsing
     "tomli>=2.0.0;python_version<'3.11'",
     "tomllib-stubs>=0.1.0;python_version<'3.11'",
 ]

--- a/packages/darnit/src/darnit/config/framework_schema.py
+++ b/packages/darnit/src/darnit/config/framework_schema.py
@@ -553,6 +553,7 @@ class RemediationConfig(BaseModel):
     file_create: Optional["FileCreateRemediationConfig"] = None
     exec: Optional["ExecRemediationConfig"] = None
     api_call: Optional["ApiCallRemediationConfig"] = None
+    project_update: Optional["ProjectUpdateRemediationConfig"] = None
 
     # Common settings
     template: str | None = None  # Template name reference
@@ -663,6 +664,32 @@ class ApiCallRemediationConfig(BaseModel):
 
     # JQ filter for response
     jq_filter: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ProjectUpdateRemediationConfig(BaseModel):
+    """Configuration for .project/ file update remediation.
+
+    Updates .project/project.yaml with new values after remediation actions.
+    This keeps .project/ in sync with the actual project state.
+
+    Example:
+        ```toml
+        [controls."OSPS-VM-02.01".remediation.project_update]
+        set = { "security.policy.path" = "SECURITY.md" }
+        ```
+
+    The `set` dictionary uses dotted paths to specify nested YAML updates:
+    - "security.policy.path" -> updates security.policy.path in project.yaml
+    - "governance.codeowners.path" -> updates governance.codeowners.path
+    """
+    # Values to set in .project/project.yaml
+    # Keys are dotted paths, values are the new values
+    set: dict[str, Any] = Field(default_factory=dict)
+
+    # Whether to create .project/ directory if it doesn't exist
+    create_if_missing: bool = True
 
     model_config = ConfigDict(extra="allow")
 

--- a/packages/darnit/src/darnit/context/__init__.py
+++ b/packages/darnit/src/darnit/context/__init__.py
@@ -32,6 +32,18 @@ from .confidence import (
     calculate_confidence,
     format_confidence_explanation,
 )
+from .dot_project import (
+    DotProjectReader,
+    DotProjectWriter,
+    ProjectConfig,
+)
+from .dot_project_mapper import DotProjectMapper
+from .inject import (
+    create_check_context_with_project,
+    get_project_value,
+    has_project_value,
+    inject_project_context,
+)
 from .sieve import (
     ContextDetectionResult,
     ContextSieve,
@@ -50,4 +62,13 @@ __all__ = [
     "ContextSieve",
     "ContextDetectionResult",
     "get_context_sieve",
+    # .project/ integration
+    "DotProjectReader",
+    "DotProjectWriter",
+    "ProjectConfig",
+    "DotProjectMapper",
+    "inject_project_context",
+    "create_check_context_with_project",
+    "get_project_value",
+    "has_project_value",
 ]

--- a/packages/darnit/src/darnit/context/dot_project.py
+++ b/packages/darnit/src/darnit/context/dot_project.py
@@ -1,0 +1,555 @@
+"""CNCF .project/ specification reader and writer.
+
+This module implements reading and writing of .project/project.yaml files
+following the CNCF .project/ specification.
+
+Specification: https://github.com/cncf/automation/tree/main/utilities/dot-project
+Targeted Spec Version: 1.0.0 (based on types.go as of 2024-01)
+
+The reader is tolerant of unknown fields for forward compatibility with
+spec evolution. Required fields are validated per the CNCF types.go struct.
+
+Example:
+    from darnit.context.dot_project import DotProjectReader, DotProjectWriter
+
+    # Read project metadata
+    reader = DotProjectReader("/path/to/repo")
+    if reader.exists():
+        config = reader.read()
+        print(config.name)
+        print(config.maintainers)
+
+    # Write updates (preserving comments)
+    writer = DotProjectWriter("/path/to/repo")
+    writer.update({"security": {"policy": {"path": "SECURITY.md"}}})
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Targeted .project/ spec version
+# Based on cncf/automation types.go
+# Update this when we verify compatibility with newer spec versions
+DOT_PROJECT_SPEC_VERSION = "1.0.0"
+DOT_PROJECT_SPEC_URL = "https://github.com/cncf/automation/tree/main/utilities/dot-project"
+
+
+@dataclass
+class FileReference:
+    """Reference to a file path within the repository."""
+
+    path: str
+
+
+@dataclass
+class SecurityConfig:
+    """Security section of .project/project.yaml."""
+
+    policy: FileReference | None = None
+    threat_model: FileReference | None = None
+
+    # Allow unknown fields for forward compatibility
+    _extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GovernanceConfig:
+    """Governance section of .project/project.yaml."""
+
+    contributing: FileReference | None = None
+    codeowners: FileReference | None = None
+    governance_doc: FileReference | None = None
+
+    # Allow unknown fields for forward compatibility
+    _extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class LegalConfig:
+    """Legal section of .project/project.yaml."""
+
+    license: FileReference | None = None
+
+    # Allow unknown fields for forward compatibility
+    _extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DocumentationConfig:
+    """Documentation section of .project/project.yaml."""
+
+    readme: FileReference | None = None
+    support: FileReference | None = None
+    architecture: FileReference | None = None
+    api: FileReference | None = None
+
+    # Allow unknown fields for forward compatibility
+    _extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Audit:
+    """Audit record in .project/project.yaml."""
+
+    date: str | None = None
+    url: str | None = None
+    type: str | None = None
+
+    # Allow unknown fields for forward compatibility
+    _extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MaturityEntry:
+    """Maturity log entry in .project/project.yaml."""
+
+    phase: str | None = None
+    date: str | None = None
+    issue: str | None = None
+
+    # Allow unknown fields for forward compatibility
+    _extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ExtensionConfig:
+    """Extension configuration for third-party tools."""
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ProjectConfig:
+    """Complete .project/project.yaml configuration.
+
+    This dataclass maps to the CNCF .project/ specification types.go struct.
+    All fields except name and repositories are optional.
+    Unknown fields are preserved in _extra for forward compatibility.
+    """
+
+    # Required fields
+    name: str = ""
+    repositories: list[str] = field(default_factory=list)
+
+    # Optional core fields
+    description: str = ""
+    schema_version: str = ""
+    type: str = ""
+    website: str = ""
+    artwork: str = ""
+
+    # Optional list fields
+    mailing_lists: list[str] = field(default_factory=list)
+    maturity_log: list[MaturityEntry] = field(default_factory=list)
+    audits: list[Audit] = field(default_factory=list)
+
+    # Optional map fields
+    social: dict[str, str] = field(default_factory=dict)
+
+    # Optional structured sections
+    security: SecurityConfig | None = None
+    governance: GovernanceConfig | None = None
+    legal: LegalConfig | None = None
+    documentation: DocumentationConfig | None = None
+
+    # Extensions (PR #131)
+    extensions: dict[str, ExtensionConfig] = field(default_factory=dict)
+
+    # Maintainers (from project.yaml or maintainers.yaml)
+    maintainers: list[str] = field(default_factory=list)
+
+    # Allow unknown fields for forward compatibility
+    _extra: dict[str, Any] = field(default_factory=dict)
+
+    # Track source file for write-back
+    _source_path: Path | None = None
+
+    def is_valid(self) -> tuple[bool, list[str]]:
+        """Check if required fields are present.
+
+        Returns:
+            Tuple of (is_valid, list of missing field names)
+        """
+        missing = []
+        if not self.name:
+            missing.append("name")
+        if not self.repositories:
+            missing.append("repositories")
+        return len(missing) == 0, missing
+
+
+class DotProjectReader:
+    """Reader for .project/ directory files.
+
+    Implements tolerant parsing that preserves unknown fields for
+    forward compatibility with spec evolution.
+    """
+
+    def __init__(self, repo_path: str | Path):
+        """Initialize reader with repository path.
+
+        Args:
+            repo_path: Path to the repository root
+        """
+        self.repo_path = Path(repo_path)
+        self.project_dir = self.repo_path / ".project"
+        self.project_yaml = self.project_dir / "project.yaml"
+        self.maintainers_yaml = self.project_dir / "maintainers.yaml"
+
+    def exists(self) -> bool:
+        """Check if .project/project.yaml exists."""
+        return self.project_yaml.exists()
+
+    def read(self) -> ProjectConfig:
+        """Read and parse .project/project.yaml.
+
+        Returns:
+            ProjectConfig with parsed data, or empty config if file doesn't exist
+
+        Raises:
+            ValueError: If YAML parsing fails
+        """
+        if not self.exists():
+            logger.debug("No .project/project.yaml found at %s", self.repo_path)
+            return ProjectConfig()
+
+        try:
+            # Use ruamel.yaml for round-trip preservation
+            from ruamel.yaml import YAML
+
+            yaml = YAML()
+            yaml.preserve_quotes = True
+
+            with open(self.project_yaml) as f:
+                data = yaml.load(f)
+
+            if data is None:
+                data = {}
+
+            config = self._parse_config(data)
+            config._source_path = self.project_yaml
+
+            # Also check for maintainers.yaml
+            if self.maintainers_yaml.exists():
+                maintainers = self._read_maintainers()
+                if maintainers:
+                    config.maintainers = maintainers
+
+            # Validate and log warnings for missing required fields
+            is_valid, missing = config.is_valid()
+            if not is_valid:
+                logger.warning(
+                    ".project/project.yaml missing required fields: %s",
+                    ", ".join(missing),
+                )
+
+            return config
+
+        except ImportError:
+            logger.error("ruamel.yaml not installed. Install with: pip install ruamel.yaml")
+            raise
+        except Exception as e:
+            logger.error("Failed to parse .project/project.yaml: %s", e)
+            raise ValueError(f"Failed to parse .project/project.yaml: {e}") from e
+
+    def _read_maintainers(self) -> list[str]:
+        """Read maintainers from maintainers.yaml."""
+        try:
+            from ruamel.yaml import YAML
+
+            yaml = YAML()
+            with open(self.maintainers_yaml) as f:
+                data = yaml.load(f)
+
+            if data is None:
+                return []
+
+            # Extract maintainer handles from various formats
+            maintainers = []
+            if isinstance(data, list):
+                for entry in data:
+                    if isinstance(entry, str):
+                        maintainers.append(self._normalize_handle(entry))
+                    elif isinstance(entry, dict) and "handle" in entry:
+                        maintainers.append(self._normalize_handle(entry["handle"]))
+            elif isinstance(data, dict):
+                # Check for nested maintainers list
+                if "maintainers" in data:
+                    return self._extract_maintainers(data["maintainers"])
+                if "project-maintainers" in data:
+                    return self._extract_maintainers(data["project-maintainers"])
+
+            return maintainers
+
+        except Exception as e:
+            logger.warning("Failed to read maintainers.yaml: %s", e)
+            return []
+
+    def _extract_maintainers(self, data: Any) -> list[str]:
+        """Extract maintainer handles from various data structures."""
+        if isinstance(data, list):
+            maintainers = []
+            for entry in data:
+                if isinstance(entry, str):
+                    maintainers.append(self._normalize_handle(entry))
+                elif isinstance(entry, dict):
+                    if "handle" in entry:
+                        maintainers.append(self._normalize_handle(entry["handle"]))
+                    elif "github" in entry:
+                        maintainers.append(self._normalize_handle(entry["github"]))
+            return maintainers
+        return []
+
+    def _normalize_handle(self, handle: str) -> str:
+        """Normalize a maintainer handle (strip @ and whitespace)."""
+        return handle.strip().lstrip("@")
+
+    def _parse_config(self, data: dict[str, Any]) -> ProjectConfig:
+        """Parse raw YAML data into ProjectConfig."""
+        config = ProjectConfig()
+
+        # Known fields
+        known_fields = {
+            "name",
+            "description",
+            "schema_version",
+            "type",
+            "website",
+            "artwork",
+            "repositories",
+            "mailing_lists",
+            "social",
+            "maturity_log",
+            "audits",
+            "security",
+            "governance",
+            "legal",
+            "documentation",
+            "extensions",
+        }
+
+        # Parse known fields
+        config.name = data.get("name", "")
+        config.description = data.get("description", "")
+        config.schema_version = data.get("schema_version", "")
+        config.type = data.get("type", "")
+        config.website = data.get("website", "")
+        config.artwork = data.get("artwork", "")
+        config.repositories = data.get("repositories", [])
+        config.mailing_lists = data.get("mailing_lists", [])
+        config.social = data.get("social", {})
+
+        # Parse maturity log
+        if "maturity_log" in data:
+            config.maturity_log = [
+                self._parse_maturity_entry(entry) for entry in data["maturity_log"]
+            ]
+
+        # Parse audits
+        if "audits" in data:
+            config.audits = [self._parse_audit(entry) for entry in data["audits"]]
+
+        # Parse structured sections
+        if "security" in data:
+            config.security = self._parse_security(data["security"])
+
+        if "governance" in data:
+            config.governance = self._parse_governance(data["governance"])
+
+        if "legal" in data:
+            config.legal = self._parse_legal(data["legal"])
+
+        if "documentation" in data:
+            config.documentation = self._parse_documentation(data["documentation"])
+
+        # Parse extensions
+        if "extensions" in data:
+            config.extensions = self._parse_extensions(data["extensions"])
+
+        # Preserve unknown fields
+        for key, value in data.items():
+            if key not in known_fields:
+                config._extra[key] = value
+                logger.debug("Preserving unknown .project field: %s", key)
+
+        return config
+
+    def _parse_file_reference(self, data: Any) -> FileReference | None:
+        """Parse a file reference from various formats."""
+        if data is None:
+            return None
+        if isinstance(data, str):
+            return FileReference(path=data)
+        if isinstance(data, dict) and "path" in data:
+            return FileReference(path=data["path"])
+        return None
+
+    def _parse_security(self, data: dict[str, Any]) -> SecurityConfig:
+        """Parse security section."""
+        known = {"policy", "threat_model"}
+        config = SecurityConfig(
+            policy=self._parse_file_reference(data.get("policy")),
+            threat_model=self._parse_file_reference(data.get("threat_model")),
+        )
+        for key, value in data.items():
+            if key not in known:
+                config._extra[key] = value
+        return config
+
+    def _parse_governance(self, data: dict[str, Any]) -> GovernanceConfig:
+        """Parse governance section."""
+        known = {"contributing", "codeowners", "governance_doc"}
+        config = GovernanceConfig(
+            contributing=self._parse_file_reference(data.get("contributing")),
+            codeowners=self._parse_file_reference(data.get("codeowners")),
+            governance_doc=self._parse_file_reference(data.get("governance_doc")),
+        )
+        for key, value in data.items():
+            if key not in known:
+                config._extra[key] = value
+        return config
+
+    def _parse_legal(self, data: dict[str, Any]) -> LegalConfig:
+        """Parse legal section."""
+        known = {"license"}
+        config = LegalConfig(
+            license=self._parse_file_reference(data.get("license")),
+        )
+        for key, value in data.items():
+            if key not in known:
+                config._extra[key] = value
+        return config
+
+    def _parse_documentation(self, data: dict[str, Any]) -> DocumentationConfig:
+        """Parse documentation section."""
+        known = {"readme", "support", "architecture", "api"}
+        config = DocumentationConfig(
+            readme=self._parse_file_reference(data.get("readme")),
+            support=self._parse_file_reference(data.get("support")),
+            architecture=self._parse_file_reference(data.get("architecture")),
+            api=self._parse_file_reference(data.get("api")),
+        )
+        for key, value in data.items():
+            if key not in known:
+                config._extra[key] = value
+        return config
+
+    def _parse_extensions(self, data: dict[str, Any]) -> dict[str, ExtensionConfig]:
+        """Parse extensions section."""
+        extensions = {}
+        for name, ext_data in data.items():
+            if isinstance(ext_data, dict):
+                extensions[name] = ExtensionConfig(
+                    metadata=ext_data.get("metadata", {}),
+                    config=ext_data.get("config", {}),
+                )
+        return extensions
+
+    def _parse_maturity_entry(self, data: dict[str, Any]) -> MaturityEntry:
+        """Parse a maturity log entry."""
+        known = {"phase", "date", "issue"}
+        entry = MaturityEntry(
+            phase=data.get("phase"),
+            date=data.get("date"),
+            issue=data.get("issue"),
+        )
+        for key, value in data.items():
+            if key not in known:
+                entry._extra[key] = value
+        return entry
+
+    def _parse_audit(self, data: dict[str, Any]) -> Audit:
+        """Parse an audit entry."""
+        known = {"date", "url", "type"}
+        audit = Audit(
+            date=data.get("date"),
+            url=data.get("url"),
+            type=data.get("type"),
+        )
+        for key, value in data.items():
+            if key not in known:
+                audit._extra[key] = value
+        return audit
+
+
+class DotProjectWriter:
+    """Writer for .project/ directory files.
+
+    Implements comment-preserving YAML writing using ruamel.yaml's
+    round-trip capabilities.
+    """
+
+    def __init__(self, repo_path: str | Path):
+        """Initialize writer with repository path.
+
+        Args:
+            repo_path: Path to the repository root
+        """
+        self.repo_path = Path(repo_path)
+        self.project_dir = self.repo_path / ".project"
+        self.project_yaml = self.project_dir / "project.yaml"
+
+    def update(self, updates: dict[str, Any]) -> None:
+        """Update .project/project.yaml with new values.
+
+        This method preserves existing content and comments while
+        applying the specified updates.
+
+        Args:
+            updates: Dictionary of updates to apply (nested paths supported)
+
+        Example:
+            writer.update({"security": {"policy": {"path": "SECURITY.md"}}})
+        """
+        from ruamel.yaml import YAML
+
+        yaml = YAML()
+        yaml.preserve_quotes = True
+        yaml.indent(mapping=2, sequence=4, offset=2)
+
+        # Read existing content or create new
+        if self.project_yaml.exists():
+            with open(self.project_yaml) as f:
+                data = yaml.load(f)
+            if data is None:
+                data = {}
+        else:
+            # Create directory and new file
+            self.project_dir.mkdir(parents=True, exist_ok=True)
+            data = {"schema_version": DOT_PROJECT_SPEC_VERSION}
+
+        # Apply updates recursively
+        self._deep_update(data, updates)
+
+        # Write back
+        with open(self.project_yaml, "w") as f:
+            yaml.dump(data, f)
+
+        logger.info("Updated .project/project.yaml")
+
+    def _deep_update(self, target: dict, updates: dict) -> None:
+        """Recursively update nested dictionaries."""
+        for key, value in updates.items():
+            if isinstance(value, dict) and isinstance(target.get(key), dict):
+                self._deep_update(target[key], value)
+            else:
+                target[key] = value
+
+    def set_security_policy_path(self, path: str) -> None:
+        """Convenience method to set security.policy.path."""
+        self.update({"security": {"policy": {"path": path}}})
+
+    def set_codeowners_path(self, path: str) -> None:
+        """Convenience method to set governance.codeowners.path."""
+        self.update({"governance": {"codeowners": {"path": path}}})
+
+    def set_contributing_path(self, path: str) -> None:
+        """Convenience method to set governance.contributing.path."""
+        self.update({"governance": {"contributing": {"path": path}}})

--- a/packages/darnit/src/darnit/context/dot_project_mapper.py
+++ b/packages/darnit/src/darnit/context/dot_project_mapper.py
@@ -1,0 +1,216 @@
+"""Map .project/ configuration to sieve context variables.
+
+This module bridges the .project/ reader with the sieve context system,
+mapping structured .project/ data to flat context variables that can be
+used in checks and remediation.
+
+Context variable naming convention:
+- project.* - Direct .project/ fields
+- project.security.* - Security section fields
+- project.governance.* - Governance section fields
+- project.maintainers - Maintainer list
+
+Example:
+    from darnit.context.dot_project_mapper import DotProjectMapper
+
+    mapper = DotProjectMapper("/path/to/repo")
+    context = mapper.get_context()
+
+    # Access mapped values
+    security_policy_path = context.get("project.security.policy_path")
+    maintainers = context.get("project.maintainers", [])
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from darnit.context.dot_project import DotProjectReader, ProjectConfig
+
+logger = logging.getLogger(__name__)
+
+
+class DotProjectMapper:
+    """Maps .project/ configuration to context variables.
+
+    This class reads .project/ files and flattens them into a dictionary
+    of context variables that can be injected into the sieve pipeline.
+    """
+
+    def __init__(self, repo_path: str | Path):
+        """Initialize mapper with repository path.
+
+        Args:
+            repo_path: Path to the repository root
+        """
+        self.repo_path = Path(repo_path)
+        self.reader = DotProjectReader(repo_path)
+        self._config: ProjectConfig | None = None
+        self._context: dict[str, Any] | None = None
+
+    @property
+    def config(self) -> ProjectConfig:
+        """Get the parsed .project/ configuration."""
+        if self._config is None:
+            self._config = self.reader.read()
+        return self._config
+
+    def get_context(self) -> dict[str, Any]:
+        """Get all context variables from .project/ configuration.
+
+        Returns:
+            Dictionary of context variables with dotted keys
+        """
+        if self._context is not None:
+            return self._context
+
+        config = self.config
+        context: dict[str, Any] = {}
+
+        # Core project fields
+        if config.name:
+            context["project.name"] = config.name
+        if config.description:
+            context["project.description"] = config.description
+        if config.schema_version:
+            context["project.schema_version"] = config.schema_version
+        if config.type:
+            context["project.type"] = config.type
+        if config.website:
+            context["project.website"] = config.website
+        if config.repositories:
+            context["project.repositories"] = config.repositories
+
+        # Maintainers (high priority for remediation)
+        if config.maintainers:
+            context["project.maintainers"] = config.maintainers
+
+        # Security section
+        if config.security:
+            self._map_security(config.security, context)
+
+        # Governance section
+        if config.governance:
+            self._map_governance(config.governance, context)
+
+        # Legal section
+        if config.legal:
+            self._map_legal(config.legal, context)
+
+        # Documentation section
+        if config.documentation:
+            self._map_documentation(config.documentation, context)
+
+        # Extensions
+        if config.extensions:
+            self._map_extensions(config.extensions, context)
+
+        # Social links
+        if config.social:
+            for platform, handle in config.social.items():
+                context[f"project.social.{platform}"] = handle
+
+        # Mailing lists
+        if config.mailing_lists:
+            context["project.mailing_lists"] = config.mailing_lists
+
+        self._context = context
+        return context
+
+    def _map_security(self, security: Any, context: dict[str, Any]) -> None:
+        """Map security section to context variables."""
+        if security.policy:
+            context["project.security.policy_path"] = security.policy.path
+        if security.threat_model:
+            context["project.security.threat_model_path"] = security.threat_model.path
+
+        # Include any extra fields
+        for key, value in security._extra.items():
+            context[f"project.security.{key}"] = value
+
+    def _map_governance(self, governance: Any, context: dict[str, Any]) -> None:
+        """Map governance section to context variables."""
+        if governance.contributing:
+            context["project.governance.contributing_path"] = governance.contributing.path
+        if governance.codeowners:
+            context["project.governance.codeowners_path"] = governance.codeowners.path
+        if governance.governance_doc:
+            context["project.governance.governance_doc_path"] = governance.governance_doc.path
+
+        # Include any extra fields
+        for key, value in governance._extra.items():
+            context[f"project.governance.{key}"] = value
+
+    def _map_legal(self, legal: Any, context: dict[str, Any]) -> None:
+        """Map legal section to context variables."""
+        if legal.license:
+            context["project.legal.license_path"] = legal.license.path
+
+        # Include any extra fields
+        for key, value in legal._extra.items():
+            context[f"project.legal.{key}"] = value
+
+    def _map_documentation(self, documentation: Any, context: dict[str, Any]) -> None:
+        """Map documentation section to context variables."""
+        if documentation.readme:
+            context["project.documentation.readme_path"] = documentation.readme.path
+        if documentation.support:
+            context["project.documentation.support_path"] = documentation.support.path
+        if documentation.architecture:
+            context["project.documentation.architecture_path"] = documentation.architecture.path
+        if documentation.api:
+            context["project.documentation.api_path"] = documentation.api.path
+
+        # Include any extra fields
+        for key, value in documentation._extra.items():
+            context[f"project.documentation.{key}"] = value
+
+    def _map_extensions(
+        self, extensions: dict[str, Any], context: dict[str, Any]
+    ) -> None:
+        """Map extensions section to context variables."""
+        for ext_name, ext_config in extensions.items():
+            # Extension metadata
+            if ext_config.metadata:
+                for key, value in ext_config.metadata.items():
+                    context[f"project.extensions.{ext_name}.metadata.{key}"] = value
+
+            # Extension config
+            if ext_config.config:
+                for key, value in ext_config.config.items():
+                    context[f"project.extensions.{ext_name}.config.{key}"] = value
+
+    def has_security_policy(self) -> bool:
+        """Check if a security policy path is defined."""
+        return self.config.security is not None and self.config.security.policy is not None
+
+    def has_codeowners(self) -> bool:
+        """Check if a CODEOWNERS path is defined."""
+        return (
+            self.config.governance is not None
+            and self.config.governance.codeowners is not None
+        )
+
+    def has_maintainers(self) -> bool:
+        """Check if maintainers are defined."""
+        return len(self.config.maintainers) > 0
+
+    def get_security_policy_path(self) -> str | None:
+        """Get the security policy path if defined."""
+        if self.config.security and self.config.security.policy:
+            return self.config.security.policy.path
+        return None
+
+    def get_codeowners_path(self) -> str | None:
+        """Get the CODEOWNERS path if defined."""
+        if self.config.governance and self.config.governance.codeowners:
+            return self.config.governance.codeowners.path
+        return None
+
+    def get_darnit_extension_config(self) -> dict[str, Any]:
+        """Get darnit-specific extension configuration."""
+        if "darnit" in self.config.extensions:
+            return self.config.extensions["darnit"].config
+        return {}

--- a/packages/darnit/src/darnit/context/inject.py
+++ b/packages/darnit/src/darnit/context/inject.py
@@ -1,0 +1,131 @@
+"""Inject .project/ context into the sieve pipeline.
+
+This module provides utilities to inject .project/ context into CheckContext
+objects used by the sieve orchestrator.
+
+Example:
+    from darnit.context.inject import inject_project_context
+    from darnit.sieve.models import CheckContext
+
+    context = CheckContext(
+        owner="org",
+        repo="repo",
+        local_path="/path/to/repo",
+        default_branch="main",
+        control_id="OSPS-AC-01.01",
+    )
+
+    # Inject .project/ context
+    inject_project_context(context)
+
+    # Now context.project_context contains .project/ data
+    policy_path = context.project_context.get("project.security.policy_path")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from darnit.context.dot_project_mapper import DotProjectMapper
+
+if TYPE_CHECKING:
+    from darnit.sieve.models import CheckContext
+
+logger = logging.getLogger(__name__)
+
+
+def inject_project_context(context: CheckContext) -> None:
+    """Inject .project/ context into a CheckContext.
+
+    This function reads .project/project.yaml from the repository path
+    and populates context.project_context with the mapped values.
+
+    Args:
+        context: CheckContext to populate with .project/ data
+    """
+    try:
+        mapper = DotProjectMapper(context.local_path)
+        project_context = mapper.get_context()
+
+        context.project_context = project_context
+
+        if project_context:
+            logger.debug(
+                "Injected %d .project/ context variables for %s",
+                len(project_context),
+                context.control_id,
+            )
+        else:
+            logger.debug("No .project/ context available for %s", context.control_id)
+
+    except Exception as e:
+        logger.warning("Failed to inject .project/ context: %s", e)
+        context.project_context = {}
+
+
+def create_check_context_with_project(
+    owner: str,
+    repo: str,
+    local_path: str,
+    default_branch: str,
+    control_id: str,
+    control_metadata: dict | None = None,
+) -> CheckContext:
+    """Create a CheckContext with .project/ context pre-populated.
+
+    This is a convenience function that creates a CheckContext and
+    automatically injects .project/ context.
+
+    Args:
+        owner: Repository owner
+        repo: Repository name
+        local_path: Path to local repository
+        default_branch: Default branch name
+        control_id: Control ID being checked
+        control_metadata: Optional control metadata
+
+    Returns:
+        CheckContext with project_context populated
+    """
+    from darnit.sieve.models import CheckContext
+
+    context = CheckContext(
+        owner=owner,
+        repo=repo,
+        local_path=local_path,
+        default_branch=default_branch,
+        control_id=control_id,
+        control_metadata=control_metadata or {},
+    )
+
+    inject_project_context(context)
+
+    return context
+
+
+def get_project_value(context: CheckContext, key: str, default: any = None) -> any:
+    """Get a value from .project/ context.
+
+    Args:
+        context: CheckContext with project_context
+        key: Dotted key like "project.security.policy_path"
+        default: Default value if key not found
+
+    Returns:
+        Value from project_context or default
+    """
+    return context.project_context.get(key, default)
+
+
+def has_project_value(context: CheckContext, key: str) -> bool:
+    """Check if a .project/ context value exists.
+
+    Args:
+        context: CheckContext with project_context
+        key: Dotted key like "project.security.policy_path"
+
+    Returns:
+        True if key exists in project_context
+    """
+    return key in context.project_context

--- a/packages/darnit/src/darnit/sieve/models.py
+++ b/packages/darnit/src/darnit/sieve/models.py
@@ -46,6 +46,10 @@ class CheckContext:
     # LocatorConfig for this specific control (from TOML)
     locator_config: Optional["LocatorConfig"] = None
 
+    # .project/ context (from DotProjectMapper)
+    # Contains flattened project metadata like project.security.policy_path, project.maintainers
+    project_context: dict[str, Any] = field(default_factory=dict)
+
 
 @dataclass
 class PassResult:

--- a/tests/darnit/context/test_dot_project.py
+++ b/tests/darnit/context/test_dot_project.py
@@ -1,0 +1,1166 @@
+"""Tests for the CNCF .project/ specification reader and writer.
+
+These tests verify:
+1. Task 1.5.1: Basic .project/ parser functionality
+2. Task 1.5.2: Tolerant parsing of unknown fields (forward compatibility)
+3. Task 1.5.3: Write-back with comment preservation
+4. Task 1.5.4: Integration test with real .project/ file structure
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+class TestDotProjectReader:
+    """Test the DotProjectReader class (Task 1.5.1)."""
+
+    @pytest.mark.unit
+    def test_reader_exists_returns_false_when_no_file(self, temp_dir: Path):
+        """Reader.exists() returns False when no .project/project.yaml exists."""
+        from darnit.context.dot_project import DotProjectReader
+
+        reader = DotProjectReader(temp_dir)
+        assert reader.exists() is False
+
+    @pytest.mark.unit
+    def test_reader_exists_returns_true_when_file_exists(self, temp_dir: Path):
+        """Reader.exists() returns True when .project/project.yaml exists."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("name: test-project\n")
+
+        reader = DotProjectReader(temp_dir)
+        assert reader.exists() is True
+
+    @pytest.mark.unit
+    def test_read_returns_empty_config_when_no_file(self, temp_dir: Path):
+        """Reader.read() returns empty ProjectConfig when file doesn't exist."""
+        from darnit.context.dot_project import DotProjectReader
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.name == ""
+        assert config.repositories == []
+
+    @pytest.mark.unit
+    def test_read_parses_required_fields(self, temp_dir: Path):
+        """Reader correctly parses required name and repositories fields."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+  - https://github.com/org/repo2
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.name == "my-project"
+        assert len(config.repositories) == 2
+        assert "https://github.com/org/repo" in config.repositories
+
+    @pytest.mark.unit
+    def test_read_parses_optional_core_fields(self, temp_dir: Path):
+        """Reader correctly parses optional core fields."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+description: A test project
+schema_version: "1.0.0"
+type: software
+website: https://example.com
+artwork: https://example.com/logo.png
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.description == "A test project"
+        assert config.schema_version == "1.0.0"
+        assert config.type == "software"
+        assert config.website == "https://example.com"
+        assert config.artwork == "https://example.com/logo.png"
+
+    @pytest.mark.unit
+    def test_read_parses_security_section(self, temp_dir: Path):
+        """Reader correctly parses security section with file references."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+security:
+  policy:
+    path: SECURITY.md
+  threat_model:
+    path: docs/threat-model.md
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.security is not None
+        assert config.security.policy is not None
+        assert config.security.policy.path == "SECURITY.md"
+        assert config.security.threat_model is not None
+        assert config.security.threat_model.path == "docs/threat-model.md"
+
+    @pytest.mark.unit
+    def test_read_parses_governance_section(self, temp_dir: Path):
+        """Reader correctly parses governance section."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+governance:
+  contributing:
+    path: CONTRIBUTING.md
+  codeowners:
+    path: .github/CODEOWNERS
+  governance_doc:
+    path: GOVERNANCE.md
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.governance is not None
+        assert config.governance.contributing.path == "CONTRIBUTING.md"
+        assert config.governance.codeowners.path == ".github/CODEOWNERS"
+        assert config.governance.governance_doc.path == "GOVERNANCE.md"
+
+    @pytest.mark.unit
+    def test_read_parses_documentation_section(self, temp_dir: Path):
+        """Reader correctly parses documentation section."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+documentation:
+  readme:
+    path: README.md
+  support:
+    path: SUPPORT.md
+  architecture:
+    path: docs/architecture.md
+  api:
+    path: docs/api.md
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.documentation is not None
+        assert config.documentation.readme.path == "README.md"
+        assert config.documentation.support.path == "SUPPORT.md"
+        assert config.documentation.architecture.path == "docs/architecture.md"
+        assert config.documentation.api.path == "docs/api.md"
+
+    @pytest.mark.unit
+    def test_read_parses_legal_section(self, temp_dir: Path):
+        """Reader correctly parses legal section."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+legal:
+  license:
+    path: LICENSE
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.legal is not None
+        assert config.legal.license.path == "LICENSE"
+
+    @pytest.mark.unit
+    def test_read_parses_extensions_section(self, temp_dir: Path):
+        """Reader correctly parses extensions section."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+extensions:
+  darnit:
+    metadata:
+      version: "1.0.0"
+    config:
+      level: 2
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert "darnit" in config.extensions
+        assert config.extensions["darnit"].metadata["version"] == "1.0.0"
+        assert config.extensions["darnit"].config["level"] == 2
+
+    @pytest.mark.unit
+    def test_read_parses_maturity_log(self, temp_dir: Path):
+        """Reader correctly parses maturity_log list."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+maturity_log:
+  - phase: sandbox
+    date: "2024-01-01"
+    issue: https://github.com/org/toc/issues/123
+  - phase: incubating
+    date: "2024-06-01"
+    issue: https://github.com/org/toc/issues/456
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert len(config.maturity_log) == 2
+        assert config.maturity_log[0].phase == "sandbox"
+        assert config.maturity_log[0].date == "2024-01-01"
+        assert config.maturity_log[1].phase == "incubating"
+
+    @pytest.mark.unit
+    def test_read_parses_audits(self, temp_dir: Path):
+        """Reader correctly parses audits list."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+audits:
+  - date: "2024-03-01"
+    url: https://audits.example.com/report-123
+    type: security
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert len(config.audits) == 1
+        assert config.audits[0].date == "2024-03-01"
+        assert config.audits[0].type == "security"
+
+    @pytest.mark.unit
+    def test_read_parses_social(self, temp_dir: Path):
+        """Reader correctly parses social map."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+social:
+  slack: https://slack.example.com/channel
+  twitter: "@myproject"
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.social["slack"] == "https://slack.example.com/channel"
+        assert config.social["twitter"] == "@myproject"
+
+
+class TestDotProjectReaderMaintainers:
+    """Test maintainers parsing from .project/ files."""
+
+    @pytest.mark.unit
+    def test_read_maintainers_from_maintainers_yaml_list(self, temp_dir: Path):
+        """Reader reads maintainers from maintainers.yaml simple list."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+""")
+        (project_dir / "maintainers.yaml").write_text("""
+- alice
+- "@bob"
+- charlie
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert "alice" in config.maintainers
+        assert "bob" in config.maintainers
+        assert "charlie" in config.maintainers
+
+    @pytest.mark.unit
+    def test_read_maintainers_from_maintainers_yaml_dict_format(self, temp_dir: Path):
+        """Reader reads maintainers from maintainers.yaml with dict entries."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+""")
+        (project_dir / "maintainers.yaml").write_text("""
+- handle: alice
+  name: Alice Smith
+- handle: "@bob"
+  name: Bob Jones
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert "alice" in config.maintainers
+        assert "bob" in config.maintainers
+
+    @pytest.mark.unit
+    def test_read_maintainers_nested_list(self, temp_dir: Path):
+        """Reader reads maintainers from nested maintainers key."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+""")
+        (project_dir / "maintainers.yaml").write_text("""
+maintainers:
+  - alice
+  - bob
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert "alice" in config.maintainers
+        assert "bob" in config.maintainers
+
+    @pytest.mark.unit
+    def test_normalize_handle_strips_at_symbol(self, temp_dir: Path):
+        """Reader normalizes handles by stripping @ prefix."""
+        from darnit.context.dot_project import DotProjectReader
+
+        reader = DotProjectReader(temp_dir)
+        assert reader._normalize_handle("@alice") == "alice"
+        assert reader._normalize_handle("  @bob  ") == "bob"
+        assert reader._normalize_handle("charlie") == "charlie"
+
+
+class TestDotProjectReaderTolerantParsing:
+    """Test tolerant parsing of unknown fields (Task 1.5.2)."""
+
+    @pytest.mark.unit
+    def test_unknown_top_level_fields_preserved(self, temp_dir: Path):
+        """Unknown top-level fields are preserved in _extra."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+future_field: some_value
+another_new_field:
+  nested: data
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        # Known fields parsed normally
+        assert config.name == "my-project"
+
+        # Unknown fields preserved in _extra
+        assert "future_field" in config._extra
+        assert config._extra["future_field"] == "some_value"
+        assert "another_new_field" in config._extra
+        assert config._extra["another_new_field"]["nested"] == "data"
+
+    @pytest.mark.unit
+    def test_unknown_security_fields_preserved(self, temp_dir: Path):
+        """Unknown fields in security section are preserved."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+security:
+  policy:
+    path: SECURITY.md
+  new_security_feature: enabled
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.security is not None
+        assert "new_security_feature" in config.security._extra
+        assert config.security._extra["new_security_feature"] == "enabled"
+
+    @pytest.mark.unit
+    def test_unknown_governance_fields_preserved(self, temp_dir: Path):
+        """Unknown fields in governance section are preserved."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+governance:
+  contributing:
+    path: CONTRIBUTING.md
+  new_governance_field: value
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.governance is not None
+        assert "new_governance_field" in config.governance._extra
+
+    @pytest.mark.unit
+    def test_unknown_maturity_entry_fields_preserved(self, temp_dir: Path):
+        """Unknown fields in maturity_log entries are preserved."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+maturity_log:
+  - phase: sandbox
+    date: "2024-01-01"
+    new_maturity_field: extra_data
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert len(config.maturity_log) == 1
+        assert "new_maturity_field" in config.maturity_log[0]._extra
+
+    @pytest.mark.unit
+    def test_file_reference_string_format(self, temp_dir: Path):
+        """File references can be specified as simple strings."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+security:
+  policy: SECURITY.md
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        # String format should also work
+        assert config.security is not None
+        assert config.security.policy is not None
+        assert config.security.policy.path == "SECURITY.md"
+
+
+class TestDotProjectConfigValidation:
+    """Test ProjectConfig validation."""
+
+    @pytest.mark.unit
+    def test_is_valid_with_required_fields(self, temp_dir: Path):
+        """Config is valid when required fields are present."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        is_valid, missing = config.is_valid()
+        assert is_valid is True
+        assert len(missing) == 0
+
+    @pytest.mark.unit
+    def test_is_valid_missing_name(self, temp_dir: Path):
+        """Config is invalid when name is missing."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+repositories:
+  - https://github.com/org/repo
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        is_valid, missing = config.is_valid()
+        assert is_valid is False
+        assert "name" in missing
+
+    @pytest.mark.unit
+    def test_is_valid_missing_repositories(self, temp_dir: Path):
+        """Config is invalid when repositories is missing."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        is_valid, missing = config.is_valid()
+        assert is_valid is False
+        assert "repositories" in missing
+
+    @pytest.mark.unit
+    def test_is_valid_empty_config(self):
+        """Empty config is invalid."""
+        from darnit.context.dot_project import ProjectConfig
+
+        config = ProjectConfig()
+
+        is_valid, missing = config.is_valid()
+        assert is_valid is False
+        assert "name" in missing
+        assert "repositories" in missing
+
+
+class TestDotProjectWriter:
+    """Test the DotProjectWriter class (Task 1.5.3)."""
+
+    @pytest.mark.unit
+    def test_writer_creates_directory_and_file(self, temp_dir: Path):
+        """Writer creates .project/ directory and project.yaml if not exists."""
+        from darnit.context.dot_project import DotProjectWriter
+
+        writer = DotProjectWriter(temp_dir)
+        writer.update({"name": "new-project"})
+
+        project_yaml = temp_dir / ".project" / "project.yaml"
+        assert project_yaml.exists()
+
+        content = project_yaml.read_text()
+        assert "new-project" in content
+
+    @pytest.mark.unit
+    def test_writer_updates_existing_file(self, temp_dir: Path):
+        """Writer updates existing .project/project.yaml."""
+        from darnit.context.dot_project import DotProjectWriter
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: old-name
+repositories:
+  - https://github.com/org/repo
+""")
+
+        writer = DotProjectWriter(temp_dir)
+        writer.update({"name": "new-name"})
+
+        content = (project_dir / "project.yaml").read_text()
+        assert "new-name" in content
+        assert "old-name" not in content
+        # repositories should still be present
+        assert "https://github.com/org/repo" in content
+
+    @pytest.mark.unit
+    def test_writer_deep_updates_nested_fields(self, temp_dir: Path):
+        """Writer performs deep updates on nested fields."""
+        from darnit.context.dot_project import DotProjectWriter
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+security:
+  threat_model:
+    path: existing/threat-model.md
+""")
+
+        writer = DotProjectWriter(temp_dir)
+        writer.update({"security": {"policy": {"path": "SECURITY.md"}}})
+
+        content = (project_dir / "project.yaml").read_text()
+        # New policy should be added
+        assert "SECURITY.md" in content
+        # Existing threat_model should be preserved
+        assert "existing/threat-model.md" in content
+
+    @pytest.mark.unit
+    def test_writer_preserves_comments(self, temp_dir: Path):
+        """Writer preserves YAML comments during updates."""
+        from darnit.context.dot_project import DotProjectWriter
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""# Project configuration
+# Generated by darnit
+
+name: my-project  # The project name
+repositories:
+  # Main repository
+  - https://github.com/org/repo
+""")
+
+        writer = DotProjectWriter(temp_dir)
+        writer.update({"description": "A test project"})
+
+        content = (project_dir / "project.yaml").read_text()
+        # Comments should be preserved
+        assert "# Project configuration" in content
+        assert "# Generated by darnit" in content
+        assert "# The project name" in content
+        assert "# Main repository" in content
+        # New field should be added
+        assert "A test project" in content
+
+    @pytest.mark.unit
+    def test_set_security_policy_path(self, temp_dir: Path):
+        """Convenience method sets security.policy.path."""
+        from darnit.context.dot_project import DotProjectWriter
+
+        writer = DotProjectWriter(temp_dir)
+        writer.set_security_policy_path("SECURITY.md")
+
+        content = (temp_dir / ".project" / "project.yaml").read_text()
+        assert "security:" in content
+        assert "policy:" in content
+        assert "SECURITY.md" in content
+
+    @pytest.mark.unit
+    def test_set_codeowners_path(self, temp_dir: Path):
+        """Convenience method sets governance.codeowners.path."""
+        from darnit.context.dot_project import DotProjectWriter
+
+        writer = DotProjectWriter(temp_dir)
+        writer.set_codeowners_path(".github/CODEOWNERS")
+
+        content = (temp_dir / ".project" / "project.yaml").read_text()
+        assert "governance:" in content
+        assert "codeowners:" in content
+        assert ".github/CODEOWNERS" in content
+
+    @pytest.mark.unit
+    def test_set_contributing_path(self, temp_dir: Path):
+        """Convenience method sets governance.contributing.path."""
+        from darnit.context.dot_project import DotProjectWriter
+
+        writer = DotProjectWriter(temp_dir)
+        writer.set_contributing_path("CONTRIBUTING.md")
+
+        content = (temp_dir / ".project" / "project.yaml").read_text()
+        assert "governance:" in content
+        assert "contributing:" in content
+        assert "CONTRIBUTING.md" in content
+
+    @pytest.mark.unit
+    def test_writer_sets_schema_version_on_new_file(self, temp_dir: Path):
+        """Writer sets schema_version when creating new file."""
+        from darnit.context.dot_project import DOT_PROJECT_SPEC_VERSION, DotProjectWriter
+
+        writer = DotProjectWriter(temp_dir)
+        writer.update({"name": "new-project"})
+
+        content = (temp_dir / ".project" / "project.yaml").read_text()
+        assert "schema_version:" in content
+        assert DOT_PROJECT_SPEC_VERSION in content
+
+
+class TestDotProjectMapper:
+    """Test the DotProjectMapper for context injection."""
+
+    @pytest.mark.unit
+    def test_mapper_returns_empty_context_when_no_file(self, temp_dir: Path):
+        """Mapper returns empty dict when no .project/ exists."""
+        from darnit.context.dot_project_mapper import DotProjectMapper
+
+        mapper = DotProjectMapper(temp_dir)
+        context = mapper.get_context()
+
+        assert context == {}
+
+    @pytest.mark.unit
+    def test_mapper_maps_security_section(self, temp_dir: Path):
+        """Mapper correctly maps security section to context variables."""
+        from darnit.context.dot_project_mapper import DotProjectMapper
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+security:
+  policy:
+    path: SECURITY.md
+  threat_model:
+    path: docs/threat-model.md
+""")
+
+        mapper = DotProjectMapper(temp_dir)
+        context = mapper.get_context()
+
+        assert context.get("project.security.policy_path") == "SECURITY.md"
+        assert context.get("project.security.threat_model_path") == "docs/threat-model.md"
+
+    @pytest.mark.unit
+    def test_mapper_maps_governance_section(self, temp_dir: Path):
+        """Mapper correctly maps governance section to context variables."""
+        from darnit.context.dot_project_mapper import DotProjectMapper
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+governance:
+  contributing:
+    path: CONTRIBUTING.md
+  codeowners:
+    path: .github/CODEOWNERS
+""")
+
+        mapper = DotProjectMapper(temp_dir)
+        context = mapper.get_context()
+
+        assert context.get("project.governance.contributing_path") == "CONTRIBUTING.md"
+        assert context.get("project.governance.codeowners_path") == ".github/CODEOWNERS"
+
+    @pytest.mark.unit
+    def test_mapper_maps_maintainers(self, temp_dir: Path):
+        """Mapper correctly maps maintainers list."""
+        from darnit.context.dot_project_mapper import DotProjectMapper
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+""")
+        (project_dir / "maintainers.yaml").write_text("""
+- alice
+- bob
+""")
+
+        mapper = DotProjectMapper(temp_dir)
+        context = mapper.get_context()
+
+        assert "alice" in context.get("project.maintainers", [])
+        assert "bob" in context.get("project.maintainers", [])
+
+
+class TestDotProjectInjection:
+    """Test injection of .project/ context into CheckContext."""
+
+    @pytest.mark.unit
+    def test_inject_project_context(self, temp_dir: Path):
+        """inject_project_context populates context.project_context."""
+        from darnit.context.inject import inject_project_context
+        from darnit.sieve.models import CheckContext
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+security:
+  policy:
+    path: SECURITY.md
+""")
+
+        context = CheckContext(
+            owner="org",
+            repo="repo",
+            local_path=str(temp_dir),
+            default_branch="main",
+            control_id="TEST-01",
+        )
+
+        inject_project_context(context)
+
+        assert context.project_context.get("project.security.policy_path") == "SECURITY.md"
+
+    @pytest.mark.unit
+    def test_create_check_context_with_project(self, temp_dir: Path):
+        """create_check_context_with_project creates context with .project/ data."""
+        from darnit.context.inject import create_check_context_with_project
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+security:
+  policy:
+    path: SECURITY.md
+""")
+
+        context = create_check_context_with_project(
+            owner="org",
+            repo="repo",
+            local_path=str(temp_dir),
+            default_branch="main",
+            control_id="TEST-01",
+        )
+
+        assert context.project_context.get("project.security.policy_path") == "SECURITY.md"
+
+    @pytest.mark.unit
+    def test_get_project_value(self, temp_dir: Path):
+        """get_project_value retrieves values from project_context."""
+        from darnit.context.inject import get_project_value, inject_project_context
+        from darnit.sieve.models import CheckContext
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+security:
+  policy:
+    path: SECURITY.md
+""")
+
+        context = CheckContext(
+            owner="org",
+            repo="repo",
+            local_path=str(temp_dir),
+            default_branch="main",
+            control_id="TEST-01",
+        )
+        inject_project_context(context)
+
+        assert get_project_value(context, "project.security.policy_path") == "SECURITY.md"
+        assert get_project_value(context, "nonexistent", "default") == "default"
+
+    @pytest.mark.unit
+    def test_has_project_value(self, temp_dir: Path):
+        """has_project_value checks if key exists in project_context."""
+        from darnit.context.inject import has_project_value, inject_project_context
+        from darnit.sieve.models import CheckContext
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+        (project_dir / "project.yaml").write_text("""
+name: my-project
+repositories:
+  - https://github.com/org/repo
+security:
+  policy:
+    path: SECURITY.md
+""")
+
+        context = CheckContext(
+            owner="org",
+            repo="repo",
+            local_path=str(temp_dir),
+            default_branch="main",
+            control_id="TEST-01",
+        )
+        inject_project_context(context)
+
+        assert has_project_value(context, "project.security.policy_path") is True
+        assert has_project_value(context, "nonexistent") is False
+
+
+class TestDotProjectIntegration:
+    """Integration tests for .project/ functionality (Task 1.5.4)."""
+
+    @pytest.mark.integration
+    def test_full_read_write_cycle(self, temp_dir: Path):
+        """Test complete read-write-read cycle with .project/ file."""
+        from darnit.context.dot_project import DotProjectReader, DotProjectWriter
+
+        # Initial write
+        writer = DotProjectWriter(temp_dir)
+        writer.update({
+            "name": "integration-test",
+            "repositories": ["https://github.com/org/repo"],
+        })
+        writer.set_security_policy_path("SECURITY.md")
+        writer.set_codeowners_path(".github/CODEOWNERS")
+
+        # Read back
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        assert config.name == "integration-test"
+        assert len(config.repositories) == 1
+        assert config.security.policy.path == "SECURITY.md"
+        assert config.governance.codeowners.path == ".github/CODEOWNERS"
+
+        # Update
+        writer.update({
+            "description": "Added description",
+            "security": {"threat_model": {"path": "docs/threat-model.md"}},
+        })
+
+        # Read again
+        config = reader.read()
+
+        assert config.description == "Added description"
+        # Original security.policy should still be there
+        assert config.security.policy.path == "SECURITY.md"
+        # New threat_model should be added
+        assert config.security.threat_model.path == "docs/threat-model.md"
+
+    @pytest.mark.integration
+    def test_real_cncf_project_structure(self, temp_dir: Path):
+        """Test parsing a realistic CNCF .project/ structure."""
+        from darnit.context.dot_project import DotProjectReader
+
+        project_dir = temp_dir / ".project"
+        project_dir.mkdir()
+
+        # Create a realistic CNCF project.yaml
+        (project_dir / "project.yaml").write_text("""
+# CNCF Project Configuration
+# See: https://github.com/cncf/automation/tree/main/utilities/dot-project
+
+name: my-cncf-project
+description: A sample CNCF project demonstrating .project/ structure
+schema_version: "1.0.0"
+type: software
+
+repositories:
+  - https://github.com/cncf/my-project
+  - https://github.com/cncf/my-project-website
+
+website: https://my-project.io
+artwork: https://my-project.io/images/logo.svg
+
+mailing_lists:
+  - my-project@lists.cncf.io
+  - my-project-security@lists.cncf.io
+
+social:
+  slack: https://cloud-native.slack.com/channels/my-project
+  twitter: "@myproject"
+  linkedin: https://linkedin.com/company/myproject
+
+security:
+  policy:
+    path: SECURITY.md
+  threat_model:
+    path: docs/security/threat-model.md
+
+governance:
+  contributing:
+    path: CONTRIBUTING.md
+  codeowners:
+    path: .github/CODEOWNERS
+  governance_doc:
+    path: GOVERNANCE.md
+
+legal:
+  license:
+    path: LICENSE
+
+documentation:
+  readme:
+    path: README.md
+  support:
+    path: SUPPORT.md
+  architecture:
+    path: docs/architecture.md
+  api:
+    path: docs/api-reference.md
+
+maturity_log:
+  - phase: sandbox
+    date: "2023-06-01"
+    issue: https://github.com/cncf/toc/issues/1234
+  - phase: incubating
+    date: "2024-01-15"
+    issue: https://github.com/cncf/toc/issues/1567
+
+audits:
+  - date: "2024-02-01"
+    url: https://example.com/audits/my-project-2024
+    type: security
+
+extensions:
+  darnit:
+    metadata:
+      version: "1.0.0"
+    config:
+      target_level: 2
+      skip_controls:
+        - OSPS-AC-01.02
+""")
+
+        # Create maintainers.yaml
+        (project_dir / "maintainers.yaml").write_text("""
+# Project Maintainers
+project-maintainers:
+  - handle: alice
+    name: Alice Smith
+    company: CNCF
+  - handle: bob
+    name: Bob Jones
+    company: CNCF
+""")
+
+        reader = DotProjectReader(temp_dir)
+        config = reader.read()
+
+        # Verify all sections parsed correctly
+        assert config.name == "my-cncf-project"
+        assert config.schema_version == "1.0.0"
+        assert len(config.repositories) == 2
+        assert config.website == "https://my-project.io"
+
+        # Security
+        assert config.security.policy.path == "SECURITY.md"
+        assert config.security.threat_model.path == "docs/security/threat-model.md"
+
+        # Governance
+        assert config.governance.contributing.path == "CONTRIBUTING.md"
+        assert config.governance.codeowners.path == ".github/CODEOWNERS"
+
+        # Documentation
+        assert config.documentation.readme.path == "README.md"
+        assert config.documentation.architecture.path == "docs/architecture.md"
+
+        # Maturity log
+        assert len(config.maturity_log) == 2
+        assert config.maturity_log[0].phase == "sandbox"
+        assert config.maturity_log[1].phase == "incubating"
+
+        # Audits
+        assert len(config.audits) == 1
+        assert config.audits[0].type == "security"
+
+        # Extensions
+        assert "darnit" in config.extensions
+        assert config.extensions["darnit"].config["target_level"] == 2
+
+        # Maintainers
+        assert "alice" in config.maintainers
+        assert "bob" in config.maintainers
+
+        # Validation
+        is_valid, missing = config.is_valid()
+        assert is_valid is True
+
+    @pytest.mark.integration
+    def test_context_injection_end_to_end(self, temp_dir: Path):
+        """Test complete flow from .project/ file to CheckContext."""
+        from darnit.context.dot_project import DotProjectWriter
+        from darnit.context.inject import (
+            create_check_context_with_project,
+            get_project_value,
+            has_project_value,
+        )
+
+        # Create .project/ via writer
+        writer = DotProjectWriter(temp_dir)
+        writer.update({
+            "name": "e2e-test",
+            "repositories": ["https://github.com/org/repo"],
+            "security": {
+                "policy": {"path": "SECURITY.md"},
+            },
+            "governance": {
+                "codeowners": {"path": ".github/CODEOWNERS"},
+                "contributing": {"path": "CONTRIBUTING.md"},
+            },
+        })
+
+        # Create maintainers.yaml
+        project_dir = temp_dir / ".project"
+        (project_dir / "maintainers.yaml").write_text("""
+- alice
+- bob
+""")
+
+        # Create CheckContext with injected .project/ data
+        context = create_check_context_with_project(
+            owner="org",
+            repo="repo",
+            local_path=str(temp_dir),
+            default_branch="main",
+            control_id="TEST-01",
+        )
+
+        # Verify all context variables
+        assert has_project_value(context, "project.security.policy_path")
+        assert get_project_value(context, "project.security.policy_path") == "SECURITY.md"
+
+        assert has_project_value(context, "project.governance.codeowners_path")
+        assert get_project_value(context, "project.governance.codeowners_path") == ".github/CODEOWNERS"
+
+        assert has_project_value(context, "project.maintainers")
+        maintainers = get_project_value(context, "project.maintainers")
+        assert "alice" in maintainers
+        assert "bob" in maintainers

--- a/uv.lock
+++ b/uv.lock
@@ -383,6 +383,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pydantic", extra = ["email"] },
     { name = "pyyaml" },
+    { name = "ruamel-yaml" },
 ]
 
 [package.optional-dependencies]
@@ -399,6 +400,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18.0" },
     { name = "sigstore", marker = "extra == 'attestation'", specifier = ">=3.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "tomllib-stubs", marker = "python_full_version < '3.11'", specifier = ">=0.1.0" },
@@ -1404,6 +1406,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implement Phase 1 of the toml-schema-v2 change, adding support for reading and writing CNCF `.project/project.yaml` files with forward compatibility.

### Core features

- **DotProjectReader**: Parse `.project/project.yaml` with tolerant parsing that preserves unknown fields for forward compatibility with spec evolution
- **DotProjectWriter**: Update `.project/` files while preserving YAML comments using ruamel.yaml round-trip capabilities  
- **DotProjectMapper**: Map `.project/` sections to flat context variables (`project.security.*`, `project.governance.*`, `project.maintainers`)
- **Context injection**: Populate `CheckContext.project_context` from `.project/` data
- **ProjectUpdateRemediationConfig**: Schema for remediation write-back to `.project/`

### Phase 1 Progress

| Section | Tasks | Status |
|---------|-------|--------|
| 1.1 Core Parser | 5/5 | ✅ |
| 1.2 Context Mapping | 5/5 | ✅ |
| 1.3 Write-Back | 5/5 | ✅ |
| 1.4 Upstream Tracking | 0/4 | ⬜ (deferred) |
| 1.5 Testing | 4/4 | ✅ |

**Total: 18/22 Phase 1 tasks complete**

## Test plan

- [x] 45 new tests in `tests/darnit/context/test_dot_project.py`
- [x] Unit tests for parser, tolerant parsing, write-back
- [x] Integration tests with realistic CNCF project structure
- [x] Full test suite passes (606 tests)
- [x] Lint checks pass

## Related

- Part of: toml-schema-v2 change
- Spec: https://github.com/cncf/automation/tree/main/utilities/dot-project
- Targeted spec version: 1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)