### PR TITLE
docs: Replace whitelist/blacklist with allowlist/denylist

### DIFF
--- a/packages/darnit/src/darnit/config/control_loader.py
+++ b/packages/darnit/src/darnit/config/control_loader.py
@@ -54,7 +54,7 @@ logger = get_logger("config.control_loader")
 # Module Import Security
 # =============================================================================
 
-# Base whitelist - always allowed
+# Base allowlist - always allowed
 _BASE_ALLOWED_PREFIXES = (
     "darnit.",
     "darnit_baseline.",
@@ -69,7 +69,7 @@ _discovered_prefixes: set[str] | None = None
 def _get_allowed_module_prefixes() -> tuple[str, ...]:
     """Get allowed module prefixes, including registered plugins.
 
-    Combines the base whitelist with prefixes from all registered
+    Combines the base allowlist with prefixes from all registered
     entry points in darnit.* groups. This allows third-party plugins
     to register their modules as trusted.
 
@@ -102,7 +102,7 @@ def _get_allowed_module_prefixes() -> tuple[str, ...]:
 
 
 def _is_module_allowed(module_path: str) -> bool:
-    """Check if a module path is in the allowed whitelist.
+    """Check if a module path is in the allowed allowlist.
 
     Args:
         module_path: Full module path (e.g., "darnit_baseline.controls.level2")
@@ -128,9 +128,9 @@ def _resolve_check_function(reference: str) -> Callable | None:
     2. Direct check functions: module:check_func
        - The function itself is used as the check
 
-    Security: Only allows loading modules from whitelisted prefixes
+    Security: Only allows loading modules from allowlisted prefixes
     to prevent arbitrary code execution from malicious TOML files.
-    The whitelist includes base darnit packages plus any packages
+    The allowlist includes base darnit packages plus any packages
     registered via entry points.
 
     Args:
@@ -145,7 +145,7 @@ def _resolve_check_function(reference: str) -> Callable | None:
 
     module_path, func_name = reference.rsplit(":", 1)
 
-    # Security: Validate module path against whitelist
+    # Security: Validate module path against allowlist
     if not _is_module_allowed(module_path):
         logger.warning(
             f"Blocked import of '{module_path}': not in allowed module prefixes. "

--- a/packages/darnit/src/darnit/core/adapters.py
+++ b/packages/darnit/src/darnit/core/adapters.py
@@ -454,7 +454,7 @@ class AdapterRegistry:
     # Config-based adapter definitions
     _adapter_configs: dict[str, dict[str, Any]] = field(default_factory=dict)
 
-    # Allowed module prefixes for dynamic imports (security whitelist)
+    # Allowed module prefixes for dynamic imports (security allowlist)
     ALLOWED_MODULE_PREFIXES: tuple = (
         "darnit.",
         "darnit_baseline.",
@@ -655,7 +655,7 @@ class AdapterRegistry:
             logger.error(f"Adapter {name} missing 'module' in config")
             return None
 
-        # Security: Validate module path against whitelist to prevent arbitrary code loading
+        # Security: Validate module path against allowlist to prevent arbitrary code loading
         if not any(module_path.startswith(prefix) for prefix in self.ALLOWED_MODULE_PREFIXES):
             logger.error(
                 f"Adapter {name}: module '{module_path}' not in allowed prefixes. "

--- a/packages/darnit/src/darnit/core/handlers.py
+++ b/packages/darnit/src/darnit/core/handlers.py
@@ -202,7 +202,7 @@ class HandlerRegistry:
             handlers = [h for h in handlers if h.plugin == plugin]
         return handlers
 
-    # Allowed module prefixes for handler imports (security whitelist)
+    # Allowed module prefixes for handler imports (security allowlist)
     # Only modules starting with these prefixes can be dynamically loaded
     ALLOWED_MODULE_PREFIXES = (
         "darnit.",
@@ -225,7 +225,7 @@ class HandlerRegistry:
         try:
             module_path, func_name = path.rsplit(":", 1)
 
-            # Validate module path against whitelist to prevent arbitrary imports
+            # Validate module path against allowlist to prevent arbitrary imports
             if not any(module_path.startswith(prefix) for prefix in self.ALLOWED_MODULE_PREFIXES):
                 logger.warning(
                     f"Module path '{module_path}' not in allowed prefixes: "

--- a/packages/darnit/src/darnit/core/registry.py
+++ b/packages/darnit/src/darnit/core/registry.py
@@ -219,7 +219,7 @@ class PluginRegistry:
     # Discovery state
     _discovered: set[str] = field(default_factory=set)
 
-    # Allowed module prefixes for dynamic imports (security whitelist)
+    # Allowed module prefixes for dynamic imports (security allowlist)
     ALLOWED_MODULE_PREFIXES: tuple = (
         "darnit.",
         "darnit_baseline.",
@@ -809,7 +809,7 @@ class PluginRegistry:
             logger.error(f"Adapter {name} missing 'module' in config")
             return None
 
-        # Security: Validate module path against whitelist to prevent arbitrary code loading
+        # Security: Validate module path against allowlist to prevent arbitrary code loading
         if not any(module_path.startswith(prefix) for prefix in self.ALLOWED_MODULE_PREFIXES):
             logger.error(
                 f"Adapter {name}: module '{module_path}' not in allowed prefixes. "

--- a/packages/darnit/src/darnit/sieve/cel_evaluator.py
+++ b/packages/darnit/src/darnit/sieve/cel_evaluator.py
@@ -21,7 +21,7 @@ Example:
 Security:
     - CEL is inherently sandboxed (no I/O, no imports, bounded execution)
     - Evaluation timeout enforced (default 1 second)
-    - Only whitelisted custom functions available
+    - Only allowlisted custom functions available
     - No direct filesystem or network access
     - Memory limiting: CEL's non-Turing complete nature prevents unbounded
       memory allocation. Combined with timeout, this provides adequate protection.

--- a/tests/darnit/config/test_control_loader.py
+++ b/tests/darnit/config/test_control_loader.py
@@ -434,7 +434,7 @@ class TestFrameworkSchemaValidation:
 
 
 class TestModuleImportSecurity:
-    """Test security whitelist for dynamic module imports."""
+    """Test security allowlist for dynamic module imports."""
 
     def test_base_prefixes_always_allowed(self):
         """Test that base darnit prefixes are always allowed."""

--- a/tests/darnit/core/test_handlers.py
+++ b/tests/darnit/core/test_handlers.py
@@ -101,7 +101,7 @@ class TestHandlerRegistry:
         assert callable(handler)
 
     def test_load_handler_blocked_module_path(self) -> None:
-        """Test that non-whitelisted module paths are blocked."""
+        """Test that non-allowlisted module paths are blocked."""
         registry = HandlerRegistry()
 
         # os.path is not in ALLOWED_MODULE_PREFIXES, should be blocked


### PR DESCRIPTION
## Summary

Use more inclusive terminology in code comments and docstrings.

## Changes

- `handlers.py`: "security whitelist" → "security allowlist"
- `handlers.py`: "against whitelist" → "against allowlist"  
- `test_handlers.py`: "non-whitelisted" → "non-allowlisted"

## Test plan

- [x] `uv run pytest tests/darnit/core/test_handlers.py` - 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)