### PR TITLE
feat: Add prefer_upstream option for fork audits

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/tools.py
+++ b/packages/darnit-baseline/src/darnit_baseline/tools.py
@@ -24,6 +24,7 @@ def audit_openssf_baseline(
     sign_attestation: bool = True,
     staging: bool = False,
     use_sieve: bool = True,
+    prefer_upstream: bool = True,
 ) -> str:
     """
     Run a comprehensive OpenSSF Baseline audit on a repository.
@@ -46,6 +47,8 @@ def audit_openssf_baseline(
         sign_attestation: Sign attestation with Sigstore. Default: True
         staging: Use Sigstore staging environment. Default: False
         use_sieve: Use progressive verification pipeline. Default: True
+        prefer_upstream: If True, prefer 'upstream' git remote when auto-detecting owner/repo.
+                         Useful for auditing forks against their upstream repository. Default: True
 
     Returns:
         Formatted audit report with compliance status and remediation instructions
@@ -64,7 +67,8 @@ def audit_openssf_baseline(
         return f"❌ Error: Repository path not found: {repo_path}"
 
     # Auto-detect owner/repo from git
-    detected_owner, detected_repo = _detect_owner_repo(repo_path)
+    # When prefer_upstream=True (default), check 'upstream' remote first for forks
+    detected_owner, detected_repo = _detect_owner_repo(repo_path, prefer_upstream=prefer_upstream)
     owner = owner or detected_owner
     repo = repo or detected_repo
 
@@ -878,26 +882,49 @@ def create_test_repository(
 # =============================================================================
 
 
-def _detect_owner_repo(repo_path: Path) -> tuple[str, str]:
-    """Detect owner/repo from git remote."""
+def _detect_owner_repo(repo_path: Path, prefer_upstream: bool = False) -> tuple[str, str]:
+    """Detect owner/repo from git remote.
+
+    Args:
+        repo_path: Path to the repository
+        prefer_upstream: If True, check for 'upstream' remote first (useful for forks)
+
+    Returns:
+        Tuple of (owner, repo) detected from git remotes
+    """
     import subprocess
 
-    try:
-        result = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            cwd=repo_path,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            url = result.stdout.strip()
-            if "github.com" in url:
-                parts = url.replace(".git", "").split("/")
-                if len(parts) >= 2:
-                    return parts[-2], parts[-1]
-    except (subprocess.SubprocessError, FileNotFoundError):
-        pass
+    def get_remote_url(remote_name: str) -> str | None:
+        try:
+            result = subprocess.run(
+                ["git", "remote", "get-url", remote_name],
+                capture_output=True,
+                text=True,
+                cwd=repo_path,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except (subprocess.SubprocessError, FileNotFoundError):
+            pass
+        return None
+
+    def parse_github_url(url: str) -> tuple[str, str] | None:
+        if "github.com" in url:
+            parts = url.replace(".git", "").split("/")
+            if len(parts) >= 2:
+                return parts[-2], parts[-1]
+        return None
+
+    # Order of remotes to check
+    remotes = ["upstream", "origin"] if prefer_upstream else ["origin", "upstream"]
+
+    for remote in remotes:
+        url = get_remote_url(remote)
+        if url:
+            parsed = parse_github_url(url)
+            if parsed:
+                return parsed
 
     return "unknown", repo_path.name
 


### PR DESCRIPTION
## Summary

- Add `prefer_upstream` parameter to `audit_openssf_baseline()` (default: `True`)
- Enhanced `_detect_owner_repo()` to check both `upstream` and `origin` git remotes
- When `prefer_upstream=True`, checks upstream remote first (useful for forks)

## Problem

When auditing a forked repository, the audit was checking the fork's GitHub releases (often 0 releases) instead of the upstream repository's releases. This caused controls like OSPS-BR-04.01 (release notes) to fail incorrectly.

## Solution

The audit now defaults to checking the `upstream` git remote first when auto-detecting owner/repo. This ensures controls are evaluated against the upstream project's releases, branch protection, etc.

**Example:**
```
# Before: mlieberman85/kusari-cli (fork with 0 releases) → FAIL
# After:  kusaridev/kusari-cli (upstream with releases) → PASS
```

## Test plan

- [x] Unit tested `_detect_owner_repo()` with `prefer_upstream=True/False`
- [x] Verified OSPS-BR-04.01 passes when auditing kusari-cli fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)