### PR TITLE
docs: Clarify plugin verification integration status

### DIFF
--- a/docs/SECURITY_GUIDE.md
+++ b/docs/SECURITY_GUIDE.md
@@ -289,6 +289,22 @@ remediate_audit_findings(
 
 Darnit's plugin system allows extending functionality through third-party packages. This section describes the security model for plugins.
 
+### Current Status
+
+> **Note:** The Sigstore verification module (`darnit.core.verification`) is fully
+> implemented and tested, but it is **not yet integrated into plugin discovery**.
+> Currently, `discover_implementations()` loads all entry-point plugins
+> unconditionally. The verification infrastructure is ready to be wired in — see
+> the TODO in `packages/darnit/src/darnit/core/discovery.py`.
+>
+> In practice this means:
+> - **Local development**: All plugins load without verification (expected behavior).
+> - **Published releases**: The GitHub Actions publish workflow supports Sigstore
+>   attestations (`attestations: true`), but the release trigger is not yet active.
+> - **Production hardening**: Once verification is integrated into discovery and
+>   packages are published with attestations, set `allow_unsigned = false` to
+>   enforce signed-only plugins.
+
 ### Plugin Verification with Sigstore
 
 Darnit supports [Sigstore](https://www.sigstore.dev/)-based plugin verification to ensure plugins come from trusted sources.

--- a/packages/darnit/src/darnit/core/discovery.py
+++ b/packages/darnit/src/darnit/core/discovery.py
@@ -40,6 +40,15 @@ def discover_implementations() -> dict[str, ComplianceImplementation]:
     from importlib.metadata import entry_points
     eps = entry_points(group="darnit.implementations")
 
+    # TODO: Integrate plugin verification before loading.
+    # The PluginVerifier (darnit.core.verification) is fully implemented but
+    # not yet called here. Before loading each entry point, we should:
+    #   1. Call PluginVerifier.verify_plugin(ep.name)
+    #   2. Skip plugins that fail verification (when allow_unsigned=False)
+    #   3. Log warnings for unsigned plugins (when allow_unsigned=True)
+    # This requires reading VerificationConfig from the user's .baseline.toml.
+    # See: docs/SECURITY_GUIDE.md "Plugin Security Model" for configuration details.
+
     for ep in eps:
         try:
             # Load the entry point (calls the register() function)


### PR DESCRIPTION
## Summary

- Adds a TODO in `discover_implementations()` marking where Sigstore verification should be called before loading plugins
- Adds a "Current Status" note to `docs/SECURITY_GUIDE.md` clarifying that the verification module is implemented but not yet wired into plugin discovery
- Makes the existing documentation honest about the gap between the verification infrastructure (fully built) and its integration into the runtime (not yet done)

## Test plan

- [x] `uv run ruff check .` passes
- [x] All 737 unit tests pass
- [ ] Review docs for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)