### PR TITLE
feat: .project/ integration and context collection

### DIFF
--- a/openspec/changes/toml-schema-v2/tasks.md
+++ b/openspec/changes/toml-schema-v2/tasks.md
@@ -56,36 +56,36 @@ This ensures CI will pass and prevents broken commits from being pushed.
 
 ### 2.1 Schema Definition
 
-- [ ] 2.1.1 Add `[context]` section to framework_schema.py
-- [ ] 2.1.2 Define ContextVariable Pydantic model with all fields
-- [ ] 2.1.3 Support types: string, list[string], boolean, email
-- [ ] 2.1.4 Add validation for pattern constraints
+- [x] 2.1.1 Add `[context]` section to framework_schema.py
+- [x] 2.1.2 Define ContextVariable Pydantic model with all fields
+- [x] 2.1.3 Support types: string, list[string], boolean, email
+- [x] 2.1.4 Add validation for pattern constraints
 
 ### 2.2 Resolution Logic
 
-- [ ] 2.2.1 Create `packages/darnit/src/darnit/context/collection.py`
-- [ ] 2.2.2 Implement resolution priority: .project/ → file source → prompt
-- [ ] 2.2.3 Implement file parsers: markdown_list, yaml_path, json_path
-- [ ] 2.2.4 Implement user confirmation flow for auto-detected values
+- [x] 2.2.1 Create `packages/darnit/src/darnit/context/collection.py`
+- [x] 2.2.2 Implement resolution priority: .project/ → file source → prompt
+- [x] 2.2.3 Implement file parsers: markdown_list, yaml_path, json_path
+- [x] 2.2.4 Implement user confirmation flow for auto-detected values
 
 ### 2.3 Prompt UI
 
-- [ ] 2.3.1 Add context prompt capability to MCP tools
-- [ ] 2.3.2 Implement multi-line input for list types
-- [ ] 2.3.3 Implement validation feedback (re-prompt on invalid input)
-- [ ] 2.3.4 Add --non-interactive flag to skip prompts
+- [x] 2.3.1 Add context prompt capability to MCP tools
+- [x] 2.3.2 Implement multi-line input for list types
+- [x] 2.3.3 Implement validation feedback (re-prompt on invalid input)
+- [x] 2.3.4 Add --non-interactive flag to skip prompts (N/A for MCP tools - inherently interactive)
 
 ### 2.4 Persistence
 
-- [ ] 2.4.1 Implement save-to-.project/ for collected context
-- [ ] 2.4.2 Implement save-to-.baseline.toml for darnit-specific context
-- [ ] 2.4.3 Add user prompt "Save this value for future runs?"
+- [x] 2.4.1 Implement save-to-.project/ for collected context
+- [x] 2.4.2 Implement save-to-.baseline.toml for darnit-specific context
+- [x] 2.4.3 Add user prompt "Save this value for future runs?" (handled by confirm_project_context flow)
 
 ### 2.5 Testing
 
-- [ ] 2.5.1 Add unit tests for context resolution priority
-- [ ] 2.5.2 Add unit tests for file parsers
-- [ ] 2.5.3 Add integration test for context flow into remediation
+- [x] 2.5.1 Add unit tests for context resolution priority
+- [x] 2.5.2 Add unit tests for file parsers
+- [x] 2.5.3 Add integration test for context flow into remediation
 
 ## 3. Phase 3: CEL Expressions
 

--- a/packages/darnit/src/darnit/context/__init__.py
+++ b/packages/darnit/src/darnit/context/__init__.py
@@ -24,6 +24,15 @@ Example:
         confidence = result.confidence  # e.g., 0.75 for 75%
 """
 
+from .collection import (
+    coerce_context_value,
+    parse_codeowners,
+    parse_json_path,
+    parse_markdown_list,
+    parse_yaml_path,
+    resolve_context_value,
+    validate_context_value,
+)
 from .confidence import (
     SIGNAL_WEIGHTS,
     CombinedConfidence,
@@ -71,4 +80,12 @@ __all__ = [
     "create_check_context_with_project",
     "get_project_value",
     "has_project_value",
+    # Context collection
+    "parse_markdown_list",
+    "parse_yaml_path",
+    "parse_json_path",
+    "parse_codeowners",
+    "resolve_context_value",
+    "validate_context_value",
+    "coerce_context_value",
 ]

--- a/packages/darnit/src/darnit/context/collection.py
+++ b/packages/darnit/src/darnit/context/collection.py
@@ -1,0 +1,479 @@
+"""Context collection with resolution priority and file parsing.
+
+This module implements the context resolution priority:
+1. .project/project.yaml - Primary source of truth
+2. File sources (MAINTAINERS.md, etc.) - Parse from existing files
+3. User prompt - Fall back to asking the user
+
+It also implements file parsers for extracting values from various formats:
+- markdown_list: Extract lists from markdown files
+- yaml_path: Extract values from YAML files using dot-notation paths
+- json_path: Extract values from JSON files using JSONPath expressions
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from darnit.core.logging import get_logger
+
+logger = get_logger("context.collection")
+
+
+# =============================================================================
+# File Parsers
+# =============================================================================
+
+
+def parse_markdown_list(file_path: Path, pattern: str | None = None) -> list[str]:
+    """Parse a list from a markdown file.
+
+    Extracts items from:
+    - Bullet lists (- item, * item)
+    - Numbered lists (1. item)
+    - @mentions anywhere in the file
+    - Code blocks (for CODEOWNERS format)
+
+    Args:
+        file_path: Path to the markdown file
+        pattern: Optional regex pattern to filter/extract items
+
+    Returns:
+        List of extracted values
+    """
+    if not file_path.exists():
+        return []
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        logger.debug(f"Could not read {file_path}: {e}")
+        return []
+
+    items: list[str] = []
+
+    # Extract @mentions (GitHub usernames)
+    mentions = re.findall(r"@([\w-]+)", content)
+    if mentions:
+        items.extend([f"@{m}" for m in mentions])
+
+    # Extract bullet list items
+    bullet_items = re.findall(r"^[\s]*[-*]\s+(.+)$", content, re.MULTILINE)
+    items.extend(bullet_items)
+
+    # Extract numbered list items
+    numbered_items = re.findall(r"^[\s]*\d+\.\s+(.+)$", content, re.MULTILINE)
+    items.extend(numbered_items)
+
+    # Apply pattern filter if provided
+    if pattern:
+        try:
+            regex = re.compile(pattern)
+            items = [item for item in items if regex.search(item)]
+        except re.error:
+            logger.warning(f"Invalid pattern: {pattern}")
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique_items: list[str] = []
+    for item in items:
+        item = item.strip()
+        if item and item not in seen:
+            seen.add(item)
+            unique_items.append(item)
+
+    return unique_items
+
+
+def parse_yaml_path(file_path: Path, path: str) -> Any:
+    """Extract a value from a YAML file using dot-notation path.
+
+    Args:
+        file_path: Path to the YAML file
+        path: Dot-notation path (e.g., "security.policy.path")
+
+    Returns:
+        The extracted value, or None if not found
+    """
+    if not file_path.exists():
+        return None
+
+    try:
+        import yaml
+
+        content = file_path.read_text(encoding="utf-8")
+        data = yaml.safe_load(content)
+
+        if not isinstance(data, dict):
+            return None
+
+        # Navigate the path
+        current = data
+        for key in path.split("."):
+            if isinstance(current, dict) and key in current:
+                current = current[key]
+            else:
+                return None
+
+        return current
+    except Exception as e:
+        logger.debug(f"Could not parse YAML {file_path}: {e}")
+        return None
+
+
+def parse_json_path(file_path: Path, path: str) -> Any:
+    """Extract a value from a JSON file using JSONPath-like expression.
+
+    Supports simple dot-notation paths and basic JSONPath:
+    - "$.field.subfield" - JSONPath style
+    - "field.subfield" - Simple dot notation
+
+    Args:
+        file_path: Path to the JSON file
+        path: JSONPath expression or dot-notation path
+
+    Returns:
+        The extracted value, or None if not found
+    """
+    if not file_path.exists():
+        return None
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+        data = json.loads(content)
+
+        # Normalize path (remove leading $.)
+        if path.startswith("$."):
+            path = path[2:]
+
+        if not isinstance(data, dict):
+            return None
+
+        # Navigate the path
+        current = data
+        for key in path.split("."):
+            # Handle array indexing [0]
+            if "[" in key:
+                base_key, idx_part = key.split("[", 1)
+                idx = int(idx_part.rstrip("]"))
+                if base_key:
+                    current = current.get(base_key)
+                if isinstance(current, list) and 0 <= idx < len(current):
+                    current = current[idx]
+                else:
+                    return None
+            elif isinstance(current, dict) and key in current:
+                current = current[key]
+            else:
+                return None
+
+        return current
+    except Exception as e:
+        logger.debug(f"Could not parse JSON {file_path}: {e}")
+        return None
+
+
+def parse_codeowners(file_path: Path) -> list[str]:
+    """Parse GitHub CODEOWNERS file to extract maintainers.
+
+    Args:
+        file_path: Path to CODEOWNERS file
+
+    Returns:
+        List of @mentions (users and teams)
+    """
+    if not file_path.exists():
+        return []
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        logger.debug(f"Could not read {file_path}: {e}")
+        return []
+
+    maintainers: set[str] = set()
+
+    for line in content.splitlines():
+        # Skip comments and empty lines
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        # Extract @mentions from the line
+        mentions = re.findall(r"@([\w/-]+)", line)
+        for mention in mentions:
+            # Handle org/team format
+            if "/" in mention:
+                maintainers.add(f"@{mention}")
+            else:
+                maintainers.add(f"@{mention}")
+
+    return list(maintainers)
+
+
+# =============================================================================
+# Resolution Priority
+# =============================================================================
+
+
+def resolve_context_value(
+    key: str,
+    definition: dict[str, Any],
+    repo_path: Path,
+    project_context: dict[str, Any] | None = None,
+) -> tuple[Any, str | None]:
+    """Resolve a context value following the priority chain.
+
+    Resolution priority:
+    1. .project/project.yaml (via project_context param)
+    2. File source (definition.source with definition.parser)
+    3. Auto-detection (if definition.auto_detect is true)
+    4. None (requires prompt)
+
+    Args:
+        key: The context key name
+        definition: The context definition from TOML
+        repo_path: Path to the repository
+        project_context: Pre-loaded .project/ context (optional)
+
+    Returns:
+        Tuple of (value, resolution_method)
+        - resolution_method is one of: "project", "file", "auto", None (needs prompt)
+    """
+    # 1. Check .project/project.yaml
+    if project_context:
+        store_path = definition.get("store_as")
+        if store_path:
+            value = _get_nested_value(project_context, store_path)
+            if value is not None:
+                return value, "project"
+
+    # 2. Check file source
+    source = definition.get("source")
+    parser = definition.get("parser", "auto")
+    if source:
+        source_path = repo_path / source
+        if source_path.exists():
+            value = _parse_file_source(source_path, parser, definition)
+            if value is not None:
+                return value, "file"
+
+    # 3. Check hint_sources (common file locations)
+    hint_sources = definition.get("hint_sources", [])
+    for hint_source in hint_sources:
+        hint_path = repo_path / hint_source
+        if hint_path.exists():
+            # Infer parser from filename
+            parser = _infer_parser(hint_path)
+            value = _parse_file_source(hint_path, parser, definition)
+            if value is not None:
+                return value, f"file:{hint_source}"
+
+    # 4. Auto-detection not yet implemented in this layer
+    # (handled by context_storage._auto_detect_context)
+
+    return None, None
+
+
+def _get_nested_value(data: dict[str, Any], path: str) -> Any:
+    """Get a nested value using dot notation."""
+    current = data
+    for key in path.split("."):
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        else:
+            return None
+    return current
+
+
+def _parse_file_source(
+    file_path: Path,
+    parser: str,
+    definition: dict[str, Any],
+) -> Any:
+    """Parse a file source using the specified parser."""
+    if parser == "markdown_list":
+        pattern = definition.get("pattern")
+        return parse_markdown_list(file_path, pattern) or None
+
+    elif parser == "yaml_path":
+        path = definition.get("extract_path", "")
+        return parse_yaml_path(file_path, path)
+
+    elif parser == "json_path":
+        path = definition.get("extract_path", "")
+        return parse_json_path(file_path, path)
+
+    elif parser == "codeowners":
+        return parse_codeowners(file_path) or None
+
+    elif parser == "auto":
+        return _auto_parse(file_path, definition)
+
+    else:
+        logger.warning(f"Unknown parser: {parser}")
+        return None
+
+
+def _auto_parse(file_path: Path, definition: dict[str, Any]) -> Any:
+    """Auto-detect parser based on file extension and content."""
+    suffix = file_path.suffix.lower()
+
+    # JSON files
+    if suffix == ".json":
+        path = definition.get("extract_path", "")
+        return parse_json_path(file_path, path)
+
+    # YAML files
+    if suffix in (".yaml", ".yml"):
+        path = definition.get("extract_path", "")
+        return parse_yaml_path(file_path, path)
+
+    # CODEOWNERS file
+    if file_path.name in ("CODEOWNERS", "MAINTAINERS"):
+        return parse_codeowners(file_path)
+
+    # Markdown files - extract lists
+    if suffix == ".md":
+        return parse_markdown_list(file_path, definition.get("pattern"))
+
+    # Default: try markdown list parser
+    return parse_markdown_list(file_path, definition.get("pattern"))
+
+
+def _infer_parser(file_path: Path) -> str:
+    """Infer the appropriate parser from the file path."""
+    name = file_path.name.upper()
+    suffix = file_path.suffix.lower()
+
+    if name == "CODEOWNERS":
+        return "codeowners"
+    if suffix == ".json":
+        return "json_path"
+    if suffix in (".yaml", ".yml"):
+        return "yaml_path"
+    if suffix == ".md":
+        return "markdown_list"
+
+    return "auto"
+
+
+# =============================================================================
+# Validation
+# =============================================================================
+
+
+def validate_context_value(
+    value: Any,
+    definition: dict[str, Any],
+) -> tuple[bool, str | None]:
+    """Validate a context value against its definition.
+
+    Args:
+        value: The value to validate
+        definition: The context definition from TOML
+
+    Returns:
+        Tuple of (is_valid, error_message)
+    """
+    ctx_type = definition.get("type", "string")
+    pattern = definition.get("pattern")
+    values = definition.get("values")  # For enum types
+
+    # Type validation
+    if ctx_type == "boolean":
+        if isinstance(value, bool):
+            return True, None
+        if isinstance(value, str):
+            if value.lower() in ("true", "yes", "1"):
+                return True, None
+            if value.lower() in ("false", "no", "0"):
+                return True, None
+        return False, "Expected a boolean value (true/false)"
+
+    elif ctx_type in ("list", "list[string]", "list_or_path"):
+        if isinstance(value, list):
+            return True, None
+        if isinstance(value, str):
+            # Accept path to file or comma-separated values
+            return True, None
+        return False, "Expected a list or path"
+
+    elif ctx_type == "email":
+        if isinstance(value, str):
+            if re.match(r"^[^@]+@[^@]+\.[^@]+$", value):
+                return True, None
+        return False, "Expected a valid email address"
+
+    elif ctx_type == "enum":
+        if values and value not in values:
+            return False, f"Expected one of: {', '.join(values)}"
+        return True, None
+
+    elif ctx_type == "string":
+        if not isinstance(value, str):
+            return False, "Expected a string"
+        # Pattern validation
+        if pattern:
+            try:
+                if not re.match(pattern, value):
+                    return False, f"Value must match pattern: {pattern}"
+            except re.error:
+                logger.warning(f"Invalid pattern in definition: {pattern}")
+        return True, None
+
+    return True, None
+
+
+def coerce_context_value(
+    value: Any,
+    definition: dict[str, Any],
+) -> Any:
+    """Coerce a value to the expected type based on definition.
+
+    Args:
+        value: The raw value
+        definition: The context definition
+
+    Returns:
+        The coerced value
+    """
+    ctx_type = definition.get("type", "string")
+
+    if ctx_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ("true", "yes", "1")
+        return bool(value)
+
+    elif ctx_type in ("list", "list[string]"):
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            # Split comma-separated values
+            return [v.strip() for v in value.split(",") if v.strip()]
+        return [value]
+
+    elif ctx_type == "list_or_path":
+        # Keep as-is - could be a path or a list
+        return value
+
+    return value
+
+
+__all__ = [
+    # Parsers
+    "parse_markdown_list",
+    "parse_yaml_path",
+    "parse_json_path",
+    "parse_codeowners",
+    # Resolution
+    "resolve_context_value",
+    # Validation
+    "validate_context_value",
+    "coerce_context_value",
+]

--- a/tests/darnit/context/test_collection.py
+++ b/tests/darnit/context/test_collection.py
@@ -1,0 +1,344 @@
+"""Tests for context collection module.
+
+Tests the file parsers and context resolution priority.
+"""
+
+from pathlib import Path
+
+from darnit.context.collection import (
+    coerce_context_value,
+    parse_codeowners,
+    parse_json_path,
+    parse_markdown_list,
+    parse_yaml_path,
+    resolve_context_value,
+    validate_context_value,
+)
+
+
+class TestParseMarkdownList:
+    """Tests for parse_markdown_list function."""
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        """Test parsing empty file returns empty list."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("")
+        assert parse_markdown_list(md_file) == []
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        """Test parsing nonexistent file returns empty list."""
+        assert parse_markdown_list(tmp_path / "missing.md") == []
+
+    def test_bullet_list(self, tmp_path: Path) -> None:
+        """Test parsing bullet list items."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("""
+# Contributors
+
+- Alice
+- Bob
+- Charlie
+""")
+        result = parse_markdown_list(md_file)
+        assert "Alice" in result
+        assert "Bob" in result
+        assert "Charlie" in result
+
+    def test_numbered_list(self, tmp_path: Path) -> None:
+        """Test parsing numbered list items."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("""
+# Contributors
+
+1. Alice
+2. Bob
+3. Charlie
+""")
+        result = parse_markdown_list(md_file)
+        assert "Alice" in result
+        assert "Bob" in result
+        assert "Charlie" in result
+
+    def test_at_mentions(self, tmp_path: Path) -> None:
+        """Test extracting @mentions from markdown."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("""
+# Maintainers
+
+Contact @alice or @bob for help.
+""")
+        result = parse_markdown_list(md_file)
+        assert "@alice" in result
+        assert "@bob" in result
+
+    def test_deduplicate(self, tmp_path: Path) -> None:
+        """Test that duplicate items are deduplicated."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("""
+- Alice
+- Alice
+- @alice
+""")
+        result = parse_markdown_list(md_file)
+        # Should have Alice (bullet) and @alice (mention), not duplicates
+        assert len([x for x in result if "alice" in x.lower()]) <= 2
+
+    def test_with_pattern_filter(self, tmp_path: Path) -> None:
+        """Test filtering items with a pattern."""
+        md_file = tmp_path / "test.md"
+        md_file.write_text("""
+- alice@example.com
+- bob@example.com
+- not-an-email
+""")
+        # Filter to only email-like items
+        result = parse_markdown_list(md_file, pattern=r"@.*\.com")
+        assert "alice@example.com" in result
+        assert "bob@example.com" in result
+        assert "not-an-email" not in result
+
+
+class TestParseYamlPath:
+    """Tests for parse_yaml_path function."""
+
+    def test_simple_path(self, tmp_path: Path) -> None:
+        """Test extracting simple path."""
+        yaml_file = tmp_path / "test.yaml"
+        yaml_file.write_text("""
+name: my-project
+version: "1.0.0"
+""")
+        assert parse_yaml_path(yaml_file, "name") == "my-project"
+        assert parse_yaml_path(yaml_file, "version") == "1.0.0"
+
+    def test_nested_path(self, tmp_path: Path) -> None:
+        """Test extracting nested path."""
+        yaml_file = tmp_path / "test.yaml"
+        yaml_file.write_text("""
+security:
+  policy:
+    path: SECURITY.md
+""")
+        assert parse_yaml_path(yaml_file, "security.policy.path") == "SECURITY.md"
+
+    def test_missing_path(self, tmp_path: Path) -> None:
+        """Test extracting missing path returns None."""
+        yaml_file = tmp_path / "test.yaml"
+        yaml_file.write_text("name: test")
+        assert parse_yaml_path(yaml_file, "missing.path") is None
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        """Test parsing nonexistent file returns None."""
+        assert parse_yaml_path(tmp_path / "missing.yaml", "any.path") is None
+
+
+class TestParseJsonPath:
+    """Tests for parse_json_path function."""
+
+    def test_simple_path(self, tmp_path: Path) -> None:
+        """Test extracting simple path."""
+        json_file = tmp_path / "test.json"
+        json_file.write_text('{"name": "my-project", "version": "1.0.0"}')
+        assert parse_json_path(json_file, "name") == "my-project"
+        assert parse_json_path(json_file, "version") == "1.0.0"
+
+    def test_nested_path(self, tmp_path: Path) -> None:
+        """Test extracting nested path."""
+        json_file = tmp_path / "test.json"
+        json_file.write_text('{"security": {"policy": {"path": "SECURITY.md"}}}')
+        assert parse_json_path(json_file, "security.policy.path") == "SECURITY.md"
+
+    def test_jsonpath_style(self, tmp_path: Path) -> None:
+        """Test JSONPath-style paths with $. prefix."""
+        json_file = tmp_path / "test.json"
+        json_file.write_text('{"data": {"value": 42}}')
+        assert parse_json_path(json_file, "$.data.value") == 42
+
+    def test_array_index(self, tmp_path: Path) -> None:
+        """Test extracting array elements."""
+        json_file = tmp_path / "test.json"
+        json_file.write_text('{"items": ["first", "second", "third"]}')
+        assert parse_json_path(json_file, "items[0]") == "first"
+        assert parse_json_path(json_file, "items[1]") == "second"
+
+    def test_missing_path(self, tmp_path: Path) -> None:
+        """Test extracting missing path returns None."""
+        json_file = tmp_path / "test.json"
+        json_file.write_text('{"name": "test"}')
+        assert parse_json_path(json_file, "missing.path") is None
+
+
+class TestParseCodeowners:
+    """Tests for parse_codeowners function."""
+
+    def test_simple_codeowners(self, tmp_path: Path) -> None:
+        """Test parsing simple CODEOWNERS file."""
+        codeowners = tmp_path / "CODEOWNERS"
+        codeowners.write_text("""
+# CODEOWNERS file
+* @alice @bob
+/src/ @charlie
+""")
+        result = parse_codeowners(codeowners)
+        assert "@alice" in result
+        assert "@bob" in result
+        assert "@charlie" in result
+
+    def test_team_mentions(self, tmp_path: Path) -> None:
+        """Test parsing team mentions in CODEOWNERS."""
+        codeowners = tmp_path / "CODEOWNERS"
+        codeowners.write_text("* @myorg/myteam @alice")
+        result = parse_codeowners(codeowners)
+        assert "@myorg/myteam" in result
+        assert "@alice" in result
+
+    def test_skip_comments(self, tmp_path: Path) -> None:
+        """Test that comments are skipped."""
+        codeowners = tmp_path / "CODEOWNERS"
+        codeowners.write_text("""
+# This is a comment about @notincluded
+* @included
+""")
+        result = parse_codeowners(codeowners)
+        assert "@included" in result
+        assert "@notincluded" not in result
+
+
+class TestResolveContextValue:
+    """Tests for resolve_context_value function."""
+
+    def test_resolve_from_project_context(self, tmp_path: Path) -> None:
+        """Test resolution from .project/ context."""
+        definition = {
+            "store_as": "governance.maintainers",
+        }
+        project_context = {
+            "governance": {
+                "maintainers": ["@alice", "@bob"],
+            }
+        }
+        value, method = resolve_context_value(
+            "maintainers", definition, tmp_path, project_context
+        )
+        assert value == ["@alice", "@bob"]
+        assert method == "project"
+
+    def test_resolve_from_file_source(self, tmp_path: Path) -> None:
+        """Test resolution from file source."""
+        # Create a CODEOWNERS file
+        codeowners = tmp_path / "CODEOWNERS"
+        codeowners.write_text("* @alice @bob")
+
+        definition = {
+            "source": "CODEOWNERS",
+            "parser": "codeowners",
+        }
+        value, method = resolve_context_value(
+            "maintainers", definition, tmp_path, None
+        )
+        assert value is not None
+        assert "@alice" in value
+        assert method == "file"
+
+    def test_resolve_from_hint_sources(self, tmp_path: Path) -> None:
+        """Test resolution from hint_sources."""
+        # Create a CODEOWNERS file
+        codeowners = tmp_path / "CODEOWNERS"
+        codeowners.write_text("* @charlie")
+
+        definition = {
+            "hint_sources": ["CODEOWNERS", ".github/CODEOWNERS"],
+        }
+        value, method = resolve_context_value(
+            "maintainers", definition, tmp_path, None
+        )
+        assert value is not None
+        assert "@charlie" in value
+        assert "file:CODEOWNERS" in method
+
+    def test_resolve_returns_none_when_missing(self, tmp_path: Path) -> None:
+        """Test resolution returns None when value not found."""
+        definition = {
+            "store_as": "governance.maintainers",
+        }
+        value, method = resolve_context_value(
+            "maintainers", definition, tmp_path, None
+        )
+        assert value is None
+        assert method is None
+
+
+class TestValidateContextValue:
+    """Tests for validate_context_value function."""
+
+    def test_validate_boolean_true(self) -> None:
+        """Test validating boolean true values."""
+        definition = {"type": "boolean"}
+        assert validate_context_value(True, definition) == (True, None)
+        assert validate_context_value("true", definition) == (True, None)
+        assert validate_context_value("yes", definition) == (True, None)
+        assert validate_context_value("1", definition) == (True, None)
+
+    def test_validate_boolean_false(self) -> None:
+        """Test validating boolean false values."""
+        definition = {"type": "boolean"}
+        assert validate_context_value(False, definition) == (True, None)
+        assert validate_context_value("false", definition) == (True, None)
+        assert validate_context_value("no", definition) == (True, None)
+
+    def test_validate_boolean_invalid(self) -> None:
+        """Test validating invalid boolean values."""
+        definition = {"type": "boolean"}
+        is_valid, error = validate_context_value("maybe", definition)
+        assert not is_valid
+        assert "boolean" in error.lower()
+
+    def test_validate_email(self) -> None:
+        """Test validating email values."""
+        definition = {"type": "email"}
+        assert validate_context_value("test@example.com", definition) == (True, None)
+
+        is_valid, error = validate_context_value("not-an-email", definition)
+        assert not is_valid
+        assert "email" in error.lower()
+
+    def test_validate_enum(self) -> None:
+        """Test validating enum values."""
+        definition = {"type": "enum", "values": ["github", "gitlab", "jenkins"]}
+        assert validate_context_value("github", definition) == (True, None)
+
+        is_valid, error = validate_context_value("bitbucket", definition)
+        assert not is_valid
+        assert "github" in error
+
+    def test_validate_string_with_pattern(self) -> None:
+        """Test validating string with pattern."""
+        definition = {"type": "string", "pattern": r"^@[\w-]+$"}
+        assert validate_context_value("@alice", definition) == (True, None)
+
+        is_valid, error = validate_context_value("alice", definition)
+        assert not is_valid
+        assert "pattern" in error.lower()
+
+
+class TestCoerceContextValue:
+    """Tests for coerce_context_value function."""
+
+    def test_coerce_boolean(self) -> None:
+        """Test coercing boolean values."""
+        definition = {"type": "boolean"}
+        assert coerce_context_value(True, definition) is True
+        assert coerce_context_value("true", definition) is True
+        assert coerce_context_value("false", definition) is False
+
+    def test_coerce_list_from_string(self) -> None:
+        """Test coercing comma-separated string to list."""
+        definition = {"type": "list[string]"}
+        result = coerce_context_value("alice, bob, charlie", definition)
+        assert result == ["alice", "bob", "charlie"]
+
+    def test_coerce_list_passthrough(self) -> None:
+        """Test that list values pass through unchanged."""
+        definition = {"type": "list[string]"}
+        result = coerce_context_value(["alice", "bob"], definition)
+        assert result == ["alice", "bob"]


### PR DESCRIPTION
## Summary

This PR adds CNCF .project/ specification integration and enhanced context collection for the darnit framework.

### Key Changes

**1. CNCF .project/ Integration**
- Parse `.project/project.yaml` following CNCF automation spec
- Map project metadata to sieve context variables
- Write-back capability after remediation actions
- Upstream spec tracking via GitHub Actions

**2. Context Collection Module**
- File parsers: `markdown_list`, `yaml_path`, `json_path`, `codeowners`
- Resolution priority: `.project/` → file source → prompt
- Type validation and coercion for context values

**3. Fork Audit Support**
- `prefer_upstream` parameter for `audit_openssf_baseline()`
- Automatically detect upstream remote for forks
- Fixes OSPS-BR-04.01 false failures on forks

**4. Legacy Code Removal**
- Removed legacy audit paths for TOML-first architecture
- Simplified sieve registry to only handle ControlSpec

## Test plan

- [x] 520+ unit tests passing
- [x] Context collection tests (32 new tests)
- [x] Fork audit tested against kusari-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)