### PR TITLE
fix: Skip handler registry for module:function check references

### DIFF
--- a/packages/darnit/src/darnit/config/control_loader.py
+++ b/packages/darnit/src/darnit/config/control_loader.py
@@ -145,13 +145,14 @@ def _resolve_check_function(reference: str) -> Callable | None:
         logger.warning("Empty check function reference")
         return None
 
-    # Strategy 1: Check handler registry for short names first
-    from darnit.core.handlers import get_handler
+    # Strategy 1: Check handler registry for short names (no colon) first
+    if ":" not in reference:
+        from darnit.core.handlers import get_handler
 
-    handler = get_handler(reference)
-    if handler is not None:
-        logger.debug(f"Resolved handler '{reference}' from registry")
-        return handler
+        handler = get_handler(reference)
+        if handler is not None:
+            logger.debug(f"Resolved handler '{reference}' from registry")
+            return handler
 
     # Strategy 2: Parse as module:function path
     if ":" not in reference:


### PR DESCRIPTION
## Summary

- Fixes OSPS-BR-04.01 failing with `_create_changelog_check() takes 0 positional arguments but 1 was given`
- The handler registry lookup in `_resolve_check_function()` was short-circuiting factory detection for `module:function` references, returning the raw factory function instead of invoking it
- Restricts handler registry lookup to short names only (no colon), so `module:function` paths always reach the factory detection code

## Test plan

- [x] `uv run ruff check .` passes
- [x] All 737 unit tests pass
- [x] Targeted audit confirms OSPS-BR-04.01 runs without error: `audit_openssf_baseline(local_path='.', level=2, tags='domain=BR')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)