### PR TITLE
feat: Integrate handler registry with control loader

### DIFF
--- a/openspec/changes/toml-schema-v2/tasks.md
+++ b/openspec/changes/toml-schema-v2/tasks.md
@@ -153,9 +153,9 @@ This ensures CI will pass and prevents broken commits from being pushed.
 
 ### 4.3 Plugin Resolution
 
-- [ ] 4.3.1 Resolve handler references by short name from registry
-- [ ] 4.3.2 Validate explicit module paths against whitelist
-- [ ] 4.3.3 Add helpful error for missing handlers
+- [x] 4.3.1 Resolve handler references by short name from registry
+- [x] 4.3.2 Validate explicit module paths against allowlist
+- [x] 4.3.3 Add helpful error for missing handlers
 
 ### 4.4 Sigstore Integration
 
@@ -182,7 +182,7 @@ This ensures CI will pass and prevents broken commits from being pushed.
 - [x] 4.7.1 Add unit tests for auto-registration
 - [x] 4.7.2 Add unit tests for handler resolution
 - [ ] 4.7.3 Add unit tests for Sigstore verification (mocked)
-- [ ] 4.7.4 Add integration test with darnit-baseline plugin
+- [x] 4.7.4 Add integration test with darnit-baseline plugin
 
 ## 5. Documentation & Cleanup
 

--- a/packages/darnit/src/darnit/config/control_loader.py
+++ b/packages/darnit/src/darnit/config/control_loader.py
@@ -120,13 +120,15 @@ def _is_module_allowed(module_path: str) -> bool:
 
 
 def _resolve_check_function(reference: str) -> Callable | None:
-    """Resolve a 'module:function' reference to a callable.
+    """Resolve a handler reference to a callable.
 
-    Supports two patterns:
-    1. Factory functions that return a callable: module:factory_func
-       - The factory is called, and its return value is used as the check
-    2. Direct check functions: module:check_func
-       - The function itself is used as the check
+    Supports three resolution strategies (in order):
+    1. Short name lookup: Check the handler registry for registered handlers
+       - e.g., "check_branch_protection" → registered handler function
+    2. Module:function path: Load from allowlisted module path
+       - e.g., "darnit_baseline.controls.level2:_create_changelog_check"
+    3. Factory pattern: If the resolved function can be called with no args
+       and returns a callable, use the returned callable
 
     Security: Only allows loading modules from allowlisted prefixes
     to prevent arbitrary code execution from malicious TOML files.
@@ -134,13 +136,29 @@ def _resolve_check_function(reference: str) -> Callable | None:
     registered via entry points.
 
     Args:
-        reference: String like "darnit_baseline.controls.level2:_create_changelog_check"
+        reference: Handler short name or "module:function" path
 
     Returns:
         The resolved function, or None if resolution fails
     """
-    if not reference or ":" not in reference:
-        logger.warning(f"Invalid check function reference (missing ':'): {reference}")
+    if not reference:
+        logger.warning("Empty check function reference")
+        return None
+
+    # Strategy 1: Check handler registry for short names first
+    from darnit.core.handlers import get_handler
+
+    handler = get_handler(reference)
+    if handler is not None:
+        logger.debug(f"Resolved handler '{reference}' from registry")
+        return handler
+
+    # Strategy 2: Parse as module:function path
+    if ":" not in reference:
+        logger.warning(
+            f"Handler '{reference}' not found in registry and not a module:function path. "
+            f"Register it with @register_handler or use full module:function syntax."
+        )
         return None
 
     module_path, func_name = reference.rsplit(":", 1)

--- a/tests/darnit/config/test_control_loader.py
+++ b/tests/darnit/config/test_control_loader.py
@@ -475,8 +475,12 @@ class TestModuleImportSecurity:
     def test_resolve_invalid_reference_format(self):
         """Test that invalid references are rejected."""
         assert _resolve_check_function("") is None
-        assert _resolve_check_function("no_colon_here") is None
         assert _resolve_check_function(None) is None  # type: ignore
+
+    def test_resolve_short_name_not_found_without_colon(self):
+        """Test helpful error for unregistered short name."""
+        # Short name without colon should suggest registration
+        assert _resolve_check_function("unknown_handler") is None
 
     def test_get_allowed_prefixes_includes_base(self):
         """Test that base prefixes are in allowed list."""
@@ -491,6 +495,57 @@ class TestModuleImportSecurity:
         # These should be blocked - they look similar but aren't valid prefixes
         assert not _is_module_allowed("darnit_malicious.evil")
         assert not _is_module_allowed("darnitfake.payload")
+
+
+class TestHandlerRegistryResolution:
+    """Test handler registry integration with _resolve_check_function."""
+
+    def test_resolve_from_registry_short_name(self):
+        """Test that registered handlers are resolved by short name."""
+        from darnit.core.handlers import get_handler_registry
+
+        registry = get_handler_registry()
+
+        # Register a test handler
+        def test_handler(context):
+            return True
+
+        registry.register_handler("test_check_handler", test_handler, plugin="test")
+
+        try:
+            # Should resolve from registry
+            resolved = _resolve_check_function("test_check_handler")
+            assert resolved is test_handler
+        finally:
+            # Cleanup
+            registry._handlers.pop("test_check_handler", None)
+
+    def test_resolve_fallback_to_module_path(self):
+        """Test that module:function paths work when not in registry."""
+        # This should fall back to module path resolution
+        result = _resolve_check_function(
+            "darnit_baseline.controls.level2:_create_changelog_check"
+        )
+        assert callable(result)
+
+    def test_resolve_registry_takes_precedence(self):
+        """Test that registry lookup happens before module path parsing."""
+        from darnit.core.handlers import get_handler_registry
+
+        registry = get_handler_registry()
+
+        # Register a handler with a name that looks like a module path
+        def custom_handler(context):
+            return "custom"
+
+        registry.register_handler("my_custom_check", custom_handler, plugin="test")
+
+        try:
+            # Should find in registry, not try to parse as module:function
+            resolved = _resolve_check_function("my_custom_check")
+            assert resolved is custom_handler
+        finally:
+            registry._handlers.pop("my_custom_check", None)
 
 
 if __name__ == "__main__":

--- a/tests/darnit/core/test_handlers.py
+++ b/tests/darnit/core/test_handlers.py
@@ -332,3 +332,55 @@ class TestRegistryClear:
         assert registry.get_handler("h") is None
         assert registry.get_pass("p") is None
         assert registry._current_plugin is None
+
+
+class TestDarnitBaselineIntegration:
+    """Integration tests with darnit-baseline plugin."""
+
+    def test_resolve_baseline_handler_by_module_path(self) -> None:
+        """Test resolving darnit-baseline handler via module:function path."""
+        registry = HandlerRegistry()
+
+        # Should resolve darnit_baseline module path
+        handler = registry.get_handler(
+            "darnit_baseline.controls.level2:_create_changelog_check"
+        )
+        assert handler is not None
+        assert callable(handler)
+
+    def test_resolve_blocked_module_path(self) -> None:
+        """Test that non-allowlisted modules are blocked."""
+        registry = HandlerRegistry()
+
+        # Should block arbitrary modules
+        handler = registry.get_handler("os:system")
+        assert handler is None
+
+        handler = registry.get_handler("subprocess:run")
+        assert handler is None
+
+    def test_allowlist_includes_darnit_packages(self) -> None:
+        """Test that allowlist includes all darnit package prefixes."""
+        from darnit.core.handlers import HandlerRegistry
+
+        allowed = HandlerRegistry.ALLOWED_MODULE_PREFIXES
+
+        assert "darnit." in allowed
+        assert "darnit_baseline." in allowed
+        assert "darnit_testchecks." in allowed
+
+    def test_get_handler_with_colon_tries_module_resolution(self) -> None:
+        """Test that handler names with ':' trigger module resolution."""
+        registry = HandlerRegistry()
+
+        # Valid darnit_baseline path should resolve
+        handler = registry.get_handler(
+            "darnit_baseline.controls.level1:_create_license_check"
+        )
+        assert callable(handler)
+
+        # Invalid path (bad function name) should return None gracefully
+        handler = registry.get_handler(
+            "darnit_baseline.controls.level1:nonexistent_function"
+        )
+        assert handler is None


### PR DESCRIPTION
## Summary

- Update `_resolve_check_function` to first check handler registry for short names before falling back to module:function path resolution
- Add helpful error message suggesting `@register_handler` or full module:function syntax for unresolved handlers
- Add integration tests verifying handler resolution works with darnit-baseline

## Changes

- **control_loader.py**: Modified `_resolve_check_function` to support 3-strategy resolution:
  1. Short name lookup from handler registry
  2. Module:function path resolution (with allowlist validation)
  3. Factory pattern detection

- **test_control_loader.py**: Added `TestHandlerRegistryResolution` with 3 tests

- **test_handlers.py**: Added `TestDarnitBaselineIntegration` with 4 integration tests

## Tasks Completed

- [x] 4.3.1 Resolve handler references by short name from registry
- [x] 4.3.2 Validate explicit module paths against allowlist
- [x] 4.3.3 Add helpful error for missing handlers
- [x] 4.7.4 Add integration test with darnit-baseline plugin

## Test plan

- [x] All 703 tests pass
- [x] Linting passes
- [x] kusari repo scan passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)