### PR TITLE
feat: Built-in MCP tools, project_update, on_pass, and example plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/docs/IMPLEMENTATION_GUIDE.md
+++ b/docs/IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,1362 @@
+# Building a darnit Implementation
+
+This guide walks through building a compliance implementation for the darnit framework.
+By the end, you'll have a working plugin that defines controls, runs automated checks
+through the sieve pipeline, and provides remediation actions.
+
+We'll build a hypothetical implementation called "darnit-mystandard" that checks projects
+against a fictional "My Compliance Standard". Along the way, we'll reference how
+`darnit-baseline` (the OpenSSF Baseline implementation) solves the same problems.
+
+## Prerequisites
+
+- Python 3.11+
+- Familiarity with Python packaging (pyproject.toml, entry points)
+- A local clone of the darnit repository for reference
+
+> **Working example**: The `packages/darnit-example/` package is a complete,
+> installable implementation that follows every step in this guide. You can
+> study it alongside these instructions — see `packages/darnit-example/README.md`
+> for a mapping between guide sections and example files.
+
+## Architecture Overview
+
+darnit uses a plugin architecture that separates the core framework from compliance
+implementations:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    darnit (framework)                    │
+│                                                         │
+│  ┌──────────┐  ┌──────────┐  ┌────────┐  ┌──────────┐  │
+│  │ Discovery │  │  Sieve   │  │ Config │  │  Server  │  │
+│  │  System   │  │ Pipeline │  │ Loader │  │  (MCP)   │  │
+│  └──────────┘  └──────────┘  └────────┘  └──────────┘  │
+│        │              │            │                     │
+│        ▼              ▼            ▼                     │
+│  ComplianceImplementation Protocol                      │
+└────────────────┬────────────────────────────────────────┘
+                 │
+    ┌────────────┼────────────────┐
+    ▼            ▼                ▼
+┌─────────┐  ┌──────────┐  ┌──────────┐
+│ darnit- │  │ darnit-  │  │  your    │
+│baseline │  │testchecks│  │  plugin  │
+└─────────┘  └──────────┘  └──────────┘
+```
+
+**Key rule**: The framework never imports implementation packages directly. All
+communication goes through the `ComplianceImplementation` protocol. Implementations
+*may* import from the framework.
+
+### The three layers
+
+darnit operates at three distinct layers. Each layer has built-in primitives and
+plugin extensibility:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Layer 3: MCP Tools (what the AI assistant calls)       │
+│                                                         │
+│  Built-in: audit, remediate, list_controls              │
+│  Plugin:   any Python function registered as a handler  │
+│                                                         │
+│  TOML:  [mcp.tools.audit]                               │
+│         builtin = "audit"                               │
+├─────────────────────────────────────────────────────────┤
+│  Layer 2: Remediation (how to fix a failing control)    │
+│                                                         │
+│  Built-in: file_create, exec, api_call, project_update  │
+│  Plugin:   handler = "my_module:my_func"                │
+│                                                         │
+│  TOML:  [controls."X".remediation.file_create]          │
+│         path = "SECURITY.md"                            │
+│         template = "security_policy"                    │
+├─────────────────────────────────────────────────────────┤
+│  Layer 1: Checking (how to verify a control)            │
+│                                                         │
+│  Built-in: file_must_exist, exec, pattern, manual       │
+│  Plugin:   config_check = "my_module:my_func"           │
+│                                                         │
+│  TOML:  [controls."X".passes.deterministic]             │
+│         file_must_exist = ["README.md"]                 │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Layer 1 (Checking)** answers: "Does this control pass?" Using built-in pass types
+(file existence, command execution, regex patterns) or custom Python check functions.
+
+**Layer 2 (Remediation)** answers: "How do I fix it?" Using built-in actions
+(create file from template, run command, call API, update project config) or custom
+Python remediation functions.
+
+**Layer 3 (MCP Tools)** answers: "What can the AI assistant do?" Using built-in
+tools (audit all controls, remediate failures, list controls) or custom Python
+tool handlers.
+
+For simple frameworks, all three layers can be TOML-only — no Python required.
+For complex frameworks, any layer can be extended with Python plugins.
+
+---
+
+## Quick Start: TOML-Only Framework (No Python)
+
+If your controls only need file checks and template-based remediation, you can
+create a working MCP server with just a TOML file:
+
+```toml
+# my-standard.toml
+[metadata]
+name = "my-standard"
+version = "0.1.0"
+schema_version = "0.1.0-alpha"
+spec_version = "v1.0"
+description = "My compliance standard"
+
+[templates.readme]
+content = "# $REPO\nA brief description.\n"
+
+[controls."MS-01"]
+name = "HasReadme"
+description = "Project must have a README"
+tags = { level = 1, domain = "DOC" }
+
+[controls."MS-01".passes]
+deterministic = { file_must_exist = ["README.md", "README.rst"] }
+
+[controls."MS-01".passes.manual]
+steps = ["Check for README in project root"]
+
+[controls."MS-01".remediation]
+safe = true
+dry_run_supported = true
+
+[controls."MS-01".remediation.file_create]
+path = "README.md"
+template = "readme"
+
+[controls."MS-01".remediation.project_update]
+set = { "documentation.readme.path" = "README.md" }
+
+[mcp.tools.audit]
+builtin = "audit"
+description = "Run compliance audit"
+
+[mcp.tools.remediate]
+builtin = "remediate"
+description = "Auto-fix failing controls"
+
+[mcp.tools.list_controls]
+builtin = "list_controls"
+description = "List all controls"
+```
+
+Serve it directly:
+
+```bash
+darnit serve /path/to/my-standard.toml
+```
+
+Or configure in Claude Code:
+
+```json
+{
+  "mcpServers": {
+    "my-standard": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/darnit", "darnit", "serve", "/path/to/my-standard.toml"]
+    }
+  }
+}
+```
+
+The `builtin = "audit"` tools use the framework's generic implementations that
+work with any TOML-defined controls. For custom tools, use a Python plugin
+package instead (see sections below).
+
+---
+
+## 1. Package Setup
+
+### Directory structure
+
+```
+darnit-mystandard/
+├── pyproject.toml
+├── mystandard.toml              # Framework configuration
+└── src/
+    └── darnit_mystandard/
+        ├── __init__.py           # register() function
+        ├── implementation.py     # ComplianceImplementation class
+        ├── controls/
+        │   ├── __init__.py
+        │   └── level1.py         # Python-defined controls
+        └── remediation/
+            ├── __init__.py
+            └── registry.py       # Remediation action mappings
+```
+
+### pyproject.toml
+
+The critical piece is the entry point registration. darnit discovers implementations
+through the `darnit.implementations` entry point group:
+
+```toml
+[project]
+name = "darnit-mystandard"
+version = "0.1.0"
+description = "My Compliance Standard checks for darnit"
+requires-python = ">=3.11"
+dependencies = [
+    "darnit>=0.1.0",
+]
+
+[project.entry-points."darnit.implementations"]
+mystandard = "darnit_mystandard:register"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/darnit_mystandard"]
+```
+
+The entry point format is `name = "module:function"`. When darnit starts, it calls
+`importlib.metadata.entry_points(group="darnit.implementations")`, loads each entry
+point, and calls the returned function.
+
+### The register() function
+
+```python
+# src/darnit_mystandard/__init__.py
+
+def register():
+    """Register the My Standard implementation with darnit.
+
+    Called by darnit's plugin discovery via entry points.
+    """
+    from .implementation import MyStandardImplementation
+    return MyStandardImplementation()
+```
+
+The lazy import inside `register()` is intentional — it avoids loading the
+implementation class until darnit actually needs it.
+
+> **Reference**: See `packages/darnit-baseline/src/darnit_baseline/__init__.py`
+> and `packages/darnit-baseline/pyproject.toml` for the real implementation.
+
+---
+
+## 2. The Implementation Class
+
+Your implementation must satisfy the `ComplianceImplementation` protocol defined in
+`packages/darnit/src/darnit/core/plugin.py`. This is a `typing.Protocol` (structural
+typing), so you don't need to inherit from it — just implement the required interface.
+
+### Protocol definition
+
+```python
+@runtime_checkable
+class ComplianceImplementation(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def display_name(self) -> str: ...
+
+    @property
+    def version(self) -> str: ...
+
+    @property
+    def spec_version(self) -> str: ...
+
+    def get_all_controls(self) -> list[ControlSpec]: ...
+    def get_controls_by_level(self, level: int) -> list[ControlSpec]: ...
+    def get_rules_catalog(self) -> dict[str, Any]: ...
+    def get_remediation_registry(self) -> dict[str, Any]: ...
+    def get_framework_config_path(self) -> Path | None: ...
+    def register_controls(self) -> None: ...
+```
+
+### Required properties (4)
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| `name` | `str` | Unique identifier (e.g., `"mystandard"`) |
+| `display_name` | `str` | Human-readable name (e.g., `"My Compliance Standard"`) |
+| `version` | `str` | Implementation version (e.g., `"0.1.0"`) |
+| `spec_version` | `str` | Spec version implemented (e.g., `"MySpec v1.0"`) |
+
+### Required methods (6)
+
+| Method | Purpose |
+|--------|---------|
+| `get_all_controls()` | Return all controls as `ControlSpec` objects |
+| `get_controls_by_level(level)` | Filter controls by maturity level |
+| `get_rules_catalog()` | Return SARIF rule definitions for output formatting |
+| `get_remediation_registry()` | Return mapping of remediation categories to fix functions |
+| `get_framework_config_path()` | Return path to the TOML configuration file |
+| `register_controls()` | Import Python control modules to trigger registration |
+
+### Optional methods
+
+| Method | Purpose |
+|--------|---------|
+| `register_handlers()` | Register MCP tool handlers (checked via `hasattr`) |
+
+### Minimal implementation
+
+```python
+# src/darnit_mystandard/implementation.py
+from pathlib import Path
+from typing import Any
+
+from darnit.core.plugin import ControlSpec
+
+
+class MyStandardImplementation:
+    """My Compliance Standard implementation for darnit."""
+
+    @property
+    def name(self) -> str:
+        return "mystandard"
+
+    @property
+    def display_name(self) -> str:
+        return "My Compliance Standard"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def spec_version(self) -> str:
+        return "MySpec v1.0"
+
+    def get_all_controls(self) -> list[ControlSpec]:
+        controls = []
+        for level in [1, 2, 3]:
+            controls.extend(self.get_controls_by_level(level))
+        return controls
+
+    def get_controls_by_level(self, level: int) -> list[ControlSpec]:
+        # For now, delegate to the sieve registry
+        from darnit.sieve.registry import get_control_registry
+        registry = get_control_registry()
+        return registry.get_specs_by_level(level)
+
+    def get_rules_catalog(self) -> dict[str, Any]:
+        return {}  # Populate as needed for SARIF output
+
+    def get_remediation_registry(self) -> dict[str, Any]:
+        from .remediation.registry import REMEDIATION_REGISTRY
+        return REMEDIATION_REGISTRY
+
+    def get_framework_config_path(self) -> Path | None:
+        # Navigate from implementation.py to the TOML file
+        return Path(__file__).parent.parent.parent / "mystandard.toml"
+
+    def register_controls(self) -> None:
+        """Import control modules to trigger @register_control calls."""
+        from .controls import level1  # noqa: F401
+```
+
+The `get_framework_config_path()` method deserves attention: it must return the
+correct path relative to `implementation.py`. The path traversal depends on your
+package structure. For `src/darnit_mystandard/implementation.py` reaching
+`mystandard.toml` at the package root:
+
+```
+implementation.py  →  parent (darnit_mystandard/)
+                   →  parent (src/)
+                   →  parent (darnit-mystandard/)
+                   →  / mystandard.toml
+```
+
+> **Reference**: See `packages/darnit-baseline/src/darnit_baseline/implementation.py`
+> for the full OpenSSF Baseline implementation class.
+
+---
+
+## 3. TOML Framework Configuration
+
+The TOML file is the declarative heart of your implementation. It defines metadata,
+templates, context collection prompts, and control definitions. The framework loads
+this file via `get_framework_config_path()`.
+
+### Metadata section
+
+```toml
+[metadata]
+name = "mystandard"
+display_name = "My Compliance Standard"
+version = "0.1.0"
+schema_version = "0.1.0-alpha"
+spec_version = "MySpec v1.0"
+description = "Compliance controls for My Standard"
+url = "https://example.com/mystandard"
+
+[defaults]
+check_adapter = "builtin"
+remediation_adapter = "builtin"
+```
+
+### Control definitions
+
+Each control is defined under `[controls."CONTROL-ID"]`. Controls can have
+declarative passes that the framework executes without Python code:
+
+```toml
+[controls."MS-DOC-01"]
+name = "ReadmeExists"
+description = "Project must have a README file"
+tags = { level = 1, domain = "DOC", documentation = true }
+docs_url = "https://example.com/mystandard#MS-DOC-01"
+help_md = """Create a README.md file in the repository root.
+
+**Remediation:**
+1. Create README.md with project description
+2. Include usage instructions
+"""
+
+# Deterministic pass: check if file exists
+[controls."MS-DOC-01".passes.deterministic]
+file_must_exist = [
+    "README.md",
+    "README.rst",
+    "README.txt",
+    "README",
+]
+
+# Manual pass: fallback verification steps
+[controls."MS-DOC-01".passes.manual]
+steps = [
+    "Check repository root for README file",
+    "Verify README contains project description",
+]
+```
+
+### Built-in pass types
+
+The framework supports these pass types in TOML, each mapped to a pass class in
+`packages/darnit/src/darnit/sieve/passes.py`:
+
+| TOML Pass | Class | Purpose |
+|-----------|-------|---------|
+| `deterministic` | `DeterministicPass` | File existence, CEL expressions |
+| `pattern` | `PatternPass` | Regex matching in file contents |
+| `exec` | `ExecPass` | Run external commands |
+| `manual` | `ManualPass` | Human verification steps |
+
+#### file_must_exist
+
+The simplest check — pass if any listed file exists:
+
+```toml
+[controls."MS-SEC-01".passes.deterministic]
+file_must_exist = [
+    "SECURITY.md",
+    ".github/SECURITY.md",
+    "docs/SECURITY.md",
+]
+```
+
+#### exec (external command)
+
+Run a CLI tool and evaluate the result with a CEL expression:
+
+```toml
+[controls."MS-AC-01".passes.exec]
+command = ["gh", "api", "/orgs/$OWNER"]
+pass_exit_codes = [0]
+fail_exit_codes = [1]
+output_format = "json"
+expr = 'output.json.two_factor_requirement_enabled == true'
+timeout = 30
+```
+
+Variable substitution in commands: `$PATH` (local repo path), `$OWNER`,
+`$REPO`, `$BRANCH`, `$CONTROL`.
+
+#### Pattern matching
+
+Search file contents with regex:
+
+```toml
+[controls."MS-DOC-02".passes.pattern]
+file_patterns = ["SECURITY.md", ".github/SECURITY.md"]
+content_patterns = { security_contact = '([\w.-]+@[\w.-]+\.\w+|security\s*contact)' }
+pass_if_any_match = true
+```
+
+#### Manual verification
+
+Always returns INCONCLUSIVE with human-readable steps:
+
+```toml
+[controls."MS-DOC-02".passes.manual]
+steps = [
+    "Open SECURITY.md",
+    "Verify it contains a clear contact method",
+    "Confirm the contact method is monitored",
+]
+```
+
+### Remediation in TOML
+
+Controls can define declarative remediation actions that the framework executes
+without Python code. These are the built-in remediation types:
+
+#### file_create
+
+Create a file from a template:
+
+```toml
+[controls."MS-SEC-01".remediation]
+safe = true
+dry_run_supported = true
+
+[controls."MS-SEC-01".remediation.file_create]
+path = "SECURITY.md"
+template = "security_policy"
+overwrite = false
+create_dirs = true  # Create parent directories if needed
+```
+
+#### exec (run a command)
+
+```toml
+[controls."MS-BR-01".remediation.exec]
+command = ["git", "tag", "-s", "v1.0.0"]
+success_exit_codes = [0]
+timeout = 30
+```
+
+#### api_call
+
+```toml
+[controls."MS-AC-01".remediation.api_call]
+method = "PUT"
+endpoint = "/repos/$OWNER/$REPO/branches/$BRANCH/protection"
+payload_template = "branch_protection_payload"
+```
+
+#### project_update
+
+Update `.project/project.yaml` with dotted-path values after a successful
+remediation. This keeps the project config in sync with what was created:
+
+```toml
+[controls."MS-SEC-01".remediation.project_update]
+set = { "security.policy.path" = "SECURITY.md" }
+```
+
+The `set` dict maps dotted paths to values. `security.policy.path` becomes:
+
+```yaml
+# .project/project.yaml
+security:
+  policy:
+    path: SECURITY.md
+```
+
+`project_update` only runs when the primary remediation (file_create, exec, or
+api_call) succeeds. In dry-run mode, it shows a preview of what would change.
+
+### on_pass (post-check context updates)
+
+When a control **passes**, the sieve may discover useful evidence (e.g., "SECURITY.md
+exists at this path"). The `on_pass` section feeds that evidence back into
+`.project/project.yaml` so subsequent checks can use it:
+
+```toml
+[controls."MS-SEC-01".on_pass]
+project_update = { "security.policy.path" = "SECURITY.md" }
+```
+
+Values can reference evidence gathered during the check using `$EVIDENCE.<key>`:
+
+```toml
+[controls."MS-SEC-01".on_pass]
+project_update = { "security.policy.path" = "$EVIDENCE.file" }
+```
+
+This creates a lifecycle:
+- Control passes → `on_pass` records what was found
+- Control fails → remediation fixes it → `project_update` records what was created
+- Next audit run → project config has the context for downstream controls
+
+### Templates
+
+Templates are string content blocks used by remediation actions:
+
+```toml
+[templates.security_policy]
+description = "Standard SECURITY.md template"
+content = """# Security Policy
+
+## Reporting a Vulnerability
+
+Report vulnerabilities by emailing security@$OWNER.example.com.
+We will respond within 48 hours.
+"""
+```
+
+Templates support `$OWNER` and `$REPO` variable substitution.
+
+### Context definitions
+
+Context prompts collect project-specific information to improve audit accuracy:
+
+```toml
+[context.ci_provider]
+type = "enum"
+prompt = "What CI/CD system does this project use?"
+hint = "Select your primary CI/CD provider"
+values = ["github", "gitlab", "jenkins", "none", "other"]
+affects = ["MS-CI-01", "MS-CI-02"]
+store_as = "ci.provider"
+auto_detect = true
+required = false
+```
+
+Context values are stored in `.project/project.yaml` and injected into checks
+via `CheckContext.project_context`.
+
+> **Reference**: See `packages/darnit-baseline/openssf-baseline.toml` for a full
+> TOML configuration with 62 controls, templates, and context definitions.
+
+---
+
+## 4. The Sieve Pipeline
+
+The sieve is a 4-phase verification pipeline. Each control defines one or more
+"passes" that execute in order. The orchestrator stops at the first conclusive result.
+
+```
+DETERMINISTIC  →  PATTERN  →  LLM  →  MANUAL
+     ↓               ↓          ↓        ↓
+  Exact checks    Heuristics   AI     Human
+  (high conf)     (med conf)   eval   review
+```
+
+### Phase execution rules
+
+1. **DETERMINISTIC**: File existence, API calls, config lookups. Returns PASS, FAIL,
+   or INCONCLUSIVE.
+2. **PATTERN**: Regex matching, content analysis. Only runs if DETERMINISTIC was
+   INCONCLUSIVE.
+3. **LLM**: Asks the calling LLM to analyze evidence. Only runs if earlier phases
+   were INCONCLUSIVE.
+4. **MANUAL**: Always returns INCONCLUSIVE (rendered as WARN) with verification steps.
+   This is the fallback when no automated check can determine the result.
+
+### Key data types
+
+All defined in `packages/darnit/src/darnit/sieve/models.py`:
+
+```python
+class VerificationPhase(Enum):
+    DETERMINISTIC = "deterministic"
+    PATTERN = "pattern"
+    LLM = "llm"
+    MANUAL = "manual"
+
+class PassOutcome(Enum):
+    PASS = "pass"           # Control satisfied
+    FAIL = "fail"           # Control NOT satisfied
+    INCONCLUSIVE = "inconclusive"  # Cannot determine, try next pass
+    ERROR = "error"         # Pass failed to execute
+```
+
+**PassResult** is what every pass returns:
+
+```python
+@dataclass
+class PassResult:
+    phase: VerificationPhase
+    outcome: PassOutcome
+    message: str
+    evidence: dict[str, Any] | None = None
+    confidence: float | None = None  # 0.0-1.0, primarily for LLM pass
+    details: dict[str, Any] | None = None
+```
+
+**CheckContext** is what every pass receives:
+
+```python
+@dataclass
+class CheckContext:
+    owner: str                  # GitHub org/user
+    repo: str                   # Repository name
+    local_path: str             # Path to cloned repo
+    default_branch: str         # e.g., "main"
+    control_id: str             # e.g., "MS-DOC-01"
+    control_metadata: dict      # From TOML definition
+    gathered_evidence: dict     # Accumulated from previous passes
+    project_context: dict       # From .project/project.yaml
+```
+
+### ControlSpec (sieve version)
+
+Controls registered with the sieve use the sieve-specific `ControlSpec` from
+`darnit.sieve.models`, not the one from `darnit.core.plugin`:
+
+```python
+from darnit.sieve.models import ControlSpec
+
+ControlSpec(
+    control_id="MS-DOC-01",
+    level=1,
+    domain="DOC",
+    name="ReadmeExists",
+    description="Project must have a README file",
+    passes=[
+        DeterministicPass(file_must_exist=["README.md", "README.rst"]),
+        ManualPass(verification_steps=["Check for README"]),
+    ],
+)
+```
+
+The sieve `ControlSpec` includes a `passes` field (list of pass objects) and validates
+that passes are in the correct phase order (DETERMINISTIC → PATTERN → LLM → MANUAL).
+
+> **Reference**: See `packages/darnit/src/darnit/sieve/models.py` for all data types
+> and `openspec/specs/framework-design/spec.md` for the authoritative specification.
+
+---
+
+## 5. Python Controls
+
+When TOML declarations aren't expressive enough — for example, when you need to call
+APIs, run complex logic, or combine multiple data sources — define controls in Python.
+
+### The registration pattern
+
+```python
+# src/darnit_mystandard/controls/level1.py
+from darnit.sieve.models import (
+    CheckContext,
+    ControlSpec,
+    PassOutcome,
+    PassResult,
+    VerificationPhase,
+)
+from darnit.sieve.passes import DeterministicPass, ManualPass
+from darnit.sieve.registry import register_control
+```
+
+### Factory functions (important pattern)
+
+Python controls that need runtime logic use **factory functions** that return
+closures. This is a critical pattern — use it whenever a pass needs to execute
+custom logic:
+
+```python
+def _create_api_check() -> Callable[[CheckContext], PassResult]:
+    """Create an API check for control MS-AC-01."""
+
+    def check(ctx: CheckContext) -> PassResult:
+        # Your custom logic here
+        import subprocess, json
+        result = subprocess.run(
+            ["gh", "api", f"/repos/{ctx.owner}/{ctx.repo}"],
+            capture_output=True, text=True, timeout=30,
+        )
+
+        if result.returncode != 0:
+            return PassResult(
+                phase=VerificationPhase.DETERMINISTIC,
+                outcome=PassOutcome.INCONCLUSIVE,
+                message="Could not reach API",
+            )
+
+        data = json.loads(result.stdout)
+        if data.get("private") is False:
+            return PassResult(
+                phase=VerificationPhase.DETERMINISTIC,
+                outcome=PassOutcome.PASS,
+                message="Repository is public",
+                evidence={"private": False},
+            )
+        else:
+            return PassResult(
+                phase=VerificationPhase.DETERMINISTIC,
+                outcome=PassOutcome.FAIL,
+                message="Repository is private",
+                evidence={"private": True},
+            )
+
+    return check
+```
+
+**Why factory functions?** The `DeterministicPass.config_check` field expects a
+`Callable[[CheckContext], PassResult]`. The factory function creates a closure that
+captures any setup state and returns a function with the right signature. Without
+the factory, you'd pass the function itself — but that prevents per-registration
+customization and makes testing harder.
+
+### Registering the control
+
+Call `register_control()` at module level. When `register_controls()` imports this
+module, the registration happens automatically:
+
+```python
+register_control(ControlSpec(
+    control_id="MS-AC-01",
+    level=1,
+    domain="AC",
+    name="PublicRepository",
+    description="Repository must be publicly accessible",
+    passes=[
+        DeterministicPass(config_check=_create_api_check()),
+        ManualPass(
+            verification_steps=[
+                "Check repository visibility in Settings",
+                "Verify repository is not private",
+            ],
+        ),
+    ],
+))
+```
+
+### Combining TOML and Python passes
+
+A single control can have some passes defined in TOML and others in Python. The
+TOML-defined passes are loaded by the framework's config system, while Python
+passes are registered via `register_control()`. When both exist for the same
+control ID, the Python registration takes precedence (the registry skips
+duplicates by default).
+
+### How register_controls() triggers it all
+
+In your implementation class:
+
+```python
+def register_controls(self) -> None:
+    from .controls import level1  # noqa: F401
+```
+
+The `import level1` executes the module, which runs the `register_control()` calls
+at module level. The `# noqa: F401` suppresses the "imported but unused" warning
+because the import is only for its side effects.
+
+> **Reference**: See `packages/darnit-baseline/src/darnit_baseline/controls/level1.py`
+> for 24 real Python controls including API checks, file analysis, and pattern matching.
+
+---
+
+## 6. Remediation
+
+Remediation maps audit failures to automated fix actions. The registry tells the
+framework which function to call when a control fails.
+
+### Registry structure
+
+```python
+# src/darnit_mystandard/remediation/registry.py
+from typing import Any
+
+REMEDIATION_REGISTRY: dict[str, dict[str, Any]] = {
+    "security_policy": {
+        "description": "Create SECURITY.md with vulnerability reporting info",
+        "controls": ["MS-SEC-01", "MS-SEC-02"],
+        "function": "create_security_policy",
+        "safe": True,           # Safe to auto-apply without confirmation
+        "requires_api": False,  # Doesn't need GitHub API access
+    },
+    "branch_protection": {
+        "description": "Enable branch protection rules",
+        "controls": ["MS-AC-02", "MS-AC-03"],
+        "function": "enable_branch_protection",
+        "safe": True,
+        "requires_api": True,
+    },
+}
+```
+
+### Registry fields
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `description` | `str` | Human-readable description of the fix |
+| `controls` | `list[str]` | Control IDs this remediation addresses |
+| `function` | `str` | Name of the function to call |
+| `safe` | `bool` | Whether auto-application is safe |
+| `requires_api` | `bool` | Whether the fix needs API access |
+| `requires_context` | `list[dict]` | Context values needed before applying |
+
+### Context requirements
+
+Some remediations need user-confirmed context before they can run:
+
+```python
+"codeowners": {
+    "description": "Create CODEOWNERS file",
+    "controls": ["MS-GV-01"],
+    "function": "create_codeowners",
+    "safe": True,
+    "requires_api": False,
+    "requires_context": [{
+        "key": "maintainers",
+        "required": True,
+        "confidence_threshold": 0.9,
+        "prompt_if_auto_detected": True,
+        "warning": "Please confirm who should be code owners.",
+    }],
+},
+```
+
+### Remediation action functions
+
+The actual remediation functions are defined separately and invoked by name from the
+registry. They typically create or modify files in the repository:
+
+```python
+# src/darnit_mystandard/remediation/actions.py
+
+def create_security_policy(owner: str, repo: str, local_path: str, **kwargs) -> dict:
+    """Create a SECURITY.md file.
+
+    Returns:
+        dict with keys: success (bool), message (str), files_created (list)
+    """
+    import os
+
+    security_path = os.path.join(local_path, "SECURITY.md")
+    if os.path.exists(security_path):
+        return {
+            "success": True,
+            "message": "SECURITY.md already exists",
+            "files_created": [],
+        }
+
+    content = f"# Security Policy\n\nReport vulnerabilities to security@{owner}.example.com\n"
+    with open(security_path, "w") as f:
+        f.write(content)
+
+    return {
+        "success": True,
+        "message": "Created SECURITY.md",
+        "files_created": ["SECURITY.md"],
+    }
+```
+
+> **Reference**: See `packages/darnit-baseline/src/darnit_baseline/remediation/registry.py`
+> for the full OpenSSF Baseline remediation registry with 11 categories.
+
+---
+
+## 7. MCP Tools
+
+MCP tools are functions exposed to AI assistants (Claude, etc.) via the Model Context
+Protocol. There are two ways to provide them: built-in tools (TOML-only) and custom
+handler tools (requires Python).
+
+### Built-in MCP tools
+
+The framework provides generic built-in tools that work with any TOML-defined
+framework. Reference them with `builtin = "..."` instead of `handler = "..."`:
+
+```toml
+[mcp.tools.audit]
+builtin = "audit"
+description = "Run compliance audit"
+
+[mcp.tools.remediate]
+builtin = "remediate"
+description = "Auto-fix failing controls"
+
+[mcp.tools.list_controls]
+builtin = "list_controls"
+description = "List all controls by level"
+```
+
+Available built-in tools:
+
+| Name | What it does |
+|------|-------------|
+| `audit` | Load controls from this framework's TOML, run sieve on each, return formatted report |
+| `remediate` | Run audit, then apply declarative remediations (file_create, exec, api_call) for failures |
+| `list_controls` | Return JSON list of all controls grouped by level |
+
+Built-in tools automatically receive the framework name from the `[metadata]` section,
+so they know which TOML to load. They support `local_path`, `level`, and `dry_run`
+parameters.
+
+Use built-in tools when your framework only needs standard audit/remediate behavior.
+Use custom handler tools (below) when you need additional parameters, custom output
+formats, or specialized logic.
+
+### Custom handler tools
+
+If your implementation provides custom MCP tools, register them through the handler
+system.
+
+### The register_handlers() method
+
+This is an **optional** method on your implementation class. The framework checks
+for it with `hasattr()` before calling:
+
+```python
+# In implementation.py
+
+def register_handlers(self) -> None:
+    """Register MCP tool handlers."""
+    from darnit.core.handlers import get_handler_registry
+    from . import tools
+
+    registry = get_handler_registry()
+    registry.set_plugin_context(self.name)
+
+    # Register each handler by short name
+    registry.register_handler("audit_mystandard", tools.audit_mystandard)
+    registry.register_handler("list_checks", tools.list_checks)
+
+    # Clear plugin context when done
+    registry.set_plugin_context(None)
+```
+
+### How it works
+
+1. `set_plugin_context(self.name)` — tells the registry which plugin is registering
+   handlers (for audit trails)
+2. `register_handler("name", func)` — registers the function under a short name
+3. `set_plugin_context(None)` — clears the context
+
+Handlers can then be referenced in TOML by short name:
+
+```toml
+[mcp.tools.audit_mystandard]
+handler = "audit_mystandard"
+```
+
+Or by full module path:
+
+```toml
+[mcp.tools.audit_mystandard]
+handler = "darnit_mystandard.tools:audit_mystandard"
+```
+
+### Module allowlist security
+
+When handlers are referenced by `module:function` path in TOML, the registry only
+allows imports from approved module prefixes. The default allowlist in
+`packages/darnit/src/darnit/core/handlers.py`:
+
+```python
+ALLOWED_MODULE_PREFIXES = (
+    "darnit.",
+    "darnit_baseline.",
+    "darnit_testchecks.",
+)
+```
+
+If your implementation uses `module:function` references, you'll need to add your
+module prefix to this allowlist. Using short names (via `register_handler()`) avoids
+this restriction entirely.
+
+> **Reference**: See `packages/darnit-baseline/src/darnit_baseline/implementation.py:92`
+> for the OpenSSF Baseline's `register_handlers()` method and
+> `packages/darnit/src/darnit/core/handlers.py` for the full handler registry.
+
+---
+
+## 8. Testing
+
+### Protocol compliance tests
+
+Verify your implementation satisfies the `ComplianceImplementation` protocol:
+
+```python
+# tests/test_mystandard/test_implementation.py
+from darnit.core.plugin import ComplianceImplementation
+from darnit_mystandard.implementation import MyStandardImplementation
+
+
+def test_implements_protocol():
+    impl = MyStandardImplementation()
+    assert isinstance(impl, ComplianceImplementation)
+
+
+def test_properties():
+    impl = MyStandardImplementation()
+    assert impl.name == "mystandard"
+    assert impl.display_name == "My Compliance Standard"
+    assert impl.version == "0.1.0"
+    assert impl.spec_version == "MySpec v1.0"
+
+
+def test_get_framework_config_path():
+    impl = MyStandardImplementation()
+    path = impl.get_framework_config_path()
+    assert path is not None
+    assert path.name == "mystandard.toml"
+    # Verify the file actually exists at this path
+    assert path.exists(), f"TOML not found at {path}"
+```
+
+### Control unit tests
+
+Test individual controls by mocking external dependencies:
+
+```python
+# tests/test_mystandard/test_controls.py
+from darnit.sieve.models import CheckContext, PassOutcome
+
+
+def _make_context(tmp_path, **kwargs):
+    """Create a CheckContext for testing."""
+    return CheckContext(
+        owner="test-owner",
+        repo="test-repo",
+        local_path=str(tmp_path),
+        default_branch="main",
+        control_id="MS-DOC-01",
+        **kwargs,
+    )
+
+
+def test_readme_exists_pass(tmp_path):
+    """README check passes when README.md exists."""
+    (tmp_path / "README.md").write_text("# My Project")
+
+    from darnit.sieve.passes import DeterministicPass
+    check = DeterministicPass(file_must_exist=["README.md"])
+    result = check.execute(_make_context(tmp_path))
+
+    assert result.outcome == PassOutcome.PASS
+
+
+def test_readme_exists_fail(tmp_path):
+    """README check fails when no README exists."""
+    from darnit.sieve.passes import DeterministicPass
+    check = DeterministicPass(file_must_exist=["README.md", "README.rst"])
+    result = check.execute(_make_context(tmp_path))
+
+    assert result.outcome == PassOutcome.FAIL
+```
+
+### Testing API-based controls
+
+Mock the subprocess calls to avoid hitting real APIs:
+
+```python
+from unittest.mock import patch
+import json
+
+
+def test_api_check_pass(tmp_path):
+    """API check passes when API returns expected data."""
+    mock_response = json.dumps({"private": False})
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = mock_response
+
+        # Call your check function
+        from darnit_mystandard.controls.level1 import _create_api_check
+        check = _create_api_check()
+        result = check(_make_context(tmp_path))
+
+        assert result.outcome == PassOutcome.PASS
+```
+
+### Integration tests
+
+Test the full audit pipeline end-to-end:
+
+```python
+def test_full_audit(tmp_path):
+    """Run a complete audit against a test repository."""
+    # Set up minimal repo structure
+    (tmp_path / "README.md").write_text("# Test")
+    (tmp_path / "LICENSE").write_text("MIT License")
+    (tmp_path / "SECURITY.md").write_text("Report to security@test.com")
+
+    from darnit_mystandard.implementation import MyStandardImplementation
+    impl = MyStandardImplementation()
+
+    # Register controls
+    impl.register_controls()
+
+    # Get controls and verify they loaded
+    controls = impl.get_all_controls()
+    assert len(controls) > 0
+```
+
+### Test organization
+
+```
+tests/
+├── test_mystandard/
+│   ├── __init__.py
+│   ├── test_implementation.py   # Protocol compliance
+│   ├── test_controls.py         # Individual control logic
+│   ├── test_remediation.py      # Remediation actions
+│   └── conftest.py              # Shared fixtures
+└── integration/
+    └── test_full_audit.py       # End-to-end (may need network)
+```
+
+> **Reference**: See `tests/darnit_baseline/` for the OpenSSF Baseline test suite.
+
+---
+
+## 9. Common Pitfalls
+
+### Factory functions vs direct functions
+
+**Problem**: Passing a function directly to `DeterministicPass(config_check=...)` that
+doesn't match the expected signature `Callable[[CheckContext], PassResult]`.
+
+```python
+# WRONG: This passes the result of calling the function, not the function itself
+DeterministicPass(config_check=my_check(ctx))
+
+# WRONG: Direct function with wrong signature
+def my_check(owner, repo):  # Wrong signature!
+    ...
+DeterministicPass(config_check=my_check)
+
+# CORRECT: Factory returns a closure with the right signature
+def _create_my_check() -> Callable[[CheckContext], PassResult]:
+    def check(ctx: CheckContext) -> PassResult:
+        ...
+    return check
+
+DeterministicPass(config_check=_create_my_check())
+```
+
+Note that `DeterministicPass` also supports `api_check` with signature
+`Callable[[str, str], PassResult]` (owner, repo). Use `config_check` for the
+`CheckContext`-based signature, which gives you access to more context.
+
+### Module allowlist for dynamic loading
+
+If you reference handlers by `module:function` path in TOML, the handler registry
+enforces a module allowlist. Your module must start with an approved prefix
+(`darnit.`, `darnit_baseline.`, `darnit_testchecks.`). For new implementations,
+either:
+
+1. Use short names via `register_handler()` (recommended), or
+2. Add your module prefix to `HandlerRegistry.ALLOWED_MODULE_PREFIXES`
+
+### TOML path resolution
+
+`get_framework_config_path()` returns a path relative to `implementation.py`.
+Count the `parent` traversals carefully:
+
+```python
+# From: src/darnit_mystandard/implementation.py
+# To:   mystandard.toml (at package root)
+Path(__file__).parent  # → src/darnit_mystandard/
+             .parent   # → src/
+             .parent   # → darnit-mystandard/
+             / "mystandard.toml"
+```
+
+If this path is wrong, the framework silently falls back to an empty config.
+Add an assertion in your tests to catch this early.
+
+### Entry point naming conventions
+
+The entry point name in `pyproject.toml` becomes the key used to look up your
+implementation:
+
+```toml
+[project.entry-points."darnit.implementations"]
+mystandard = "darnit_mystandard:register"
+#  ↑ This name must match impl.name
+```
+
+If the entry point name doesn't match `impl.name`, discovery will still work but
+the implementation will be stored under `impl.name`, not the entry point name.
+Keep them consistent.
+
+### Control registration is global
+
+`register_control()` writes to a global registry. If multiple implementations
+register a control with the same ID, only the first one wins (duplicates are
+skipped). If you need to override, use the `overwrite=True` parameter:
+
+```python
+from darnit.sieve.registry import get_control_registry
+registry = get_control_registry()
+registry.register(my_spec, overwrite=True)
+```
+
+### Pass ordering validation
+
+The sieve `ControlSpec` validates that passes are in phase order
+(DETERMINISTIC → PATTERN → LLM → MANUAL). If passes are out of order,
+a warning is emitted. While not an error, out-of-order passes may produce
+unexpected results since the orchestrator assumes the order.
+
+---
+
+## 10. Quick Reference
+
+### ComplianceImplementation protocol
+
+```
+Properties:  name, display_name, version, spec_version
+Methods:     get_all_controls(), get_controls_by_level(level),
+             get_rules_catalog(), get_remediation_registry(),
+             get_framework_config_path(), register_controls()
+Optional:    register_handlers()
+```
+
+### Pass type cheat sheet
+
+| Need | TOML Pass | Python Class |
+|------|-----------|-------------|
+| File exists? | `[passes.deterministic]` + `file_must_exist` | `DeterministicPass(file_must_exist=[...])` |
+| API/CLI check? | `[passes.exec]` + `command` + `expr` | `DeterministicPass(config_check=...)` or `ExecPass(command=[...])` |
+| Regex in file? | `[passes.pattern]` + `file_patterns` + `content_patterns` | `PatternPass(file_patterns=[...], content_patterns={...})` |
+| AI analysis? | N/A (Python only) | `LLMPass(prompt_template="...", files_to_include=[...])` |
+| Human steps? | `[passes.manual]` + `steps` | `ManualPass(verification_steps=[...])` |
+
+### Key imports
+
+```python
+# Models
+from darnit.sieve.models import (
+    CheckContext, ControlSpec, PassOutcome, PassResult, VerificationPhase,
+)
+
+# Pass types
+from darnit.sieve.passes import (
+    DeterministicPass, PatternPass, LLMPass, ManualPass, ExecPass,
+)
+
+# Registration
+from darnit.sieve.registry import register_control
+
+# Protocol (for isinstance checks)
+from darnit.core.plugin import ComplianceImplementation, ControlSpec as PluginControlSpec
+
+# Handler registration
+from darnit.core.handlers import get_handler_registry
+```
+
+### Key file paths
+
+| What | Path |
+|------|------|
+| Protocol definition | `packages/darnit/src/darnit/core/plugin.py` |
+| Plugin discovery | `packages/darnit/src/darnit/core/discovery.py` |
+| Sieve models | `packages/darnit/src/darnit/sieve/models.py` |
+| Pass implementations | `packages/darnit/src/darnit/sieve/passes.py` |
+| Control registry | `packages/darnit/src/darnit/sieve/registry.py` |
+| Handler system | `packages/darnit/src/darnit/core/handlers.py` |
+| Reference implementation | `packages/darnit-baseline/src/darnit_baseline/implementation.py` |
+| Reference controls | `packages/darnit-baseline/src/darnit_baseline/controls/level1.py` |
+| Reference TOML | `packages/darnit-baseline/openssf-baseline.toml` |
+| Reference remediation | `packages/darnit-baseline/src/darnit_baseline/remediation/registry.py` |
+| Example implementation | `packages/darnit-example/src/darnit_example/implementation.py` |
+| Example TOML config | `packages/darnit-example/example-hygiene.toml` |
+| Example Python controls | `packages/darnit-example/src/darnit_example/controls/level1.py` |
+| Example tests | `tests/darnit_example/` |
+| Framework spec | `openspec/specs/framework-design/spec.md` |

--- a/openspec/changes/darnit-example/.openspec.yaml
+++ b/openspec/changes/darnit-example/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-06

--- a/openspec/changes/darnit-example/design.md
+++ b/openspec/changes/darnit-example/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The darnit framework has a well-defined `ComplianceImplementation` protocol and a mature reference implementation (`darnit-baseline` with 62 controls). However, `darnit-baseline` is large and tightly coupled to the OpenSSF specification, making it hard to use as a learning reference. The `IMPLEMENTATION_GUIDE.md` teaches the pattern with pseudocode but has no runnable companion. Plugin authors need a small, self-contained example they can copy, install, and modify.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a working, installable package that satisfies the `ComplianceImplementation` protocol
+- Demonstrate all major plugin features: TOML controls, Python controls, remediation, handler registration, testing
+- Keep the control set small enough (8 controls, 2 levels) that the entire package is readable in one sitting
+- Run fully offline (no API calls) so anyone can clone and test immediately
+- Validate that `docs/IMPLEMENTATION_GUIDE.md` is accurate and followable
+
+**Non-Goals:**
+- Replace or compete with `darnit-baseline` as a production implementation
+- Cover every framework feature (CEL expressions, locator configs, LLM pass, context-conditional controls)
+- Provide a real compliance standard — the "Project Hygiene Standard" is illustrative only
+- Modify framework internals beyond the minimum needed (`ALLOWED_MODULE_PREFIXES`)
+
+## Decisions
+
+### 1. Package location: `packages/darnit-example/` (workspace member)
+
+Place the package in the existing `packages/` directory alongside `darnit` and `darnit-baseline`. This makes it a workspace member automatically (via `packages/*` glob in `[tool.uv.workspace]`) and matches the established layout.
+
+**Alternative considered**: `docs/examples/darnit-example/` — rejected because workspace member status is needed for `uv sync` to install it as a real entry-point package, and `docs/examples/` packages are not workspace members.
+
+### 2. Control mix: 6 TOML + 2 Python
+
+Six TOML-only controls demonstrate that most checks need no Python code at all. Two Python controls show the factory function pattern (`_create_*_check() -> Callable`) and custom analyzers, which are the patterns new plugin authors are most likely to need. This ratio matches the real-world expectation: most controls are file-existence checks.
+
+**Alternative considered**: All 8 in TOML, or all 8 in Python — rejected because showing only one approach defeats the educational purpose.
+
+### 3. Control domain: "Project Hygiene" (file existence checks)
+
+All controls check for local files (README, LICENSE, .gitignore, CI config, etc.). This keeps the example runnable offline without GitHub API access, Docker, or other external dependencies.
+
+**Alternative considered**: API-based controls (like checking GitHub branch protection) — rejected because they require authentication and network access, adding friction for first-time users.
+
+### 4. Remediation: two simple file-create actions
+
+Only `create_readme` and `create_gitignore` are implemented as remediation actions. This covers the common pattern (create a missing file from a template) without bloating the example.
+
+### 5. Handler: single stub function
+
+One async handler (`example_hygiene_check`) demonstrates the registration pattern without implementing real MCP tool logic. The focus is on showing `register_handlers()` and `ALLOWED_MODULE_PREFIXES` integration.
+
+### 6. Rules catalog: inline dict in `implementation.py`
+
+The rules catalog is a simple `_RULES` dict in the implementation module rather than a separate `rules/catalog.py`. This is intentional — it keeps the example compact and avoids introducing the deprecated catalog pattern that `darnit-baseline` still carries.
+
+## Risks / Trade-offs
+
+- **Divergence from guide**: If `IMPLEMENTATION_GUIDE.md` evolves, the example could become stale → Mitigation: the guide now references the example, creating a natural reminder to keep both in sync.
+- **Workspace bloat**: Adding a third package increases `uv sync` time slightly → Acceptable for a small package with no extra dependencies.
+- **ALLOWED_MODULE_PREFIXES grows**: Each new plugin needs a prefix entry → This is a known limitation of the security allowlist approach; the example documents the pattern.
+- **Test isolation**: Python control registration uses a global registry; tests importing `level1.py` register controls permanently for the test session → Mitigated by using fresh `CheckContext` instances per test; registry pollution is harmless since control IDs are unique.

--- a/openspec/changes/darnit-example/proposal.md
+++ b/openspec/changes/darnit-example/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+No working, installable example exists that uses the modern `ComplianceImplementation` protocol. The existing examples all use outdated patterns: `darnit-testchecks` uses old adapter entry points, `docs/examples/python-framework/` redefines its own `CheckResult` and isn't installable, and `docs/examples/declarative-framework/` is pure TOML with no package structure. The recently written `docs/IMPLEMENTATION_GUIDE.md` teaches the modern pattern using a hypothetical "darnit-mystandard", but there's nothing to validate that the guide is actually followable. A real, minimal implementation would both validate the guide and serve as a copy-paste starting point for plugin authors.
+
+## What Changes
+
+- Add new `packages/darnit-example/` workspace package implementing a "Project Hygiene Standard" with 8 controls across 2 levels
+- Define 6 TOML-only controls and 2 Python controls demonstrating the factory function pattern, custom analyzers, and glob matching
+- Include remediation actions, handler registration, and a full test suite
+- Add `"darnit_example."` to `ALLOWED_MODULE_PREFIXES` in the framework's handler registry
+- Add the package to root `pyproject.toml` workspace sources and ruff isort config
+- Update `docs/IMPLEMENTATION_GUIDE.md` to reference `darnit-example` as a companion example
+
+## Capabilities
+
+### New Capabilities
+- `example-plugin`: A minimal, installable darnit implementation package demonstrating TOML controls, Python controls, remediation, handler registration, and testing
+
+### Modified Capabilities
+
+_(none — no existing spec-level requirements change)_
+
+## Impact
+
+- **New package**: `packages/darnit-example/` with entry points `darnit.implementations` and `darnit.frameworks`
+- **Framework change**: `packages/darnit/src/darnit/core/handlers.py` — one line added to `ALLOWED_MODULE_PREFIXES`
+- **Root config**: `pyproject.toml` — workspace source and ruff isort additions
+- **Documentation**: `docs/IMPLEMENTATION_GUIDE.md` — callout box and key-file-paths table updates
+- **Tests**: `tests/darnit_example/` — new test directory (no existing tests affected)

--- a/openspec/changes/darnit-example/specs/example-plugin/spec.md
+++ b/openspec/changes/darnit-example/specs/example-plugin/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: Package satisfies ComplianceImplementation protocol
+The `darnit-example` package SHALL export a `register()` function that returns an object satisfying the `ComplianceImplementation` protocol. The implementation SHALL pass `isinstance(register(), ComplianceImplementation)`.
+
+#### Scenario: Protocol compliance check
+- **WHEN** `register()` is called
+- **THEN** the returned object satisfies all required protocol properties (`name`, `display_name`, `version`, `spec_version`) and methods (`get_all_controls`, `get_controls_by_level`, `get_rules_catalog`, `get_remediation_registry`, `get_framework_config_path`, `register_controls`)
+
+#### Scenario: Entry point discovery
+- **WHEN** the package is installed via `uv sync`
+- **THEN** darnit's plugin discovery system finds it under the `darnit.implementations` entry point group with key `example-hygiene`
+
+### Requirement: Package defines 8 controls across 2 levels
+The implementation SHALL define exactly 8 controls: 6 at level 1 and 2 at level 2. Control IDs SHALL follow the `PH-{DOMAIN}-NN` format.
+
+#### Scenario: Level 1 controls
+- **WHEN** `get_controls_by_level(1)` is called
+- **THEN** 6 controls are returned with IDs `PH-DOC-01`, `PH-DOC-02`, `PH-DOC-03`, `PH-SEC-01`, `PH-CFG-01`, `PH-CFG-02`
+
+#### Scenario: Level 2 controls
+- **WHEN** `get_controls_by_level(2)` is called
+- **THEN** 2 controls are returned with IDs `PH-QA-01`, `PH-CI-01`
+
+#### Scenario: Total control count
+- **WHEN** `get_all_controls()` is called
+- **THEN** exactly 8 `ControlSpec` instances are returned
+
+### Requirement: TOML-defined controls use file_must_exist pass
+Controls `PH-DOC-01`, `PH-DOC-02`, `PH-SEC-01`, `PH-CFG-01`, `PH-CFG-02`, and `PH-QA-01` SHALL be defined declaratively in the TOML configuration file using `file_must_exist` deterministic passes.
+
+#### Scenario: TOML control for README
+- **WHEN** the sieve evaluates `PH-DOC-01` against a directory containing `README.md`
+- **THEN** the deterministic pass returns `PASS`
+
+#### Scenario: TOML control for missing file
+- **WHEN** the sieve evaluates `PH-CFG-01` against a directory without `.gitignore`
+- **THEN** the deterministic pass returns `FAIL`
+
+### Requirement: Python controls use factory function pattern
+Controls `PH-DOC-03` and `PH-CI-01` SHALL be defined in Python using the factory function pattern (`_create_*_check() -> Callable[[CheckContext], PassResult]`) and registered via `register_control()`.
+
+#### Scenario: README description check passes
+- **WHEN** `PH-DOC-03` is evaluated against a README with substantive content (>20 chars beyond title)
+- **THEN** the deterministic pass returns `PASS`
+
+#### Scenario: README description check fails for title-only
+- **WHEN** `PH-DOC-03` is evaluated against a README containing only a heading
+- **THEN** the deterministic pass returns `FAIL`
+
+#### Scenario: CI config detection via glob
+- **WHEN** `PH-CI-01` is evaluated against a directory with `.github/workflows/ci.yml`
+- **THEN** the deterministic pass returns `PASS`
+
+#### Scenario: CI config missing
+- **WHEN** `PH-CI-01` is evaluated against a directory with no CI configuration files
+- **THEN** the deterministic pass returns `FAIL`
+
+### Requirement: Multi-phase sieve demonstration
+Control `PH-SEC-01` SHALL define deterministic, pattern, and manual passes to demonstrate the multi-phase sieve pipeline. Control `PH-DOC-03` SHALL define deterministic, pattern (custom analyzer), and manual passes.
+
+#### Scenario: Security policy found by file existence
+- **WHEN** `PH-SEC-01` is evaluated and `SECURITY.md` exists
+- **THEN** the deterministic pass returns `PASS` and subsequent passes are not needed
+
+#### Scenario: README quality pattern analysis
+- **WHEN** `PH-DOC-03` pattern pass runs against a README with "Installation" and "Usage" sections
+- **THEN** the pattern pass returns `PASS`
+
+### Requirement: Remediation actions create missing files
+The package SHALL provide remediation actions `create_readme` and `create_gitignore` that create template files. Both SHALL support `dry_run` mode and SHALL skip creation if the target file already exists.
+
+#### Scenario: Dry run does not write
+- **WHEN** `create_readme(path, dry_run=True)` is called
+- **THEN** no file is created and the result status is `"dry_run"`
+
+#### Scenario: File creation
+- **WHEN** `create_readme(path, dry_run=False)` is called on a directory without README.md
+- **THEN** a README.md file is created with the project name as title
+
+#### Scenario: Skip existing file
+- **WHEN** `create_gitignore(path, dry_run=False)` is called on a directory that already has `.gitignore`
+- **THEN** the existing file is not modified and the result status is `"skipped"`
+
+### Requirement: Handler registration with plugin context
+The implementation SHALL provide a `register_handlers()` method that registers at least one handler with the framework's handler registry. The handler SHALL be tagged with the plugin name `"example-hygiene"`.
+
+#### Scenario: Handler appears in registry
+- **WHEN** `register_handlers()` is called
+- **THEN** the handler `"example_hygiene_check"` is present in the handler registry with plugin context `"example-hygiene"`
+
+### Requirement: Framework config path resolves to existing file
+`get_framework_config_path()` SHALL return a `Path` object pointing to `example-hygiene.toml` that exists on disk.
+
+#### Scenario: Config path exists
+- **WHEN** `get_framework_config_path()` is called
+- **THEN** the returned path has filename `example-hygiene.toml` and `path.exists()` is `True`
+
+### Requirement: Framework integration with minimal changes
+The package SHALL integrate into the darnit workspace with only two framework-side changes: adding `"darnit_example."` to `ALLOWED_MODULE_PREFIXES` in handlers.py, and adding `darnit-example` to the root `pyproject.toml` workspace sources and ruff config.
+
+#### Scenario: Module prefix allowlisted
+- **WHEN** handler resolution attempts to load a `darnit_example.*` module
+- **THEN** the security allowlist permits the import
+
+### Requirement: Documentation cross-references
+The package README SHALL map each section of `docs/IMPLEMENTATION_GUIDE.md` to its corresponding example file. The implementation guide SHALL reference `packages/darnit-example/` as a working companion example.
+
+#### Scenario: Guide references example
+- **WHEN** a reader opens `docs/IMPLEMENTATION_GUIDE.md`
+- **THEN** a callout after Prerequisites points to `packages/darnit-example/` and the Key file paths table includes example package entries

--- a/openspec/changes/darnit-example/tasks.md
+++ b/openspec/changes/darnit-example/tasks.md
@@ -1,0 +1,56 @@
+## 1. Package Skeleton
+
+- [x] 1.1 Create `packages/darnit-example/pyproject.toml` with entry points for `darnit.implementations` and `darnit.frameworks`
+- [x] 1.2 Create `src/darnit_example/__init__.py` with `register()` and `get_framework_path()` functions
+- [x] 1.3 Create `src/darnit_example/implementation.py` with `ExampleHygieneImplementation` class satisfying `ComplianceImplementation` protocol
+- [x] 1.4 Create empty `__init__.py` files for `controls/` and `remediation/` subpackages
+
+## 2. TOML Configuration
+
+- [x] 2.1 Create `example-hygiene.toml` with metadata section matching implementation properties
+- [x] 2.2 Define templates for README and .gitignore remediation
+- [x] 2.3 Define 6 TOML controls (PH-DOC-01, PH-DOC-02, PH-SEC-01, PH-CFG-01, PH-CFG-02, PH-QA-01) using `file_must_exist` deterministic passes
+- [x] 2.4 Add multi-phase passes to PH-SEC-01 (deterministic + pattern + manual)
+- [x] 2.5 Add context definition for project_name
+
+## 3. Python Controls
+
+- [x] 3.1 Create `controls/level1.py` with PH-DOC-03 (ReadmeHasDescription) using factory function pattern and custom pattern analyzer
+- [x] 3.2 Create PH-CI-01 (CIConfigExists) with glob-based CI config detection
+- [x] 3.3 Register both controls via `register_control()` with appropriate pass lists
+
+## 4. Remediation
+
+- [x] 4.1 Create `remediation/registry.py` with `REMEDIATION_REGISTRY` mapping controls to fix functions
+- [x] 4.2 Create `remediation/actions.py` with `create_readme()` and `create_gitignore()` supporting dry_run mode
+
+## 5. Handler Registration
+
+- [x] 5.1 Create `tools.py` with stub `example_hygiene_check` async handler
+- [x] 5.2 Implement `register_handlers()` in implementation class
+
+## 6. Framework Integration
+
+- [x] 6.1 Add `"darnit_example."` to `ALLOWED_MODULE_PREFIXES` in `packages/darnit/src/darnit/core/handlers.py`
+- [x] 6.2 Add `darnit-example = { workspace = true }` to root `pyproject.toml` `[tool.uv.sources]`
+- [x] 6.3 Add `"darnit_example"` to `tool.ruff.lint.isort.known-first-party`
+
+## 7. Tests
+
+- [x] 7.1 Create `tests/darnit_example/conftest.py` with `make_context`, `empty_project`, and `full_project` fixtures
+- [x] 7.2 Create `test_implementation.py` with protocol compliance, property, control count, handler, and register() tests
+- [x] 7.3 Create `test_controls.py` with pass/fail tests for PH-DOC-03 and PH-CI-01
+- [x] 7.4 Create `test_remediation.py` with dry_run, create, skip, and content tests for both actions
+
+## 8. Documentation
+
+- [x] 8.1 Create `packages/darnit-example/README.md` with control table and guide-section mapping
+- [x] 8.2 Update `docs/IMPLEMENTATION_GUIDE.md` Prerequisites section with callout to example package
+- [x] 8.3 Add darnit-example entries to Key file paths table in IMPLEMENTATION_GUIDE.md
+
+## 9. Validation
+
+- [x] 9.1 Run `uv sync` to verify package installs successfully
+- [x] 9.2 Run `uv run ruff check .` with zero errors
+- [x] 9.3 Run `uv run pytest tests/darnit_example/ -v` with all tests passing
+- [x] 9.4 Run `uv run pytest tests/ --ignore=tests/integration/ -q` to confirm no regressions

--- a/openspec/changes/implementation-guide/.openspec.yaml
+++ b/openspec/changes/implementation-guide/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-06

--- a/packages/darnit-example/README.md
+++ b/packages/darnit-example/README.md
@@ -1,0 +1,56 @@
+# darnit-example
+
+A working example of a [darnit](../darnit/) compliance plugin that implements a
+simple "Project Hygiene Standard" with 8 controls across 2 maturity levels.
+
+This package is the companion reference implementation for
+[docs/IMPLEMENTATION_GUIDE.md](../../docs/IMPLEMENTATION_GUIDE.md). Every pattern
+described in that guide has a concrete counterpart here.
+
+## Controls
+
+### Level 1 — Basic Project Setup (6 controls)
+
+| ID | Name | Defined In | Description |
+|----|------|-----------|-------------|
+| `PH-DOC-01` | ReadmeExists | TOML | Project has a README file |
+| `PH-DOC-02` | LicenseExists | TOML | Project has a LICENSE file |
+| `PH-DOC-03` | ReadmeHasDescription | Python | README contains a description |
+| `PH-SEC-01` | SecurityPolicyExists | TOML | Project has a security policy |
+| `PH-CFG-01` | GitignoreExists | TOML | Project has a .gitignore |
+| `PH-CFG-02` | EditorConfigExists | TOML | Project has an .editorconfig |
+
+### Level 2 — Quality Practices (2 controls)
+
+| ID | Name | Defined In | Description |
+|----|------|-----------|-------------|
+| `PH-QA-01` | ContributingGuideExists | TOML | Project has a CONTRIBUTING guide |
+| `PH-CI-01` | CIConfigExists | Python | Project has CI/CD configuration |
+
+## Mapping to IMPLEMENTATION_GUIDE.md
+
+| Guide Section | Example File |
+|--------------|-------------|
+| Step 1: Package skeleton | `pyproject.toml`, `src/darnit_example/__init__.py` |
+| Step 2: Implementation class | `src/darnit_example/implementation.py` |
+| Step 3: TOML config | `example-hygiene.toml` |
+| Step 4: Python controls | `src/darnit_example/controls/level1.py` |
+| Step 5: Remediation | `src/darnit_example/remediation/` |
+| Step 6: Handler registration | `src/darnit_example/tools.py` |
+| Step 7: Testing | `tests/darnit_example/` |
+
+## Design Choices
+
+- **6 TOML + 2 Python controls** — shows that most checks need no Python code
+- **PH-SEC-01 has 3 pass types** — demonstrates the multi-phase sieve
+  (deterministic → pattern → manual)
+- **PH-DOC-03 uses a custom analyzer** — shows factory function pattern
+- **PH-CI-01 uses glob patterns** — shows dynamic file matching in Python
+- **No API checks** — keeps the example runnable offline
+
+## Running Tests
+
+```bash
+# From the repository root
+uv run pytest tests/darnit_example/ -v
+```

--- a/packages/darnit-example/example-hygiene.toml
+++ b/packages/darnit-example/example-hygiene.toml
@@ -1,0 +1,409 @@
+# Project Hygiene Standard Framework Definition
+# Example darnit implementation with 8 controls across 2 maturity levels.
+#
+# This file accompanies the darnit-example package and demonstrates how to
+# define controls declaratively in TOML. See docs/IMPLEMENTATION_GUIDE.md.
+
+[metadata]
+name = "example-hygiene"
+display_name = "Project Hygiene Standard (Example)"
+version = "0.1.0"
+schema_version = "0.1.0-alpha"
+spec_version = "PH v1.0"
+description = "Example project hygiene controls for open source projects"
+
+[defaults]
+check_adapter = "builtin"
+remediation_adapter = "builtin"
+
+# =============================================================================
+# Templates for Remediation
+# =============================================================================
+
+[templates.readme_standard]
+description = "Standard README.md template for new projects"
+content = """# $REPO
+
+A brief description of what this project does.
+
+## Installation
+
+```bash
+# Add installation instructions here
+```
+
+## Usage
+
+```bash
+# Add usage examples here
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute.
+
+## License
+
+See [LICENSE](LICENSE) for details.
+"""
+
+[templates.gitignore_standard]
+description = "Standard .gitignore template"
+content = """# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Byte-compiled / optimized files
+__pycache__/
+*.py[cod]
+*$py.class
+"""
+
+[templates.license_mit]
+description = "MIT License template"
+content = """MIT License
+
+Copyright (c) $YEAR $OWNER
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+[templates.security_policy]
+description = "Basic security policy template"
+content = """# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, please open an issue or email the maintainers.
+
+We will acknowledge receipt within 48 hours and provide a timeline for a fix.
+"""
+
+[templates.editorconfig_standard]
+description = "Standard .editorconfig template"
+content = """root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+"""
+
+[templates.contributing_standard]
+description = "Basic CONTRIBUTING guide template"
+content = """# Contributing to $REPO
+
+## How to Contribute
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Open a pull request
+
+## Code of Conduct
+
+Be respectful and constructive in all interactions.
+"""
+
+[templates.ci_github_actions]
+description = "Minimal GitHub Actions CI workflow"
+content = """name: CI
+on: [push, pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+"""
+
+# =============================================================================
+# Context Definitions
+# =============================================================================
+
+[context.project_name]
+type = "string"
+prompt = "What is the project name?"
+hint = "Used for README template rendering"
+affects = ["PH-DOC-01"]
+store_as = "project.name"
+auto_detect = true
+required = false
+
+# =============================================================================
+# Level 1 Controls — Basic Project Setup (6 controls)
+# =============================================================================
+
+# --- PH-DOC-01: ReadmeExists (TOML-defined) ---
+[controls."PH-DOC-01"]
+name = "ReadmeExists"
+description = "Project has a README file"
+tags = { level = 1, domain = "DOC", documentation = true }
+help_md = """Every project should have a README explaining what it does.
+
+**Remediation:**
+1. Create a README.md in the project root
+2. Include project name, description, and basic usage
+"""
+
+[controls."PH-DOC-01".passes]
+deterministic = { file_must_exist = [
+    "README.md",
+    "README",
+    "README.rst",
+    "README.txt",
+]}
+
+[controls."PH-DOC-01".passes.manual]
+steps = [
+    "Check that a README file exists in the project root",
+    "Verify it contains meaningful content (not just a title)",
+]
+
+[controls."PH-DOC-01".on_pass]
+project_update = { "documentation.readme.path" = "README.md" }
+
+[controls."PH-DOC-01".remediation]
+handler = "create_readme"
+safe = true
+dry_run_supported = true
+
+[controls."PH-DOC-01".remediation.file_create]
+path = "README.md"
+template = "readme_standard"
+overwrite = false
+
+[controls."PH-DOC-01".remediation.project_update]
+set = { "documentation.readme.path" = "README.md" }
+
+# --- PH-DOC-02: LicenseExists (TOML-defined) ---
+[controls."PH-DOC-02"]
+name = "LicenseExists"
+description = "Project has a LICENSE file"
+tags = { level = 1, domain = "DOC", documentation = true, legal = true }
+help_md = """A LICENSE file clarifies how others can use the project.
+
+**Remediation:**
+1. Choose a license (e.g., MIT, Apache-2.0, GPL)
+2. Create a LICENSE file in the project root
+"""
+
+[controls."PH-DOC-02".passes]
+deterministic = { file_must_exist = [
+    "LICENSE",
+    "LICENSE.md",
+    "LICENSE.txt",
+    "LICENCE",
+    "LICENCE.md",
+]}
+
+[controls."PH-DOC-02".passes.manual]
+steps = [
+    "Check that a LICENSE file exists in the project root",
+    "Verify it contains a recognized open source license",
+]
+
+[controls."PH-DOC-02".remediation]
+safe = true
+dry_run_supported = true
+
+[controls."PH-DOC-02".remediation.file_create]
+path = "LICENSE"
+template = "license_mit"
+overwrite = false
+
+[controls."PH-DOC-02".remediation.project_update]
+set = { "legal.license.path" = "LICENSE" }
+
+# --- PH-DOC-03: ReadmeHasDescription ---
+# This control is Python-defined in controls/level1.py
+# (demonstrates multi-phase sieve with custom analyzer)
+
+# --- PH-SEC-01: SecurityPolicyExists (TOML-defined, multi-phase) ---
+[controls."PH-SEC-01"]
+name = "SecurityPolicyExists"
+description = "Project has a security policy for vulnerability reporting"
+tags = { level = 1, domain = "SEC", security = true }
+help_md = """A SECURITY.md tells users how to report vulnerabilities.
+
+**Remediation:**
+1. Create SECURITY.md in the project root or .github/ directory
+2. Include instructions for reporting vulnerabilities
+3. Specify a response timeline
+"""
+
+[controls."PH-SEC-01".passes]
+deterministic = { file_must_exist = [
+    "SECURITY.md",
+    ".github/SECURITY.md",
+    "docs/SECURITY.md",
+]}
+
+# Pattern pass: also check if README mentions security reporting
+[controls."PH-SEC-01".passes.pattern]
+file_patterns = ["README.md", "README.rst", "README"]
+
+[controls."PH-SEC-01".passes.pattern.content_patterns]
+security_section = "(?i)(security|vulnerability|report.*vulnerabilit)"
+
+[controls."PH-SEC-01".passes.manual]
+steps = [
+    "Look for SECURITY.md in the repository root or .github/ directory",
+    "Verify it contains vulnerability reporting instructions",
+    "Check for a security contact or email address",
+]
+
+[controls."PH-SEC-01".on_pass]
+project_update = { "security.policy.path" = "SECURITY.md" }
+
+[controls."PH-SEC-01".remediation]
+safe = true
+dry_run_supported = true
+
+[controls."PH-SEC-01".remediation.file_create]
+path = "SECURITY.md"
+template = "security_policy"
+overwrite = false
+
+[controls."PH-SEC-01".remediation.project_update]
+set = { "security.policy.path" = "SECURITY.md" }
+
+# --- PH-CFG-01: GitignoreExists (TOML-defined) ---
+[controls."PH-CFG-01"]
+name = "GitignoreExists"
+description = "Project has a .gitignore file"
+tags = { level = 1, domain = "CFG", configuration = true }
+help_md = """A .gitignore prevents committing build artifacts and secrets.
+
+**Remediation:**
+1. Create a .gitignore in the project root
+2. Add patterns for your language/framework
+"""
+
+[controls."PH-CFG-01".passes]
+deterministic = { file_must_exist = [".gitignore"] }
+
+[controls."PH-CFG-01".remediation]
+handler = "create_gitignore"
+safe = true
+dry_run_supported = true
+
+[controls."PH-CFG-01".remediation.file_create]
+path = ".gitignore"
+template = "gitignore_standard"
+overwrite = false
+
+# --- PH-CFG-02: EditorConfigExists (TOML-defined) ---
+[controls."PH-CFG-02"]
+name = "EditorConfigExists"
+description = "Project has an .editorconfig file"
+tags = { level = 1, domain = "CFG", configuration = true }
+help_md = """An .editorconfig ensures consistent formatting across editors.
+
+**Remediation:**
+1. Create an .editorconfig in the project root
+2. Define indent style, charset, and line endings
+"""
+
+[controls."PH-CFG-02".passes]
+deterministic = { file_must_exist = [".editorconfig"] }
+
+[controls."PH-CFG-02".remediation]
+safe = true
+dry_run_supported = true
+
+[controls."PH-CFG-02".remediation.file_create]
+path = ".editorconfig"
+template = "editorconfig_standard"
+overwrite = false
+
+# =============================================================================
+# Level 2 Controls — Quality Practices (2 controls)
+# =============================================================================
+
+# --- PH-QA-01: ContributingGuideExists (TOML-defined) ---
+[controls."PH-QA-01"]
+name = "ContributingGuideExists"
+description = "Project has a CONTRIBUTING guide"
+tags = { level = 2, domain = "QA", documentation = true, quality = true }
+help_md = """A CONTRIBUTING guide helps new contributors get started.
+
+**Remediation:**
+1. Create CONTRIBUTING.md in the project root
+2. Include setup instructions, coding standards, and PR process
+"""
+
+[controls."PH-QA-01".passes]
+deterministic = { file_must_exist = [
+    "CONTRIBUTING.md",
+    "CONTRIBUTING",
+    "CONTRIBUTING.rst",
+    ".github/CONTRIBUTING.md",
+]}
+
+[controls."PH-QA-01".remediation]
+safe = true
+dry_run_supported = true
+
+[controls."PH-QA-01".remediation.file_create]
+path = "CONTRIBUTING.md"
+template = "contributing_standard"
+overwrite = false
+
+[controls."PH-QA-01".remediation.project_update]
+set = { "governance.contributing.path" = "CONTRIBUTING.md" }
+
+# --- PH-CI-01: CIConfigExists ---
+# This control is Python-defined in controls/level1.py
+# (demonstrates glob pattern checking in Python)
+
+# =============================================================================
+# MCP Server Configuration
+# =============================================================================
+
+[mcp]
+name = "example-hygiene"
+description = "Project Hygiene Standard compliance tools (example)"
+
+[mcp.tools.example_hygiene_check]
+handler = "example_hygiene_check"
+description = "Run a project hygiene audit. Checks all PH controls via the sieve pipeline and returns a markdown report with pass/fail status and remediation guidance."
+
+[mcp.tools.remediate_hygiene]
+handler = "remediate_hygiene"
+description = "Auto-fix failing hygiene controls by creating missing files from TOML-defined templates. Run example_hygiene_check first to see what will be fixed. Use dry_run=true (default) to preview changes."

--- a/packages/darnit-example/pyproject.toml
+++ b/packages/darnit-example/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "darnit-example"
+version = "0.1.0"
+description = "Example 'Project Hygiene Standard' implementation for darnit"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "darnit>=0.1.0",
+]
+
+[project.entry-points."darnit.implementations"]
+example-hygiene = "darnit_example:register"
+
+[project.entry-points."darnit.frameworks"]
+example-hygiene = "darnit_example:get_framework_path"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/darnit_example"]

--- a/packages/darnit-example/src/darnit_example/__init__.py
+++ b/packages/darnit-example/src/darnit_example/__init__.py
@@ -1,0 +1,51 @@
+"""darnit-example - Example 'Project Hygiene Standard' implementation for darnit.
+
+This package demonstrates how to build a darnit compliance plugin using the
+modern ComplianceImplementation protocol. It implements a simple "Project
+Hygiene Standard" with 8 controls across 2 maturity levels.
+
+See packages/darnit-example/README.md and docs/IMPLEMENTATION_GUIDE.md for
+a walkthrough of how this package is structured.
+
+Usage:
+    # Automatic registration via entry points
+    from darnit.core.discovery import discover_implementations
+    implementations = discover_implementations()
+    hygiene = implementations.get("example-hygiene")
+
+    # Direct access
+    from darnit_example import register
+    implementation = register()
+
+    # Framework path for declarative config system
+    from darnit_example import get_framework_path
+    path = get_framework_path()  # Returns Path to example-hygiene.toml
+"""
+
+__version__ = "0.1.0"
+
+from pathlib import Path
+
+
+def get_framework_path() -> Path | None:
+    """Get the path to the example hygiene framework TOML file.
+
+    Returns:
+        Path: Absolute path to example-hygiene.toml, or None if not found.
+    """
+    from .implementation import ExampleHygieneImplementation
+
+    return ExampleHygieneImplementation().get_framework_config_path()
+
+
+def register():
+    """Register the Example Hygiene implementation with darnit.
+
+    This function is called by darnit's plugin discovery system via entry points.
+
+    Returns:
+        ExampleHygieneImplementation: The registered implementation instance.
+    """
+    from .implementation import ExampleHygieneImplementation
+
+    return ExampleHygieneImplementation()

--- a/packages/darnit-example/src/darnit_example/controls/__init__.py
+++ b/packages/darnit-example/src/darnit_example/controls/__init__.py
@@ -1,0 +1,1 @@
+"""Python-defined controls for the Project Hygiene Standard."""

--- a/packages/darnit-example/src/darnit_example/controls/level1.py
+++ b/packages/darnit-example/src/darnit_example/controls/level1.py
@@ -1,0 +1,215 @@
+"""Python-defined controls for the Project Hygiene Standard.
+
+This module defines 2 controls that need Python logic beyond what TOML can express:
+- PH-DOC-03: ReadmeHasDescription (custom analyzer for content quality)
+- PH-CI-01: CIConfigExists (glob pattern matching for CI configs)
+"""
+
+import glob as glob_module
+import os
+import re
+from collections.abc import Callable
+
+from darnit.sieve.models import (
+    CheckContext,
+    ControlSpec,
+    PassOutcome,
+    PassResult,
+    VerificationPhase,
+)
+from darnit.sieve.passes import DeterministicPass, ManualPass, PatternPass
+from darnit.sieve.registry import register_control
+
+# =============================================================================
+# PH-DOC-03: ReadmeHasDescription
+# =============================================================================
+
+
+def _create_readme_description_check() -> Callable[[CheckContext], PassResult]:
+    """Create a check that verifies the README has substantive content.
+
+    Returns PASS if the README has at least one paragraph of text (>20 chars)
+    beyond just the title line.
+    """
+
+    def check(ctx: CheckContext) -> PassResult:
+        readme_names = ["README.md", "README", "README.rst", "README.txt"]
+        for name in readme_names:
+            filepath = os.path.join(ctx.local_path, name)
+            if os.path.exists(filepath):
+                try:
+                    with open(filepath, encoding="utf-8", errors="ignore") as f:
+                        content = f.read()
+                except OSError:
+                    continue
+
+                # Strip the title line (first heading) and check remaining content
+                lines = content.strip().splitlines()
+                non_title_lines = []
+                for line in lines:
+                    stripped = line.strip()
+                    # Skip headings, blank lines, and decorators
+                    if stripped.startswith("#") or stripped == "" or re.match(r"^[=\-]+$", stripped):
+                        continue
+                    non_title_lines.append(stripped)
+
+                body_text = " ".join(non_title_lines)
+                if len(body_text) > 20:
+                    return PassResult(
+                        phase=VerificationPhase.DETERMINISTIC,
+                        outcome=PassOutcome.PASS,
+                        message=f"README ({name}) contains a description ({len(body_text)} chars)",
+                        evidence={"file": name, "body_length": len(body_text)},
+                    )
+                else:
+                    return PassResult(
+                        phase=VerificationPhase.DETERMINISTIC,
+                        outcome=PassOutcome.FAIL,
+                        message=f"README ({name}) exists but has no substantive description",
+                        evidence={"file": name, "body_length": len(body_text)},
+                    )
+
+        return PassResult(
+            phase=VerificationPhase.DETERMINISTIC,
+            outcome=PassOutcome.FAIL,
+            message="No README file found",
+        )
+
+    return check
+
+
+def _create_readme_quality_analyzer() -> Callable[[CheckContext], PassResult]:
+    """Create a pattern-phase analyzer that checks README quality heuristics.
+
+    Checks for common sections like Installation, Usage, etc.
+    """
+
+    def analyze(ctx: CheckContext) -> PassResult:
+        readme_path = os.path.join(ctx.local_path, "README.md")
+        if not os.path.exists(readme_path):
+            return PassResult(
+                phase=VerificationPhase.PATTERN,
+                outcome=PassOutcome.INCONCLUSIVE,
+                message="No README.md to analyze",
+            )
+
+        try:
+            with open(readme_path, encoding="utf-8", errors="ignore") as f:
+                content = f.read().lower()
+        except OSError:
+            return PassResult(
+                phase=VerificationPhase.PATTERN,
+                outcome=PassOutcome.INCONCLUSIVE,
+                message="Could not read README.md",
+            )
+
+        # Check for common helpful sections
+        sections_found = []
+        for section in ["install", "usage", "getting started", "contributing", "license"]:
+            if section in content:
+                sections_found.append(section)
+
+        if len(sections_found) >= 2:
+            return PassResult(
+                phase=VerificationPhase.PATTERN,
+                outcome=PassOutcome.PASS,
+                message=f"README has good structure with sections: {', '.join(sections_found)}",
+                evidence={"sections_found": sections_found},
+            )
+
+        return PassResult(
+            phase=VerificationPhase.PATTERN,
+            outcome=PassOutcome.INCONCLUSIVE,
+            message=f"README has limited structure (found: {sections_found})",
+            evidence={"sections_found": sections_found},
+        )
+
+    return analyze
+
+
+register_control(
+    ControlSpec(
+        control_id="PH-DOC-03",
+        level=1,
+        domain="DOC",
+        name="ReadmeHasDescription",
+        description="README contains a project description",
+        passes=[
+            DeterministicPass(config_check=_create_readme_description_check()),
+            PatternPass(custom_analyzer=_create_readme_quality_analyzer()),
+            ManualPass(
+                verification_steps=[
+                    "Open the README file",
+                    "Verify it contains a meaningful project description",
+                    "Check that it explains what the project does and how to use it",
+                ]
+            ),
+        ],
+    )
+)
+
+
+# =============================================================================
+# PH-CI-01: CIConfigExists
+# =============================================================================
+
+
+def _create_ci_config_check() -> Callable[[CheckContext], PassResult]:
+    """Create a check that looks for CI/CD configuration files.
+
+    Searches for common CI providers: GitHub Actions, GitLab CI, CircleCI,
+    Travis CI, Jenkins, Azure Pipelines.
+    """
+
+    def check(ctx: CheckContext) -> PassResult:
+        ci_patterns = [
+            ".github/workflows/*.yml",
+            ".github/workflows/*.yaml",
+            ".gitlab-ci.yml",
+            ".circleci/config.yml",
+            ".travis.yml",
+            "Jenkinsfile",
+            "azure-pipelines.yml",
+            ".buildkite/pipeline.yml",
+        ]
+
+        for pattern in ci_patterns:
+            full_pattern = os.path.join(ctx.local_path, pattern)
+            matches = glob_module.glob(full_pattern)
+            if matches:
+                rel_paths = [os.path.relpath(m, ctx.local_path) for m in matches]
+                return PassResult(
+                    phase=VerificationPhase.DETERMINISTIC,
+                    outcome=PassOutcome.PASS,
+                    message=f"CI configuration found: {rel_paths[0]}",
+                    evidence={"ci_files": rel_paths, "pattern": pattern},
+                )
+
+        return PassResult(
+            phase=VerificationPhase.DETERMINISTIC,
+            outcome=PassOutcome.FAIL,
+            message="No CI/CD configuration found",
+            evidence={"searched_patterns": ci_patterns},
+        )
+
+    return check
+
+
+register_control(
+    ControlSpec(
+        control_id="PH-CI-01",
+        level=2,
+        domain="CI",
+        name="CIConfigExists",
+        description="Project has CI/CD configuration",
+        passes=[
+            DeterministicPass(config_check=_create_ci_config_check()),
+            ManualPass(
+                verification_steps=[
+                    "Check for CI/CD configuration (GitHub Actions, GitLab CI, etc.)",
+                    "Verify the CI pipeline runs tests on pull requests",
+                ]
+            ),
+        ],
+    )
+)

--- a/packages/darnit-example/src/darnit_example/implementation.py
+++ b/packages/darnit-example/src/darnit_example/implementation.py
@@ -1,0 +1,144 @@
+"""Example Hygiene implementation for darnit.
+
+This module provides the ExampleHygieneImplementation class that implements
+the darnit ComplianceImplementation protocol for a simple "Project Hygiene
+Standard" with 8 controls across 2 maturity levels.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from darnit.core.plugin import ControlSpec
+
+# Simple rules catalog for SARIF output
+_RULES: dict[str, dict[str, Any]] = {
+    "PH-DOC-01": {
+        "name": "ReadmeExists",
+        "level": 1,
+        "shortDescription": {"text": "Project has a README file"},
+    },
+    "PH-DOC-02": {
+        "name": "LicenseExists",
+        "level": 1,
+        "shortDescription": {"text": "Project has a LICENSE file"},
+    },
+    "PH-DOC-03": {
+        "name": "ReadmeHasDescription",
+        "level": 1,
+        "shortDescription": {"text": "README contains a project description"},
+    },
+    "PH-SEC-01": {
+        "name": "SecurityPolicyExists",
+        "level": 1,
+        "shortDescription": {"text": "Project has a security policy"},
+    },
+    "PH-CFG-01": {
+        "name": "GitignoreExists",
+        "level": 1,
+        "shortDescription": {"text": "Project has a .gitignore file"},
+    },
+    "PH-CFG-02": {
+        "name": "EditorConfigExists",
+        "level": 1,
+        "shortDescription": {"text": "Project has an .editorconfig file"},
+    },
+    "PH-QA-01": {
+        "name": "ContributingGuideExists",
+        "level": 2,
+        "shortDescription": {"text": "Project has a CONTRIBUTING guide"},
+    },
+    "PH-CI-01": {
+        "name": "CIConfigExists",
+        "level": 2,
+        "shortDescription": {"text": "Project has CI/CD configuration"},
+    },
+}
+
+
+class ExampleHygieneImplementation:
+    """Example 'Project Hygiene Standard' implementation for darnit.
+
+    This implementation provides 8 controls across 2 maturity levels:
+    - Level 1: 6 controls (basic project setup)
+    - Level 2: 2 controls (quality practices)
+    """
+
+    @property
+    def name(self) -> str:
+        return "example-hygiene"
+
+    @property
+    def display_name(self) -> str:
+        return "Project Hygiene Standard (Example)"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def spec_version(self) -> str:
+        return "PH v1.0"
+
+    def get_all_controls(self) -> list[ControlSpec]:
+        """Get all Project Hygiene controls."""
+        controls = []
+        for level in [1, 2]:
+            controls.extend(self.get_controls_by_level(level))
+        return controls
+
+    def get_controls_by_level(self, level: int) -> list[ControlSpec]:
+        """Get controls for a specific maturity level."""
+        controls = []
+        for rule_id, rule in _RULES.items():
+            if rule.get("level") == level:
+                controls.append(
+                    ControlSpec(
+                        control_id=rule_id,
+                        name=rule.get("name", rule_id),
+                        description=rule.get("shortDescription", {}).get("text", ""),
+                        level=level,
+                        domain=rule_id.split("-")[1] if "-" in rule_id else "UNKNOWN",
+                        metadata={},
+                    )
+                )
+        return controls
+
+    def get_rules_catalog(self) -> dict[str, Any]:
+        """Get the rules catalog for SARIF output."""
+        return _RULES
+
+    def get_remediation_registry(self) -> dict[str, Any]:
+        """Get the remediation registry for auto-fixes."""
+        from .remediation.registry import REMEDIATION_REGISTRY
+
+        return REMEDIATION_REGISTRY
+
+    def get_framework_config_path(self) -> Path | None:
+        """Get path to the example hygiene framework TOML file.
+
+        Returns:
+            Path to example-hygiene.toml in the package root.
+        """
+        # Navigate from implementation.py -> darnit_example -> src -> darnit-example -> toml
+        return Path(__file__).parent.parent.parent / "example-hygiene.toml"
+
+    def register_controls(self) -> None:
+        """Register Python-defined controls with the sieve registry."""
+        from .controls import level1  # noqa: F401
+
+    def register_handlers(self) -> None:
+        """Register handlers with the handler registry."""
+        from darnit.core.handlers import get_handler_registry
+
+        from . import tools
+
+        registry = get_handler_registry()
+        registry.set_plugin_context(self.name)
+
+        registry.register_handler("example_hygiene_check", tools.example_hygiene_check)
+        registry.register_handler("remediate_hygiene", tools.remediate_hygiene)
+
+        registry.set_plugin_context(None)
+
+
+__all__ = ["ExampleHygieneImplementation"]

--- a/packages/darnit-example/src/darnit_example/remediation/__init__.py
+++ b/packages/darnit-example/src/darnit_example/remediation/__init__.py
@@ -1,0 +1,1 @@
+"""Remediation actions for the Project Hygiene Standard."""

--- a/packages/darnit-example/src/darnit_example/remediation/actions.py
+++ b/packages/darnit-example/src/darnit_example/remediation/actions.py
@@ -1,0 +1,102 @@
+"""Remediation action implementations for the Project Hygiene Standard.
+
+Each function creates a missing file to satisfy a control.
+"""
+
+import os
+from pathlib import Path
+
+
+def create_readme(local_path: str, dry_run: bool = True, **kwargs: object) -> dict:
+    """Create a README.md file in the project root.
+
+    Args:
+        local_path: Path to the repository root.
+        dry_run: If True, report what would be done without writing.
+
+    Returns:
+        Dict with remediation result.
+    """
+    target = Path(local_path) / "README.md"
+    if target.exists():
+        return {
+            "status": "skipped",
+            "message": "README.md already exists",
+            "path": str(target),
+        }
+
+    repo_name = os.path.basename(os.path.abspath(local_path))
+    content = f"# {repo_name}\n\nA brief description of what this project does.\n"
+
+    if dry_run:
+        return {
+            "status": "dry_run",
+            "message": f"Would create {target}",
+            "path": str(target),
+        }
+
+    target.write_text(content, encoding="utf-8")
+    return {
+        "status": "created",
+        "message": f"Created {target}",
+        "path": str(target),
+    }
+
+
+def create_gitignore(local_path: str, dry_run: bool = True, **kwargs: object) -> dict:
+    """Create a .gitignore file in the project root.
+
+    Args:
+        local_path: Path to the repository root.
+        dry_run: If True, report what would be done without writing.
+
+    Returns:
+        Dict with remediation result.
+    """
+    target = Path(local_path) / ".gitignore"
+    if target.exists():
+        return {
+            "status": "skipped",
+            "message": ".gitignore already exists",
+            "path": str(target),
+        }
+
+    content = """\
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+.venv/
+venv/
+
+# Byte-compiled files
+__pycache__/
+*.py[cod]
+"""
+
+    if dry_run:
+        return {
+            "status": "dry_run",
+            "message": f"Would create {target}",
+            "path": str(target),
+        }
+
+    target.write_text(content, encoding="utf-8")
+    return {
+        "status": "created",
+        "message": f"Created {target}",
+        "path": str(target),
+    }

--- a/packages/darnit-example/src/darnit_example/remediation/registry.py
+++ b/packages/darnit-example/src/darnit_example/remediation/registry.py
@@ -1,0 +1,23 @@
+"""Remediation registry for the Project Hygiene Standard.
+
+Maps controls to their automated fix functions.
+"""
+
+from typing import Any
+
+REMEDIATION_REGISTRY: dict[str, dict[str, Any]] = {
+    "create_readme": {
+        "description": "Create a README.md file",
+        "controls": ["PH-DOC-01", "PH-DOC-03"],
+        "function": "create_readme",
+        "safe": True,
+        "requires_api": False,
+    },
+    "create_gitignore": {
+        "description": "Create a .gitignore file",
+        "controls": ["PH-CFG-01"],
+        "function": "create_gitignore",
+        "safe": True,
+        "requires_api": False,
+    },
+}

--- a/packages/darnit-example/src/darnit_example/tools.py
+++ b/packages/darnit-example/src/darnit_example/tools.py
@@ -1,0 +1,378 @@
+"""MCP tool handlers for the Project Hygiene Standard.
+
+This module provides:
+- example_hygiene_check: audit all PH controls via the sieve pipeline
+- remediate_hygiene: auto-fix failing controls using TOML-defined templates
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# =============================================================================
+# Shared helpers
+# =============================================================================
+
+
+def _load_all_controls(repo_path: Path, level: int):
+    """Load TOML + Python controls, filter by level, sort."""
+    from darnit.config import (
+        load_controls_from_effective,
+        load_effective_config_by_name,
+    )
+    from darnit.core.discovery import get_implementation
+    from darnit.sieve.registry import get_control_registry
+
+    config = load_effective_config_by_name("example-hygiene", repo_path)
+    toml_controls = load_controls_from_effective(config)
+
+    impl = get_implementation("example-hygiene")
+    if impl:
+        impl.register_controls()
+
+    registry = get_control_registry()
+    toml_ids = {c.control_id for c in toml_controls}
+    python_controls = [
+        spec
+        for spec in registry.get_all_specs()
+        if spec.control_id.startswith("PH-") and spec.control_id not in toml_ids
+    ]
+
+    all_controls = toml_controls + python_controls
+    all_controls = [c for c in all_controls if (c.level or 0) <= level]
+    all_controls.sort(key=lambda c: c.control_id)
+    return all_controls
+
+
+def _run_audit(repo_path: Path, controls):
+    """Run sieve on a list of controls, return legacy result dicts."""
+    from darnit.sieve import CheckContext, SieveOrchestrator
+
+    orchestrator = SieveOrchestrator()
+    results: list[dict] = []
+
+    for control in controls:
+        context = CheckContext(
+            owner="",
+            repo=repo_path.name,
+            local_path=str(repo_path),
+            default_branch="main",
+            control_id=control.control_id,
+            control_metadata={
+                "name": control.name,
+                "description": control.description,
+            },
+        )
+        result = orchestrator.verify(control, context)
+        results.append(result.to_legacy_dict())
+
+    return results
+
+
+def _load_framework_config():
+    """Load the example-hygiene TOML as a FrameworkConfig."""
+    import tomllib
+
+    from darnit.config.framework_schema import FrameworkConfig
+    from darnit.core.discovery import get_implementation
+
+    impl = get_implementation("example-hygiene")
+    if not impl:
+        msg = "example-hygiene implementation not found"
+        raise RuntimeError(msg)
+
+    toml_path = impl.get_framework_config_path()
+    if not toml_path or not toml_path.exists():
+        msg = f"Framework TOML not found: {toml_path}"
+        raise RuntimeError(msg)
+
+    with open(toml_path, "rb") as f:
+        raw = tomllib.load(f)
+
+    return FrameworkConfig(**raw)
+
+
+# =============================================================================
+# Audit tool
+# =============================================================================
+
+
+async def example_hygiene_check(
+    local_path: str = ".",
+    level: int = 2,
+) -> str:
+    """Run a project hygiene audit via the sieve pipeline.
+
+    Loads all PH controls (both TOML-defined and Python-defined), runs each
+    through the sieve orchestrator, and returns a markdown audit report.
+
+    Args:
+        local_path: Path to the repository to check.
+        level: Maximum maturity level to check (1 or 2).
+
+    Returns:
+        Markdown-formatted audit report with pass/fail details.
+    """
+    repo_path = Path(local_path).resolve()
+    if not repo_path.exists():
+        return f"Error: Repository path not found: {repo_path}"
+
+    try:
+        controls = _load_all_controls(repo_path, level)
+    except Exception as e:
+        return f"Error loading controls: {e}"
+
+    if not controls:
+        return "No controls found for the requested level."
+
+    results = _run_audit(repo_path, controls)
+    return _format_hygiene_report(str(repo_path), level, results)
+
+
+# =============================================================================
+# Remediation tool
+# =============================================================================
+
+
+async def remediate_hygiene(
+    local_path: str = ".",
+    dry_run: bool = True,
+) -> str:
+    """Auto-fix failing hygiene controls using TOML-defined templates.
+
+    Runs the audit, then for each failing control that has a remediation
+    config with file_create, uses the framework's RemediationExecutor to
+    create the missing file from its template.
+
+    Args:
+        local_path: Path to the repository to remediate.
+        dry_run: If True (default), show what would be created without writing.
+
+    Returns:
+        Markdown-formatted remediation report.
+    """
+    from darnit.config.framework_schema import (
+        FileCreateRemediationConfig,
+        RemediationConfig,
+    )
+    from darnit.remediation.executor import RemediationExecutor
+
+    repo_path = Path(local_path).resolve()
+    if not repo_path.exists():
+        return f"Error: Repository path not found: {repo_path}"
+
+    # Load framework config for templates + remediation configs
+    try:
+        fw = _load_framework_config()
+    except Exception as e:
+        return f"Error loading framework config: {e}"
+
+    # Run audit to find failures
+    try:
+        controls = _load_all_controls(repo_path, level=2)
+    except Exception as e:
+        return f"Error loading controls: {e}"
+
+    results = _run_audit(repo_path, controls)
+    failed_ids = {r["id"] for r in results if r.get("status") == "FAIL"}
+
+    if not failed_ids:
+        return "All controls pass — nothing to remediate."
+
+    # Set up executor with templates from TOML
+    executor = RemediationExecutor(
+        local_path=str(repo_path),
+        repo=repo_path.name,
+        templates=fw.templates,
+    )
+
+    # Remediation configs for Python-defined controls that aren't in the TOML
+    # [controls] section but whose templates ARE in TOML [templates].
+    _python_remediations: dict[str, RemediationConfig] = {
+        "PH-CI-01": RemediationConfig(
+            file_create=FileCreateRemediationConfig(
+                path=".github/workflows/ci.yml",
+                template="ci_github_actions",
+                create_dirs=True,
+            ),
+        ),
+        # PH-DOC-03 is fixed implicitly when PH-DOC-01 creates README.md
+        # with the readme_standard template (which has description content).
+    }
+
+    # Apply remediations for each failed control
+    remediation_results = []
+    skipped = []
+
+    for control_id in sorted(failed_ids):
+        # Try TOML control config first, then Python-control fallback
+        rem_cfg = None
+        control_cfg = fw.controls.get(control_id)
+        if control_cfg and control_cfg.remediation and control_cfg.remediation.file_create:
+            rem_cfg = control_cfg.remediation
+        elif control_id in _python_remediations:
+            rem_cfg = _python_remediations[control_id]
+
+        if rem_cfg is None:
+            skipped.append((control_id, "no file_create remediation (fixed by another control)"))
+            continue
+
+        result = executor.execute(control_id, rem_cfg, dry_run=dry_run)
+        remediation_results.append(result)
+
+    return _format_remediation_report(
+        str(repo_path), dry_run, remediation_results, skipped,
+    )
+
+
+# =============================================================================
+# Formatters
+# =============================================================================
+
+
+def _format_hygiene_report(
+    repo_path: str,
+    level: int,
+    results: list[dict],
+) -> str:
+    """Format audit results as a markdown report."""
+    passed = [r for r in results if r.get("status") == "PASS"]
+    failed = [r for r in results if r.get("status") == "FAIL"]
+    other = [r for r in results if r.get("status") not in ("PASS", "FAIL")]
+
+    lines: list[str] = []
+    lines.append("# Project Hygiene Audit Report")
+    lines.append("")
+    lines.append(f"**Path:** {repo_path}")
+    lines.append(f"**Level Assessed:** {level}")
+    lines.append("")
+
+    # -- Summary table --------------------------------------------------------
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Status | Count |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Pass | {len(passed)} |")
+    lines.append(f"| Fail | {len(failed)} |")
+    if other:
+        lines.append(f"| Other | {len(other)} |")
+    lines.append(f"| **Total** | **{len(results)}** |")
+    lines.append("")
+
+    # -- Results by status ----------------------------------------------------
+    lines.append("## Results")
+    lines.append("")
+
+    if failed:
+        lines.append(f"### FAIL ({len(failed)})")
+        lines.append("")
+        for r in failed:
+            cid = r.get("id", "?")
+            lvl = r.get("level", "?")
+            detail = r.get("details", "No details")
+            lines.append(f"- **{cid}** (L{lvl}): {detail}")
+        lines.append("")
+
+    if passed:
+        lines.append(f"### PASS ({len(passed)})")
+        lines.append("")
+        for r in passed:
+            cid = r.get("id", "?")
+            lvl = r.get("level", "?")
+            detail = r.get("details", "")
+            lines.append(f"- **{cid}** (L{lvl}): {detail}")
+        lines.append("")
+
+    if other:
+        lines.append(f"### OTHER ({len(other)})")
+        lines.append("")
+        for r in other:
+            cid = r.get("id", "?")
+            lvl = r.get("level", "?")
+            status = r.get("status", "?")
+            detail = r.get("details", "")
+            lines.append(f"- **{cid}** (L{lvl}) [{status}]: {detail}")
+        lines.append("")
+
+    # -- Remediation guidance -------------------------------------------------
+    if failed:
+        lines.append("## Remediation")
+        lines.append("")
+        lines.append(
+            "Run `remediate_hygiene` to auto-fix controls with "
+            "TOML-defined templates."
+        )
+        lines.append("")
+        lines.append("| Control | What to Create |")
+        lines.append("|---------|---------------|")
+        remediation_map = {
+            "PH-DOC-01": "README.md",
+            "PH-DOC-02": "LICENSE",
+            "PH-DOC-03": "Add a description section to README.md",
+            "PH-SEC-01": "SECURITY.md",
+            "PH-CFG-01": ".gitignore",
+            "PH-CFG-02": ".editorconfig",
+            "PH-QA-01": "CONTRIBUTING.md",
+            "PH-CI-01": ".github/workflows/ci.yml",
+        }
+        for r in failed:
+            cid = r.get("id", "?")
+            fix = remediation_map.get(cid, "See control description")
+            lines.append(f"| {cid} | {fix} |")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_remediation_report(
+    repo_path: str,
+    dry_run: bool,
+    results: list,
+    skipped: list[tuple[str, str]],
+) -> str:
+    """Format remediation results as markdown."""
+    mode = "DRY RUN" if dry_run else "APPLIED"
+    succeeded = [r for r in results if r.success]
+    errored = [r for r in results if not r.success]
+
+    lines: list[str] = []
+    lines.append(f"# Hygiene Remediation Report ({mode})")
+    lines.append("")
+    lines.append(f"**Path:** {repo_path}")
+    lines.append("")
+
+    if succeeded:
+        verb = "Would create" if dry_run else "Created"
+        lines.append(f"## {verb} ({len(succeeded)})")
+        lines.append("")
+        for r in succeeded:
+            lines.append(f"- **{r.control_id}**: {r.message}")
+        lines.append("")
+
+    if errored:
+        lines.append(f"## Errors ({len(errored)})")
+        lines.append("")
+        for r in errored:
+            lines.append(f"- **{r.control_id}**: {r.message}")
+        lines.append("")
+
+    if skipped:
+        lines.append(f"## Skipped ({len(skipped)})")
+        lines.append("")
+        for cid, reason in skipped:
+            lines.append(f"- **{cid}**: {reason}")
+        lines.append("")
+
+    if not dry_run and succeeded:
+        lines.append(
+            "Run `example_hygiene_check` to verify the fixes."
+        )
+        lines.append("")
+
+    if dry_run and succeeded:
+        lines.append(
+            "Run `remediate_hygiene` with `dry_run=false` to apply these changes."
+        )
+        lines.append("")
+
+    return "\n".join(lines)

--- a/packages/darnit/src/darnit/config/control_loader.py
+++ b/packages/darnit/src/darnit/config/control_loader.py
@@ -446,6 +446,16 @@ def control_from_framework(
     if security_severity is None and "security_severity" in tags:
         security_severity = tags["security_severity"]
 
+    # Build metadata dict
+    metadata: dict = {
+        "security_severity": security_severity,
+        "docs_url": control_config.docs_url,
+    }
+
+    # Carry on_pass config through metadata for the orchestrator
+    if hasattr(control_config, "on_pass") and control_config.on_pass:
+        metadata["on_pass"] = control_config.on_pass
+
     return ControlSpec(
         control_id=control_id,
         level=level,
@@ -454,10 +464,7 @@ def control_from_framework(
         description=control_config.description,
         passes=passes,
         tags=tags,  # Pass tags directly, ControlSpec.__post_init__ will add level/domain
-        metadata={
-            "security_severity": security_severity,
-            "docs_url": control_config.docs_url,
-        },
+        metadata=metadata,
     )
 
 

--- a/packages/darnit/src/darnit/config/framework_schema.py
+++ b/packages/darnit/src/darnit/config/framework_schema.py
@@ -712,6 +712,35 @@ class ProjectUpdateRemediationConfig(BaseModel):
 
 
 # =============================================================================
+# Post-Check Context Update
+# =============================================================================
+
+
+class OnPassConfig(BaseModel):
+    """Configuration for actions to take when a control passes.
+
+    When a check passes, the sieve has found evidence (e.g., "SECURITY.md
+    exists at path X"). This config feeds that finding back into .project/
+    so subsequent checks can use it.
+
+    The `project_update` field uses the same dotted-path format as
+    ``ProjectUpdateRemediationConfig.set``. Values can reference evidence
+    from the sieve result using ``$EVIDENCE.<key>`` syntax.
+
+    Example:
+        ```toml
+        [controls."PH-SEC-01".on_pass]
+        project_update = { "security.policy.path" = "SECURITY.md" }
+        ```
+    """
+    # Values to set in .project/project.yaml on pass
+    # Keys are dotted paths, values are literals or $EVIDENCE references
+    project_update: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+# =============================================================================
 # Template Configuration
 # =============================================================================
 
@@ -805,6 +834,9 @@ class ControlConfig(BaseModel):
 
     # Remediation routing
     remediation: RemediationConfig | None = None
+
+    # Post-check context update (applied when this control passes)
+    on_pass: OnPassConfig | None = None
 
     # Flexible key-value tags for filtering and metadata
     # Can include any attributes: level, domain, severity, category, priority, etc.

--- a/packages/darnit/src/darnit/core/handlers.py
+++ b/packages/darnit/src/darnit/core/handlers.py
@@ -207,6 +207,7 @@ class HandlerRegistry:
     ALLOWED_MODULE_PREFIXES = (
         "darnit.",
         "darnit_baseline.",
+        "darnit_example.",
         "darnit_testchecks.",
     )
 

--- a/packages/darnit/src/darnit/remediation/executor.py
+++ b/packages/darnit/src/darnit/remediation/executor.py
@@ -33,6 +33,7 @@ from darnit.config.framework_schema import (
     ApiCallRemediationConfig,
     ExecRemediationConfig,
     FileCreateRemediationConfig,
+    ProjectUpdateRemediationConfig,
     RemediationConfig,
     TemplateConfig,
 )
@@ -253,6 +254,9 @@ class RemediationExecutor:
     ) -> RemediationResult:
         """Execute a remediation based on its configuration.
 
+        After a successful remediation action, also applies any project_update
+        to keep .project/project.yaml in sync with the actual project state.
+
         Args:
             control_id: The control ID being remediated
             config: Remediation configuration from TOML
@@ -262,12 +266,13 @@ class RemediationExecutor:
             RemediationResult with execution outcome
         """
         # Determine which remediation type to use
+        result = None
         if config.file_create:
-            return self._execute_file_create(control_id, config.file_create, dry_run)
+            result = self._execute_file_create(control_id, config.file_create, dry_run)
         elif config.exec:
-            return self._execute_exec(control_id, config.exec, dry_run)
+            result = self._execute_exec(control_id, config.exec, dry_run)
         elif config.api_call:
-            return self._execute_api_call(control_id, config.api_call, dry_run)
+            result = self._execute_api_call(control_id, config.api_call, dry_run)
         elif config.handler:
             # Legacy handler reference - return info about it
             return RemediationResult(
@@ -291,6 +296,26 @@ class RemediationExecutor:
                 dry_run=dry_run,
                 details={},
             )
+
+        # Apply project_update if the primary remediation succeeded
+        if result.success and not dry_run and config.project_update:
+            try:
+                apply_project_update(
+                    self.local_path, config.project_update, control_id
+                )
+                result.details["project_update"] = "applied"
+            except Exception as e:
+                logger.warning(
+                    f"Remediation for {control_id} succeeded but "
+                    f"project_update failed: {e}"
+                )
+                result.details["project_update"] = f"failed: {e}"
+        elif result.success and dry_run and config.project_update:
+            result.details["project_update"] = (
+                f"would set: {config.project_update.set}"
+            )
+
+        return result
 
     def _execute_file_create(
         self,
@@ -610,7 +635,118 @@ class RemediationExecutor:
             )
 
 
+def apply_project_update(
+    local_path: str,
+    project_update: ProjectUpdateRemediationConfig,
+    control_id: str,
+) -> None:
+    """Apply a project_update to .project/project.yaml.
+
+    Updates the project configuration with values specified in the
+    project_update config. Uses dotted paths to set nested values.
+
+    Args:
+        local_path: Path to the repository root
+        project_update: Configuration specifying what to update
+        control_id: Control ID for logging context
+
+    Raises:
+        RuntimeError: If .project/ cannot be created or updated
+
+    Example:
+        Given project_update.set = {"security.policy.path": "SECURITY.md"},
+        this updates .project/project.yaml:
+
+            security:
+              policy:
+                path: SECURITY.md
+    """
+    if not project_update.set:
+        return
+
+    try:
+        from darnit.config.loader import load_project_config, save_project_config
+        from darnit.config.models import ProjectConfig
+    except ImportError as e:
+        logger.warning(f"Config loader not available for project_update: {e}")
+        return
+
+    # Load or create project config
+    config = load_project_config(local_path)
+    if config is None:
+        if not project_update.create_if_missing:
+            logger.debug(
+                f"No .project/ found for {control_id} and create_if_missing=False"
+            )
+            return
+        config = ProjectConfig(name="unknown")
+
+    # Apply each dotted path update
+    for dotted_path, value in project_update.set.items():
+        _set_nested_value(config, dotted_path, value)
+        logger.debug(f"project_update for {control_id}: set {dotted_path} = {value}")
+
+    # Save
+    save_project_config(config, local_path)
+    logger.info(
+        f"Applied project_update for {control_id}: "
+        f"set {len(project_update.set)} values"
+    )
+
+
+def _set_nested_value(obj: object, dotted_path: str, value: object) -> None:
+    """Set a nested attribute/dict value using a dotted path.
+
+    Supports both attribute access (for Pydantic models) and dict access.
+    Creates intermediate dicts as needed.
+
+    Args:
+        obj: Root object to update
+        dotted_path: Dot-separated path (e.g., "security.policy.path")
+        value: Value to set
+    """
+    parts = dotted_path.split(".")
+    current = obj
+
+    for part in parts[:-1]:
+        if isinstance(current, dict):
+            if part not in current:
+                current[part] = {}
+            current = current[part]
+        elif hasattr(current, part):
+            next_val = getattr(current, part)
+            if next_val is None:
+                # Try to create the expected type
+                next_val = {}
+                try:
+                    setattr(current, part, next_val)
+                except (AttributeError, TypeError, ValueError):
+                    pass
+            current = next_val
+        else:
+            # Create as dict
+            new_dict: dict = {}
+            try:
+                setattr(current, part, new_dict)
+            except (AttributeError, TypeError, ValueError):
+                pass
+            current = new_dict
+
+    # Set the final value
+    final_key = parts[-1]
+    if isinstance(current, dict):
+        current[final_key] = value
+    else:
+        try:
+            setattr(current, final_key, value)
+        except (AttributeError, TypeError, ValueError) as e:
+            logger.warning(
+                f"Could not set {dotted_path} = {value}: {e}"
+            )
+
+
 __all__ = [
     "RemediationExecutor",
     "RemediationResult",
+    "apply_project_update",
 ]

--- a/packages/darnit/src/darnit/server/factory.py
+++ b/packages/darnit/src/darnit/server/factory.py
@@ -96,6 +96,10 @@ def create_server(config_path: str | Path) -> FastMCP:
     # This enables short name resolution for handler references
     _register_implementation_handlers(config)
 
+    # Extract framework name for built-in tool binding
+    metadata = config.get("metadata", {})
+    framework_name = metadata.get("name")
+
     # Create registry and server
     registry = ToolRegistry.from_toml(config)
     server = FastMCP(server_name)
@@ -104,7 +108,7 @@ def create_server(config_path: str | Path) -> FastMCP:
     registered_count = 0
     for name, spec in registry.tools.items():
         try:
-            handler = registry.load_handler(spec)
+            handler = registry.load_handler(spec, framework_name=framework_name)
             server.add_tool(handler, name=name, description=spec.description)
             registered_count += 1
             logger.debug(f"Registered tool: {name}")
@@ -138,12 +142,16 @@ def create_server_from_dict(config: dict) -> FastMCP:
     # Register handlers from implementation before loading tools
     _register_implementation_handlers(config)
 
+    # Extract framework name for built-in tool binding
+    metadata = config.get("metadata", {})
+    framework_name = metadata.get("name")
+
     registry = ToolRegistry.from_toml(config)
     server = FastMCP(server_name)
 
     for name, spec in registry.tools.items():
         try:
-            handler = registry.load_handler(spec)
+            handler = registry.load_handler(spec, framework_name=framework_name)
             server.add_tool(handler, name=name, description=spec.description)
         except (ImportError, AttributeError, ValueError) as e:
             logger.warning(f"Failed to load tool '{name}': {e}")

--- a/packages/darnit/src/darnit/server/registry.py
+++ b/packages/darnit/src/darnit/server/registry.py
@@ -2,6 +2,11 @@
 
 This module provides data classes for representing MCP tools and a registry
 that can load tool definitions from TOML configuration files.
+
+Supports three handler resolution modes:
+1. builtin = "audit" — uses framework-provided generic tool
+2. handler = "short_name" — looks up in handler registry
+3. handler = "module.path:function_name" — imports directly
 """
 
 from __future__ import annotations
@@ -18,15 +23,17 @@ class ToolSpec:
 
     Attributes:
         name: The tool name as it will appear in MCP
-        handler: Import path in format "module.path:function_name"
+        handler: Import path in format "module.path:function_name" (or empty for builtins)
         description: Human-readable description of what the tool does
         parameters: Optional parameter overrides or metadata
+        builtin: Built-in tool name (e.g., "audit", "remediate", "list_controls")
     """
 
     name: str
     handler: str
     description: str
     parameters: dict[str, Any] = field(default_factory=dict)
+    builtin: str | None = None
 
 
 @dataclass
@@ -44,15 +51,21 @@ class ToolRegistry:
         """Load tools from a parsed TOML config dict.
 
         Expects config to have an [mcp.tools] section where each key
-        is a tool name and the value contains handler and description.
+        is a tool name and the value contains handler or builtin.
 
         Example TOML:
             [mcp]
             name = "my-server"
 
+            # Custom handler tool
             [mcp.tools.my_tool]
             handler = "mypackage.tools:my_function"
             description = "Does something useful"
+
+            # Built-in tool (no Python code needed)
+            [mcp.tools.audit]
+            builtin = "audit"
+            description = "Run compliance audit"
 
         Args:
             config: Parsed TOML configuration dictionary
@@ -68,8 +81,11 @@ class ToolRegistry:
             if not isinstance(spec, dict):
                 continue
 
-            handler = spec.get("handler")
-            if not handler:
+            builtin = spec.get("builtin")
+            handler = spec.get("handler", "")
+
+            # Must have either builtin or handler
+            if not builtin and not handler:
                 continue
 
             registry.tools[name] = ToolSpec(
@@ -77,19 +93,24 @@ class ToolRegistry:
                 handler=handler,
                 description=spec.get("description", ""),
                 parameters=spec.get("parameters", {}),
+                builtin=builtin,
             )
 
         return registry
 
-    def load_handler(self, spec: ToolSpec) -> Callable[..., Any]:
+    def load_handler(
+        self, spec: ToolSpec, framework_name: str | None = None
+    ) -> Callable[..., Any]:
         """Dynamically import and return the handler function.
 
-        Supports two formats:
-        1. Short name: "audit_openssf_baseline" - looks up in handler registry
-        2. Module path: "module.path:function_name" - imports directly
+        Supports three formats:
+        1. Built-in: builtin = "audit" - uses framework-provided generic tool
+        2. Short name: "audit_openssf_baseline" - looks up in handler registry
+        3. Module path: "module.path:function_name" - imports directly
 
         Args:
             spec: Tool specification containing the handler name or import path
+            framework_name: Framework name for built-in tool binding
 
         Returns:
             The imported function
@@ -99,6 +120,10 @@ class ToolRegistry:
             ImportError: If module cannot be imported
             AttributeError: If function doesn't exist in module
         """
+        # Built-in tool resolution
+        if spec.builtin:
+            return self._load_builtin(spec, framework_name)
+
         # If no colon, try to resolve from handler registry
         if ":" not in spec.handler:
             from darnit.core.handlers import get_handler_registry
@@ -118,6 +143,52 @@ class ToolRegistry:
         module_path, func_name = spec.handler.rsplit(":", 1)
         module = importlib.import_module(module_path)
         return getattr(module, func_name)
+
+    def _load_builtin(
+        self, spec: ToolSpec, framework_name: str | None
+    ) -> Callable[..., Any]:
+        """Load a built-in tool and bind it to a framework.
+
+        Built-in tools receive the framework name as a bound parameter
+        so they know which TOML config to load.
+
+        Args:
+            spec: Tool specification with builtin field
+            framework_name: Framework name to bind
+
+        Returns:
+            Callable with framework_name pre-bound
+
+        Raises:
+            ValueError: If builtin name is not recognized
+        """
+        import functools
+
+        from darnit.server.tools import BUILTIN_TOOLS
+
+        builtin_name = spec.builtin
+        if builtin_name not in BUILTIN_TOOLS:
+            available = ", ".join(sorted(BUILTIN_TOOLS.keys()))
+            raise ValueError(
+                f"Unknown builtin tool '{builtin_name}'. "
+                f"Available builtins: {available}"
+            )
+
+        base_fn = BUILTIN_TOOLS[builtin_name]
+
+        if not framework_name:
+            raise ValueError(
+                f"Built-in tool '{builtin_name}' requires a framework name. "
+                "Ensure [metadata] name is set in the TOML config."
+            )
+
+        # Create a wrapper that injects _framework_name
+        @functools.wraps(base_fn)
+        async def bound_handler(**kwargs):
+            kwargs["_framework_name"] = framework_name
+            return await base_fn(**kwargs)
+
+        return bound_handler
 
     def get_tool(self, name: str) -> ToolSpec | None:
         """Get a tool spec by name.

--- a/packages/darnit/src/darnit/server/tools/__init__.py
+++ b/packages/darnit/src/darnit/server/tools/__init__.py
@@ -2,8 +2,17 @@
 
 This module provides tool implementations that can be registered with an MCP server.
 Each tool is implemented as a standalone function that can be decorated with @mcp.tool().
+
+Built-in tools (audit, remediate, list_controls) are generic implementations that
+work with any TOML-defined framework. They can be referenced in TOML as:
+
+    [mcp.tools.audit]
+    builtin = "audit"
 """
 
+from .builtin_audit import builtin_audit
+from .builtin_list import builtin_list_controls
+from .builtin_remediate import builtin_remediate
 from .git_operations import (
     commit_remediation_changes_impl,
     create_remediation_branch_impl,
@@ -17,7 +26,20 @@ from .test_repository import (
     create_test_repository_impl,
 )
 
+# Registry of built-in tool implementations.
+# Keys are the names used in TOML: builtin = "<key>"
+BUILTIN_TOOLS = {
+    "audit": builtin_audit,
+    "remediate": builtin_remediate,
+    "list_controls": builtin_list_controls,
+}
+
 __all__ = [
+    # Built-in tools
+    "BUILTIN_TOOLS",
+    "builtin_audit",
+    "builtin_remediate",
+    "builtin_list_controls",
     # Git operations
     "create_remediation_branch_impl",
     "commit_remediation_changes_impl",

--- a/packages/darnit/src/darnit/server/tools/builtin_audit.py
+++ b/packages/darnit/src/darnit/server/tools/builtin_audit.py
@@ -1,0 +1,251 @@
+"""Built-in audit tool for any framework.
+
+Provides a generic audit tool that works with any TOML-defined framework.
+Implementations can use this instead of writing their own audit tool.
+
+Usage in TOML:
+    [mcp.tools.audit]
+    builtin = "audit"
+    description = "Run compliance audit"
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from darnit.core.logging import get_logger
+
+logger = get_logger("server.tools.builtin_audit")
+
+
+async def builtin_audit(
+    local_path: str = ".",
+    level: int = 3,
+    output_format: str = "markdown",
+    tags: str | list[str] | None = None,
+    *,
+    _framework_name: str = "",
+) -> str:
+    """Run a compliance audit on a repository.
+
+    Loads controls from the framework TOML, runs each through the sieve
+    verification pipeline, and returns a formatted report.
+
+    Args:
+        local_path: Path to the repository to audit.
+        level: Maximum maturity level to check (default: 3).
+        output_format: Output format - "markdown", "json", or "sarif".
+        tags: Filter controls by tags (e.g., "domain=AC", "level=1").
+        _framework_name: Internal - set by the factory at registration time.
+
+    Returns:
+        Formatted audit report.
+    """
+    import json as json_mod
+
+    from darnit.config import (
+        load_controls_from_effective,
+        load_effective_config_by_name,
+    )
+    from darnit.core.discovery import get_implementation
+    from darnit.sieve import CheckContext, SieveOrchestrator
+    from darnit.sieve.registry import get_control_registry
+
+    repo_path = Path(local_path).resolve()
+    if not repo_path.exists():
+        return f"Error: Repository path not found: {repo_path}"
+
+    if not _framework_name:
+        return "Error: No framework name configured for this audit tool."
+
+    # Load effective config (framework TOML merged with user .baseline.toml)
+    try:
+        config = load_effective_config_by_name(_framework_name, repo_path)
+    except Exception as e:
+        return f"Error loading framework config '{_framework_name}': {e}"
+
+    # Load TOML-defined controls
+    try:
+        toml_controls = load_controls_from_effective(config)
+    except Exception as e:
+        return f"Error loading controls: {e}"
+
+    # Register and load Python-defined controls if implementation exists
+    impl = get_implementation(_framework_name)
+    if impl and hasattr(impl, "register_controls"):
+        try:
+            impl.register_controls()
+        except Exception as e:
+            logger.warning(f"Error registering Python controls: {e}")
+
+    # Merge Python-defined controls that aren't in TOML
+    registry = get_control_registry()
+    toml_ids = {c.control_id for c in toml_controls}
+    python_controls = [
+        spec
+        for spec in registry.get_all_specs()
+        if spec.control_id not in toml_ids
+    ]
+
+    all_controls = toml_controls + python_controls
+
+    # Filter by level
+    all_controls = [c for c in all_controls if (c.level or 0) <= level]
+
+    # Filter by tags if specified
+    if tags:
+        try:
+            from darnit.filtering import filter_controls, parse_tags_arg
+
+            parsed_tags = parse_tags_arg(tags) if isinstance(tags, str) else tags
+            all_controls = filter_controls(all_controls, parsed_tags)
+        except ImportError:
+            logger.debug("Filtering module not available, skipping tag filter")
+        except Exception as e:
+            return f"Error filtering controls: {e}"
+
+    all_controls.sort(key=lambda c: c.control_id)
+
+    if not all_controls:
+        return "No controls found for the requested level and filters."
+
+    # Detect owner/repo for context
+    owner, repo = _detect_owner_repo(repo_path)
+
+    # Run sieve verification
+    orchestrator = SieveOrchestrator()
+    results: list[dict[str, Any]] = []
+
+    for control in all_controls:
+        context = CheckContext(
+            owner=owner,
+            repo=repo,
+            local_path=str(repo_path),
+            default_branch="main",
+            control_id=control.control_id,
+            control_metadata={
+                "name": control.name,
+                "description": control.description,
+            },
+        )
+        result = orchestrator.verify(control, context)
+        results.append(result.to_legacy_dict())
+
+    # Format output
+    if output_format == "json":
+        return json_mod.dumps(results, indent=2, default=str)
+
+    return _format_audit_report(
+        framework_name=_framework_name,
+        repo_path=str(repo_path),
+        level=level,
+        results=results,
+    )
+
+
+def _detect_owner_repo(repo_path: Path) -> tuple[str, str]:
+    """Detect owner/repo from git remote."""
+    try:
+        from darnit.core.utils import detect_repo_from_git
+
+        detected = detect_repo_from_git(str(repo_path))
+        if detected:
+            return detected.get("owner", ""), detected.get("repo", repo_path.name)
+    except Exception:
+        pass
+    return "", repo_path.name
+
+
+def _format_audit_report(
+    framework_name: str,
+    repo_path: str,
+    level: int,
+    results: list[dict[str, Any]],
+) -> str:
+    """Format audit results as a markdown report."""
+    passed = [r for r in results if r.get("status") == "PASS"]
+    failed = [r for r in results if r.get("status") == "FAIL"]
+    warned = [r for r in results if r.get("status") == "WARN"]
+    other = [r for r in results if r.get("status") not in ("PASS", "FAIL", "WARN")]
+
+    lines: list[str] = []
+    lines.append(f"# {framework_name} Audit Report")
+    lines.append("")
+    lines.append(f"**Path:** {repo_path}")
+    lines.append(f"**Level Assessed:** {level}")
+    lines.append("")
+
+    # Summary
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Status | Count |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Pass | {len(passed)} |")
+    lines.append(f"| Fail | {len(failed)} |")
+    if warned:
+        lines.append(f"| Needs Verification | {len(warned)} |")
+    if other:
+        lines.append(f"| Other | {len(other)} |")
+    lines.append(f"| **Total** | **{len(results)}** |")
+    lines.append("")
+
+    # Detailed results
+    lines.append("## Results")
+    lines.append("")
+
+    if failed:
+        lines.append(f"### FAIL ({len(failed)})")
+        lines.append("")
+        for r in failed:
+            cid = r.get("id", "?")
+            lvl = r.get("level", "?")
+            detail = r.get("details", "No details")
+            lines.append(f"- **{cid}** (L{lvl}): {detail}")
+        lines.append("")
+
+    if warned:
+        lines.append(f"### NEEDS VERIFICATION ({len(warned)})")
+        lines.append("")
+        for r in warned:
+            cid = r.get("id", "?")
+            lvl = r.get("level", "?")
+            detail = r.get("details", "")
+            lines.append(f"- **{cid}** (L{lvl}): {detail}")
+        lines.append("")
+
+    if passed:
+        lines.append(f"### PASS ({len(passed)})")
+        lines.append("")
+        for r in passed:
+            cid = r.get("id", "?")
+            lvl = r.get("level", "?")
+            detail = r.get("details", "")
+            lines.append(f"- **{cid}** (L{lvl}): {detail}")
+        lines.append("")
+
+    if other:
+        lines.append(f"### OTHER ({len(other)})")
+        lines.append("")
+        for r in other:
+            cid = r.get("id", "?")
+            lvl = r.get("level", "?")
+            status = r.get("status", "?")
+            detail = r.get("details", "")
+            lines.append(f"- **{cid}** (L{lvl}) [{status}]: {detail}")
+        lines.append("")
+
+    # Remediation guidance
+    if failed:
+        lines.append("## Remediation")
+        lines.append("")
+        lines.append(
+            "Run the `remediate` tool to auto-fix controls with "
+            "TOML-defined templates."
+        )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+__all__ = ["builtin_audit"]

--- a/packages/darnit/src/darnit/server/tools/builtin_list.py
+++ b/packages/darnit/src/darnit/server/tools/builtin_list.py
@@ -1,0 +1,106 @@
+"""Built-in list_controls tool for any framework.
+
+Provides a generic control listing tool that works with any TOML-defined framework.
+Lists all controls defined in the framework TOML organized by level.
+
+Usage in TOML:
+    [mcp.tools.list_controls]
+    builtin = "list_controls"
+    description = "List all available controls"
+"""
+
+from __future__ import annotations
+
+import json
+
+from darnit.core.logging import get_logger
+
+logger = get_logger("server.tools.builtin_list")
+
+
+async def builtin_list_controls(
+    *,
+    _framework_name: str = "",
+) -> str:
+    """List all available controls organized by level.
+
+    Returns a JSON structure with controls grouped by maturity level,
+    including names, descriptions, and domains.
+
+    Args:
+        _framework_name: Internal - set by the factory at registration time.
+
+    Returns:
+        JSON-formatted control listing.
+    """
+    from darnit.config import (
+        load_controls_from_effective,
+        load_effective_config_by_name,
+    )
+    from darnit.core.discovery import get_implementation
+    from darnit.sieve.registry import get_control_registry
+
+    if not _framework_name:
+        return "Error: No framework name configured for this tool."
+
+    # Load effective config
+    try:
+        config = load_effective_config_by_name(_framework_name)
+    except Exception as e:
+        return f"Error loading framework config '{_framework_name}': {e}"
+
+    # Load TOML controls
+    try:
+        toml_controls = load_controls_from_effective(config)
+    except Exception as e:
+        return f"Error loading controls: {e}"
+
+    # Register Python controls
+    impl = get_implementation(_framework_name)
+    if impl and hasattr(impl, "register_controls"):
+        try:
+            impl.register_controls()
+        except Exception as e:
+            logger.warning(f"Error registering Python controls: {e}")
+
+    registry = get_control_registry()
+    toml_ids = {c.control_id for c in toml_controls}
+    python_controls = [
+        spec for spec in registry.get_all_specs()
+        if spec.control_id not in toml_ids
+    ]
+
+    all_controls = toml_controls + python_controls
+    all_controls.sort(key=lambda c: c.control_id)
+
+    # Group by level
+    by_level: dict[int, list[dict]] = {}
+    for control in all_controls:
+        lvl = control.level or 0
+        if lvl not in by_level:
+            by_level[lvl] = []
+        by_level[lvl].append({
+            "id": control.control_id,
+            "name": control.name,
+            "description": control.description,
+            "domain": control.domain or "",
+        })
+
+    result = {
+        "framework": _framework_name,
+        "total": len(all_controls),
+    }
+
+    for lvl in sorted(by_level.keys()):
+        controls_at_level = by_level[lvl]
+        domains = sorted({c["domain"] for c in controls_at_level if c["domain"]})
+        result[f"level_{lvl}"] = {
+            "count": len(controls_at_level),
+            "domains": domains,
+            "controls": controls_at_level,
+        }
+
+    return json.dumps(result, indent=2)
+
+
+__all__ = ["builtin_list_controls"]

--- a/packages/darnit/src/darnit/server/tools/builtin_remediate.py
+++ b/packages/darnit/src/darnit/server/tools/builtin_remediate.py
@@ -1,0 +1,269 @@
+"""Built-in remediate tool for any framework.
+
+Provides a generic remediation tool that works with any TOML-defined framework.
+Uses the RemediationExecutor to apply file_create, exec, and api_call remediations
+defined in the framework TOML.
+
+Usage in TOML:
+    [mcp.tools.remediate]
+    builtin = "remediate"
+    description = "Auto-fix failing controls"
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from darnit.core.logging import get_logger
+
+logger = get_logger("server.tools.builtin_remediate")
+
+
+async def builtin_remediate(
+    local_path: str = ".",
+    dry_run: bool = True,
+    *,
+    _framework_name: str = "",
+) -> str:
+    """Auto-fix failing controls using TOML-defined remediations.
+
+    Runs the audit to find failures, then for each failing control that has
+    a declarative remediation config (file_create, exec, api_call), applies
+    the fix using the framework's RemediationExecutor.
+
+    Args:
+        local_path: Path to the repository to remediate.
+        dry_run: If True (default), show what would be done without writing.
+        _framework_name: Internal - set by the factory at registration time.
+
+    Returns:
+        Markdown-formatted remediation report.
+    """
+    from darnit.config import (
+        load_controls_from_effective,
+        load_effective_config_by_name,
+    )
+    from darnit.config.framework_schema import FrameworkConfig
+    from darnit.core.discovery import get_implementation
+    from darnit.remediation.executor import RemediationExecutor
+    from darnit.sieve import CheckContext, SieveOrchestrator
+    from darnit.sieve.registry import get_control_registry
+
+    repo_path = Path(local_path).resolve()
+    if not repo_path.exists():
+        return f"Error: Repository path not found: {repo_path}"
+
+    if not _framework_name:
+        return "Error: No framework name configured for this remediate tool."
+
+    # Load effective config
+    try:
+        config = load_effective_config_by_name(_framework_name, repo_path)
+    except Exception as e:
+        return f"Error loading framework config '{_framework_name}': {e}"
+
+    # Also load the raw FrameworkConfig for templates
+    fw: FrameworkConfig | None = None
+    impl = get_implementation(_framework_name)
+    if impl and hasattr(impl, "get_framework_config_path"):
+        toml_path = impl.get_framework_config_path()
+        if toml_path and toml_path.exists():
+            try:
+                import tomllib
+
+                with open(toml_path, "rb") as f:
+                    raw = tomllib.load(f)
+                fw = FrameworkConfig(**raw)
+            except Exception as e:
+                logger.warning(f"Failed to parse framework TOML: {e}")
+
+    if fw is None:
+        # Fall back to building FrameworkConfig from the effective config
+        try:
+            fw = config.framework
+        except Exception:
+            return "Error: Could not load framework configuration for templates."
+
+    # Load controls
+    try:
+        toml_controls = load_controls_from_effective(config)
+    except Exception as e:
+        return f"Error loading controls: {e}"
+
+    # Register Python controls
+    if impl and hasattr(impl, "register_controls"):
+        try:
+            impl.register_controls()
+        except Exception as e:
+            logger.warning(f"Error registering Python controls: {e}")
+
+    registry = get_control_registry()
+    toml_ids = {c.control_id for c in toml_controls}
+    python_controls = [
+        spec for spec in registry.get_all_specs()
+        if spec.control_id not in toml_ids
+    ]
+
+    all_controls = toml_controls + python_controls
+    all_controls.sort(key=lambda c: c.control_id)
+
+    if not all_controls:
+        return "No controls found."
+
+    # Run audit to find failures
+    owner, repo = _detect_owner_repo(repo_path)
+    orchestrator = SieveOrchestrator()
+    failed_ids: set[str] = set()
+
+    for control in all_controls:
+        context = CheckContext(
+            owner=owner,
+            repo=repo,
+            local_path=str(repo_path),
+            default_branch="main",
+            control_id=control.control_id,
+            control_metadata={
+                "name": control.name,
+                "description": control.description,
+            },
+        )
+        result = orchestrator.verify(control, context)
+        if result.status == "FAIL":
+            failed_ids.add(control.control_id)
+
+    if not failed_ids:
+        return "All controls pass — nothing to remediate."
+
+    # Set up executor with templates from TOML
+    executor = RemediationExecutor(
+        local_path=str(repo_path),
+        owner=owner,
+        repo=repo,
+        templates=fw.templates,
+    )
+
+    # Apply remediations for each failed control
+    remediation_results = []
+    skipped: list[tuple[str, str]] = []
+
+    for control_id in sorted(failed_ids):
+        control_cfg = fw.controls.get(control_id)
+        if not control_cfg or not control_cfg.remediation:
+            skipped.append((control_id, "no remediation defined"))
+            continue
+
+        rem_cfg = control_cfg.remediation
+
+        # Only apply declarative remediations (file_create, exec, api_call)
+        has_declarative = rem_cfg.file_create or rem_cfg.exec or rem_cfg.api_call
+        if not has_declarative:
+            if rem_cfg.handler:
+                skipped.append((control_id, f"handler-only remediation: {rem_cfg.handler}"))
+            else:
+                skipped.append((control_id, "no declarative remediation"))
+            continue
+
+        result = executor.execute(control_id, rem_cfg, dry_run=dry_run)
+        remediation_results.append(result)
+
+        # Apply project_update if the remediation succeeded and has one
+        if result.success and not dry_run and rem_cfg.project_update:
+            _apply_project_update(
+                str(repo_path), rem_cfg.project_update, control_id
+            )
+
+    return _format_remediation_report(
+        framework_name=_framework_name,
+        repo_path=str(repo_path),
+        dry_run=dry_run,
+        results=remediation_results,
+        skipped=skipped,
+    )
+
+
+def _detect_owner_repo(repo_path: Path) -> tuple[str, str]:
+    """Detect owner/repo from git remote."""
+    try:
+        from darnit.core.utils import detect_repo_from_git
+
+        detected = detect_repo_from_git(str(repo_path))
+        if detected:
+            return detected.get("owner", ""), detected.get("repo", repo_path.name)
+    except Exception:
+        pass
+    return "", repo_path.name
+
+
+def _apply_project_update(
+    local_path: str,
+    project_update: Any,
+    control_id: str,
+) -> None:
+    """Apply project_update after successful remediation.
+
+    Updates .project/project.yaml with the values specified in
+    the project_update config.
+    """
+    from darnit.remediation.executor import apply_project_update
+
+    try:
+        apply_project_update(local_path, project_update, control_id)
+    except Exception as e:
+        logger.warning(
+            f"Failed to apply project_update for {control_id}: {e}"
+        )
+
+
+def _format_remediation_report(
+    framework_name: str,
+    repo_path: str,
+    dry_run: bool,
+    results: list,
+    skipped: list[tuple[str, str]],
+) -> str:
+    """Format remediation results as markdown."""
+    mode = "DRY RUN" if dry_run else "APPLIED"
+    succeeded = [r for r in results if r.success]
+    errored = [r for r in results if not r.success]
+
+    lines: list[str] = []
+    lines.append(f"# {framework_name} Remediation Report ({mode})")
+    lines.append("")
+    lines.append(f"**Path:** {repo_path}")
+    lines.append("")
+
+    if succeeded:
+        verb = "Would create/fix" if dry_run else "Created/fixed"
+        lines.append(f"## {verb} ({len(succeeded)})")
+        lines.append("")
+        for r in succeeded:
+            lines.append(f"- **{r.control_id}**: {r.message}")
+        lines.append("")
+
+    if errored:
+        lines.append(f"## Errors ({len(errored)})")
+        lines.append("")
+        for r in errored:
+            lines.append(f"- **{r.control_id}**: {r.message}")
+        lines.append("")
+
+    if skipped:
+        lines.append(f"## Skipped ({len(skipped)})")
+        lines.append("")
+        for cid, reason in skipped:
+            lines.append(f"- **{cid}**: {reason}")
+        lines.append("")
+
+    if not dry_run and succeeded:
+        lines.append("Run the audit tool to verify the fixes.")
+        lines.append("")
+
+    if dry_run and succeeded:
+        lines.append("Run with `dry_run=false` to apply these changes.")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+__all__ = ["builtin_remediate"]

--- a/packages/darnit/src/darnit/sieve/orchestrator.py
+++ b/packages/darnit/src/darnit/sieve/orchestrator.py
@@ -92,7 +92,7 @@ class SieveOrchestrator:
 
             # Check if conclusive
             if result.outcome == PassOutcome.PASS:
-                return SieveResult(
+                sieve_result = SieveResult(
                     control_id=control_spec.control_id,
                     status="PASS",
                     message=result.message,
@@ -103,6 +103,13 @@ class SieveOrchestrator:
                     evidence=accumulated_evidence,
                     source="sieve",
                 )
+
+                # Apply on_pass context update if configured
+                self._apply_on_pass(
+                    control_spec, context, accumulated_evidence
+                )
+
+                return sieve_result
 
             elif result.outcome == PassOutcome.FAIL:
                 return SieveResult(
@@ -276,3 +283,69 @@ class SieveOrchestrator:
             result = self.verify(spec, context)
             results.append(result)
         return results
+
+    def _apply_on_pass(
+        self,
+        control_spec: ControlSpec,
+        context: CheckContext,
+        evidence: dict[str, Any],
+    ) -> None:
+        """Apply on_pass project_update when a control passes.
+
+        Reads on_pass config from control_spec.metadata and updates
+        .project/project.yaml with the specified values.
+
+        Values can reference evidence using $EVIDENCE.<key> syntax.
+
+        Args:
+            control_spec: The control that passed
+            context: Check context with local_path
+            evidence: Accumulated evidence from passes
+        """
+        on_pass = control_spec.metadata.get("on_pass")
+        if not on_pass:
+            return
+
+        # on_pass can be an OnPassConfig pydantic model or a dict
+        if hasattr(on_pass, "project_update"):
+            updates = on_pass.project_update
+        elif isinstance(on_pass, dict):
+            updates = on_pass.get("project_update", {})
+        else:
+            return
+
+        if not updates:
+            return
+
+        # Substitute $EVIDENCE references
+        resolved: dict[str, Any] = {}
+        for key, value in updates.items():
+            if isinstance(value, str) and value.startswith("$EVIDENCE."):
+                evidence_key = value[len("$EVIDENCE."):]
+                resolved[key] = evidence.get(evidence_key, value)
+            else:
+                resolved[key] = value
+
+        # Apply updates to .project/project.yaml
+        local_path = context.local_path
+        if not local_path:
+            return
+
+        try:
+            from darnit.remediation.executor import (
+                ProjectUpdateRemediationConfig,
+                apply_project_update,
+            )
+
+            config = ProjectUpdateRemediationConfig(set=resolved)
+            apply_project_update(local_path, config, control_spec.control_id)
+            logger.debug(
+                f"Applied on_pass for {control_spec.control_id}: "
+                f"set {len(resolved)} values"
+            )
+        except ImportError:
+            logger.debug("Remediation executor not available for on_pass")
+        except Exception as e:
+            logger.warning(
+                f"Failed to apply on_pass for {control_spec.control_id}: {e}"
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "darnit",
     "darnit-baseline",
+    "darnit-example",
 ]
 
 [project.urls]
@@ -44,6 +45,7 @@ members = ["packages/*"]
 [tool.uv.sources]
 darnit = { workspace = true }
 darnit-baseline = { workspace = true }
+darnit-example = { workspace = true }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -143,7 +145,7 @@ ignore = [
 "docs/examples/*" = ["B", "SIM", "E402"]  # Less strict for examples
 
 [tool.ruff.lint.isort]
-known-first-party = ["darnit", "darnit_baseline"]
+known-first-party = ["darnit", "darnit_baseline", "darnit_example"]
 
 [tool.bandit]
 exclude_dirs = ["tests", "docs/examples"]

--- a/scripts/create-example-test-repo.py
+++ b/scripts/create-example-test-repo.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Create a test repository for the darnit-example Project Hygiene Standard.
+
+Generates a minimal Python project that intentionally fails all 8 PH controls,
+with a .mcp.json pointing at the example-hygiene MCP server so Claude Code
+can audit and remediate it immediately.
+
+Usage:
+    # Create a failing repo in /tmp (default):
+    python scripts/create-example-test-repo.py --no-github
+
+    # Apply quick fixes to make all controls pass:
+    python scripts/create-example-test-repo.py --remediate /tmp/hygiene-test-repo
+
+What's intentionally missing (maps to controls):
+    README.md           → PH-DOC-01, PH-DOC-03
+    LICENSE             → PH-DOC-02
+    SECURITY.md         → PH-SEC-01
+    .gitignore          → PH-CFG-01
+    .editorconfig       → PH-CFG-02
+    CONTRIBUTING.md     → PH-QA-01
+    .github/workflows/  → PH-CI-01
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Resolve darnit workspace root (parent of scripts/)
+DARNIT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def create_repo(
+    repo_name: str,
+    parent_dir: str | None = None,
+    create_github: bool = True,
+    github_org: str | None = None,
+    make_template: bool = False,
+) -> None:
+    """Create a minimal test repo that fails all PH controls."""
+    if parent_dir is None:
+        # Create a unique temp directory so repeated runs don't collide
+        parent_dir = tempfile.mkdtemp(prefix="darnit-example-")
+
+    parent_path = Path(parent_dir).resolve()
+    repo_path = parent_path / repo_name
+
+    if repo_path.exists():
+        print(f"\033[0;31mError: Directory '{repo_path}' already exists.\033[0m")
+        sys.exit(1)
+
+    print("\033[0;32m=== Project Hygiene Test Repo Generator ===\033[0m\n")
+    print(f"Creating: {repo_path}\n")
+
+    # -- Directory structure --------------------------------------------------
+    (repo_path / "src").mkdir(parents=True)
+
+    # -- pyproject.toml (minimal, no license field) ---------------------------
+    pyproject = """\
+[project]
+name = "hygiene-test"
+version = "0.0.1"
+requires-python = ">=3.10"
+"""
+    (repo_path / "pyproject.toml").write_text(pyproject)
+
+    # -- src/main.py ----------------------------------------------------------
+    main_py = """\
+def main():
+    print("Hello from hygiene-test!")
+    print("This repo intentionally has no hygiene files.")
+    print("Run the example_hygiene_check MCP tool to see what is missing.")
+
+
+if __name__ == "__main__":
+    main()
+"""
+    (repo_path / "src" / "main.py").write_text(main_py)
+
+    # -- .mcp.json (points back to darnit workspace) -------------------------
+    mcp_config = {
+        "mcpServers": {
+            "example-hygiene": {
+                "command": "uv",
+                "args": [
+                    "--directory",
+                    str(DARNIT_ROOT),
+                    "run",
+                    "darnit",
+                    "serve",
+                    "--framework",
+                    "example-hygiene",
+                ],
+            }
+        }
+    }
+    (repo_path / ".mcp.json").write_text(json.dumps(mcp_config, indent=2) + "\n")
+
+    # -- CLAUDE.md (instructions for Claude Code) -----------------------------
+    claude_md = """\
+# Hygiene Test Repo
+
+This repo intentionally fails all Project Hygiene Standard controls.
+
+Use the `example_hygiene_check` MCP tool to audit this repository,
+then fix each failing control.
+
+## Quick start
+
+1. Run the audit: ask Claude to check this repo's hygiene
+2. Review the 8 failing controls
+3. Fix them one by one (Claude can help create the missing files)
+
+## What's missing
+
+| Control | What to create |
+|---------|---------------|
+| PH-DOC-01 | README.md |
+| PH-DOC-02 | LICENSE |
+| PH-DOC-03 | README.md with a description section |
+| PH-SEC-01 | SECURITY.md |
+| PH-CFG-01 | .gitignore |
+| PH-CFG-02 | .editorconfig |
+| PH-QA-01 | CONTRIBUTING.md |
+| PH-CI-01 | .github/workflows/*.yml |
+"""
+    (repo_path / "CLAUDE.md").write_text(claude_md)
+
+    # -- Initialize git -------------------------------------------------------
+    try:
+        subprocess.run(
+            ["git", "init"], cwd=repo_path, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "add", "."], cwd=repo_path, capture_output=True, check=True
+        )
+        subprocess.run(
+            [
+                "git",
+                "commit",
+                "-m",
+                "Initial commit - intentionally non-compliant\n\n"
+                "This repository is designed for testing Project Hygiene Standard\n"
+                "compliance. It intentionally fails all 8 PH controls.",
+            ],
+            cwd=repo_path,
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode() if e.stderr else str(e)
+        print(f"\033[0;31mGit error: {stderr}\033[0m")
+        sys.exit(1)
+
+    print("\033[0;32m✓ Local repository created\033[0m")
+
+    # -- Optional GitHub repo -------------------------------------------------
+    if create_github:
+        _create_github_repo(repo_path, repo_name, github_org, make_template)
+
+    # -- Summary --------------------------------------------------------------
+    print(f"""
+\033[0;32m=== Repository Created ===\033[0m
+
+  Location: {repo_path}
+
+\033[1;33mWhat's intentionally MISSING (for testing):\033[0m
+  ✗ README.md          (PH-DOC-01, PH-DOC-03)
+  ✗ LICENSE            (PH-DOC-02)
+  ✗ SECURITY.md        (PH-SEC-01)
+  ✗ .gitignore         (PH-CFG-01)
+  ✗ .editorconfig      (PH-CFG-02)
+  ✗ CONTRIBUTING.md    (PH-QA-01)
+  ✗ CI workflows       (PH-CI-01)
+
+\033[0;32mNext steps:\033[0m
+  1. cd {repo_path}
+  2. Open in Claude Code
+  3. Ask Claude to run the hygiene audit and fix failures
+
+\033[0;36mOr apply quick fixes:\033[0m
+  python scripts/create-example-test-repo.py --remediate {repo_path}
+""")
+
+
+def remediate_repo(repo_path_str: str) -> None:
+    """Apply minimal fixes to make all 8 PH controls pass."""
+    repo_path = Path(repo_path_str).resolve()
+    if not repo_path.exists():
+        print(f"\033[0;31mError: '{repo_path}' does not exist.\033[0m")
+        sys.exit(1)
+
+    print("\033[0;32m=== Applying Quick Remediations ===\033[0m\n")
+    print(f"Target: {repo_path}\n")
+
+    created: list[str] = []
+
+    # PH-DOC-01 + PH-DOC-03: README with description (body must be >20 chars)
+    readme = repo_path / "README.md"
+    if not readme.exists():
+        readme.write_text(
+            "# hygiene-test-repo\n\n"
+            "A test project for the Project Hygiene Standard demo.\n"
+        )
+        created.append("README.md")
+
+    # PH-DOC-02: LICENSE
+    license_file = repo_path / "LICENSE"
+    if not license_file.exists():
+        license_file.write_text("MIT License - test project for demo purposes.\n")
+        created.append("LICENSE")
+
+    # PH-SEC-01: SECURITY.md
+    security = repo_path / "SECURITY.md"
+    if not security.exists():
+        security.write_text(
+            "# Security Policy\n\nTo report a vulnerability, open an issue.\n"
+        )
+        created.append("SECURITY.md")
+
+    # PH-CFG-01: .gitignore
+    gitignore = repo_path / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("*.pyc\n__pycache__/\n")
+        created.append(".gitignore")
+
+    # PH-CFG-02: .editorconfig
+    editorconfig = repo_path / ".editorconfig"
+    if not editorconfig.exists():
+        editorconfig.write_text(
+            "root = true\n\n[*]\nindent_style = space\nindent_size = 4\n"
+        )
+        created.append(".editorconfig")
+
+    # PH-QA-01: CONTRIBUTING.md
+    contributing = repo_path / "CONTRIBUTING.md"
+    if not contributing.exists():
+        contributing.write_text("# Contributing\n\nOpen a pull request.\n")
+        created.append("CONTRIBUTING.md")
+
+    # PH-CI-01: CI config
+    workflows_dir = repo_path / ".github" / "workflows"
+    ci_file = workflows_dir / "ci.yml"
+    if not ci_file.exists():
+        workflows_dir.mkdir(parents=True, exist_ok=True)
+        ci_file.write_text(
+            "name: CI\n"
+            "on: [push, pull_request]\n"
+            "jobs:\n"
+            "  check:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+        )
+        created.append(".github/workflows/ci.yml")
+
+    if created:
+        print("\033[0;32mCreated files:\033[0m")
+        for f in created:
+            print(f"  ✓ {f}")
+        print(f"\n\033[0;32mDone! {len(created)} files created.\033[0m")
+        print("Re-run the audit to verify all controls pass.")
+    else:
+        print("\033[1;33mAll files already exist — nothing to do.\033[0m")
+
+
+def _create_github_repo(
+    repo_path: Path,
+    repo_name: str,
+    github_org: str | None,
+    make_template: bool,
+) -> None:
+    """Create a GitHub repository using the gh CLI."""
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"], capture_output=True
+        )
+        if result.returncode != 0:
+            print(
+                "\033[1;33m⚠ GitHub CLI not authenticated. "
+                "Skipping GitHub repo creation.\033[0m"
+            )
+            return
+    except FileNotFoundError:
+        print(
+            "\033[1;33m⚠ GitHub CLI (gh) not found. "
+            "Skipping GitHub repo creation.\033[0m"
+        )
+        return
+
+    if not github_org:
+        result = subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True,
+            text=True,
+        )
+        github_org = result.stdout.strip()
+        print(f"\033[1;33mUsing GitHub user: {github_org}\033[0m")
+
+    print(f"\033[0;32mCreating GitHub repository: {github_org}/{repo_name}\033[0m")
+
+    try:
+        subprocess.run(
+            [
+                "gh",
+                "repo",
+                "create",
+                f"{github_org}/{repo_name}",
+                "--public",
+                "--source",
+                str(repo_path),
+                "--remote",
+                "origin",
+                "--description",
+                "Project Hygiene test repo - intentionally non-compliant",
+                "--push",
+            ],
+            capture_output=True,
+            check=True,
+        )
+        print("\033[0;32m✓ GitHub repository created\033[0m")
+
+        if make_template:
+            subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    "--method",
+                    "PATCH",
+                    "-H",
+                    "Accept: application/vnd.github+json",
+                    f"/repos/{github_org}/{repo_name}",
+                    "-f",
+                    "is_template=true",
+                ],
+                capture_output=True,
+                check=True,
+            )
+            print("\033[0;32m✓ Repository is now a template\033[0m")
+
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode() if e.stderr else str(e)
+        print(f"\033[1;33m⚠ GitHub error: {stderr}\033[0m")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create a test repo for the Project Hygiene Standard",
+    )
+    parser.add_argument(
+        "repo_name",
+        nargs="?",
+        default="hygiene-test-repo",
+        help="Name of the repository (default: hygiene-test-repo)",
+    )
+    parser.add_argument(
+        "--parent-dir",
+        default=None,
+        help=f"Directory to create the repo in (default: {tempfile.gettempdir()})",
+    )
+    parser.add_argument(
+        "--no-github",
+        action="store_true",
+        help="Skip GitHub repository creation",
+    )
+    parser.add_argument(
+        "--github-org",
+        default=None,
+        help="GitHub org or username (default: authenticated user)",
+    )
+    parser.add_argument(
+        "--template",
+        action="store_true",
+        help="Make the GitHub repo a template",
+    )
+    parser.add_argument(
+        "--remediate",
+        metavar="PATH",
+        default=None,
+        help="Apply quick fixes to an existing test repo instead of creating a new one",
+    )
+
+    args = parser.parse_args()
+
+    if args.remediate:
+        remediate_repo(args.remediate)
+    else:
+        create_repo(
+            repo_name=args.repo_name,
+            parent_dir=args.parent_dir,
+            create_github=not args.no_github,
+            github_org=args.github_org,
+            make_template=args.template,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/darnit/remediation/test_project_update.py
+++ b/tests/darnit/remediation/test_project_update.py
@@ -1,0 +1,210 @@
+"""Tests for project_update remediation support.
+
+Tests that the RemediationExecutor correctly applies project_update
+after successful remediations, and that the standalone apply_project_update
+function works for nested dotted paths.
+"""
+
+from darnit.config.framework_schema import (
+    FileCreateRemediationConfig,
+    ProjectUpdateRemediationConfig,
+    RemediationConfig,
+    TemplateConfig,
+)
+from darnit.remediation.executor import (
+    RemediationExecutor,
+    _set_nested_value,
+    apply_project_update,
+)
+
+
+class TestSetNestedValue:
+    """Tests for the _set_nested_value helper."""
+
+    def test_single_key_dict(self):
+        """Set a top-level key in a dict."""
+        obj = {}
+        _set_nested_value(obj, "key", "value")
+        assert obj["key"] == "value"
+
+    def test_nested_dict(self):
+        """Set a nested key in a dict."""
+        obj = {}
+        _set_nested_value(obj, "a.b.c", "deep")
+        assert obj["a"]["b"]["c"] == "deep"
+
+    def test_existing_intermediate(self):
+        """Set a nested key when intermediate dicts exist."""
+        obj = {"a": {"b": {}}}
+        _set_nested_value(obj, "a.b.c", "value")
+        assert obj["a"]["b"]["c"] == "value"
+
+    def test_overwrite_value(self):
+        """Overwrite an existing value."""
+        obj = {"a": {"b": "old"}}
+        _set_nested_value(obj, "a.b", "new")
+        assert obj["a"]["b"] == "new"
+
+
+class TestProjectUpdateRemediationConfig:
+    """Tests for ProjectUpdateRemediationConfig schema."""
+
+    def test_create_with_set(self):
+        """Create config with set values."""
+        config = ProjectUpdateRemediationConfig(
+            set={"security.policy.path": "SECURITY.md"}
+        )
+        assert config.set == {"security.policy.path": "SECURITY.md"}
+
+    def test_create_empty(self):
+        """Create config with no set values."""
+        config = ProjectUpdateRemediationConfig()
+        assert config.set == {}
+
+    def test_create_if_missing_default(self):
+        """create_if_missing defaults to True."""
+        config = ProjectUpdateRemediationConfig()
+        assert config.create_if_missing is True
+
+
+class TestExecutorProjectUpdate:
+    """Tests for RemediationExecutor project_update integration."""
+
+    def test_project_update_applied_after_file_create(self, tmp_path):
+        """project_update is applied after successful file_create."""
+        # Set up executor with a template
+        templates = {
+            "test_template": TemplateConfig(content="# Test file\n"),
+        }
+        executor = RemediationExecutor(
+            local_path=str(tmp_path),
+            owner="testowner",
+            repo="testrepo",
+            templates=templates,
+        )
+
+        # Config with file_create AND project_update
+        config = RemediationConfig(
+            file_create=FileCreateRemediationConfig(
+                path="SECURITY.md",
+                template="test_template",
+            ),
+            project_update=ProjectUpdateRemediationConfig(
+                set={"security.policy.path": "SECURITY.md"},
+            ),
+        )
+
+        result = executor.execute("TEST-01", config, dry_run=False)
+        assert result.success
+
+        # project_update should be noted in details
+        assert "project_update" in result.details
+
+    def test_project_update_dry_run_preview(self, tmp_path):
+        """Dry run shows project_update preview."""
+        templates = {
+            "test_template": TemplateConfig(content="# Test\n"),
+        }
+        executor = RemediationExecutor(
+            local_path=str(tmp_path),
+            owner="testowner",
+            repo="testrepo",
+            templates=templates,
+        )
+
+        config = RemediationConfig(
+            file_create=FileCreateRemediationConfig(
+                path="README.md",
+                template="test_template",
+            ),
+            project_update=ProjectUpdateRemediationConfig(
+                set={"documentation.readme.path": "README.md"},
+            ),
+        )
+
+        result = executor.execute("TEST-01", config, dry_run=True)
+        assert result.success
+        assert "project_update" in result.details
+        assert "would set" in result.details["project_update"]
+
+    def test_project_update_not_applied_on_failure(self, tmp_path):
+        """project_update is NOT applied when remediation fails."""
+        executor = RemediationExecutor(
+            local_path=str(tmp_path),
+            owner="testowner",
+            repo="testrepo",
+        )
+
+        # Config with file_create that will fail (no template)
+        config = RemediationConfig(
+            file_create=FileCreateRemediationConfig(
+                path="README.md",
+                template="nonexistent_template",
+            ),
+            project_update=ProjectUpdateRemediationConfig(
+                set={"documentation.readme.path": "README.md"},
+            ),
+        )
+
+        result = executor.execute("TEST-01", config, dry_run=False)
+        assert not result.success
+        # project_update should NOT be in details
+        assert "project_update" not in result.details
+
+    def test_project_update_without_primary_remediation(self, tmp_path):
+        """project_update alone (no file_create/exec/api_call) doesn't run."""
+        executor = RemediationExecutor(
+            local_path=str(tmp_path),
+            owner="testowner",
+            repo="testrepo",
+        )
+
+        # Config with only project_update, no primary action
+        config = RemediationConfig(
+            project_update=ProjectUpdateRemediationConfig(
+                set={"key": "value"},
+            ),
+        )
+
+        # Should fall through to "no remediation action configured"
+        result = executor.execute("TEST-01", config, dry_run=False)
+        assert not result.success
+        assert result.remediation_type == "none"
+
+
+class TestApplyProjectUpdate:
+    """Tests for standalone apply_project_update function."""
+
+    def test_creates_project_dir(self, tmp_path):
+        """Creates .project/ directory if it doesn't exist."""
+        config = ProjectUpdateRemediationConfig(
+            set={"security.policy.path": "SECURITY.md"},
+            create_if_missing=True,
+        )
+
+        apply_project_update(str(tmp_path), config, "TEST-01")
+
+        # Check .project/ was created
+        project_dir = tmp_path / ".project"
+        assert project_dir.exists()
+
+    def test_skip_if_no_project_and_not_create(self, tmp_path):
+        """Skip if no .project/ and create_if_missing=False."""
+        config = ProjectUpdateRemediationConfig(
+            set={"security.policy.path": "SECURITY.md"},
+            create_if_missing=False,
+        )
+
+        # Should not raise, just skip
+        apply_project_update(str(tmp_path), config, "TEST-01")
+
+        # .project/ should NOT be created
+        project_dir = tmp_path / ".project"
+        assert not project_dir.exists()
+
+    def test_empty_set_is_noop(self, tmp_path):
+        """Empty set dict is a no-op."""
+        config = ProjectUpdateRemediationConfig(set={})
+        apply_project_update(str(tmp_path), config, "TEST-01")
+        # Should not create .project/
+        assert not (tmp_path / ".project").exists()

--- a/tests/darnit/server/test_builtin_tools.py
+++ b/tests/darnit/server/test_builtin_tools.py
@@ -1,0 +1,164 @@
+"""Tests for built-in tools (audit, remediate, list_controls).
+
+Tests the TOML-first architecture: built-in tools that work with any
+framework TOML without requiring Python implementation code.
+"""
+
+import pytest
+
+from darnit.server.registry import ToolRegistry, ToolSpec
+from darnit.server.tools import BUILTIN_TOOLS
+
+
+class TestBuiltinToolsRegistry:
+    """Tests for BUILTIN_TOOLS registry."""
+
+    def test_builtin_tools_available(self):
+        """All expected built-in tools are registered."""
+        assert "audit" in BUILTIN_TOOLS
+        assert "remediate" in BUILTIN_TOOLS
+        assert "list_controls" in BUILTIN_TOOLS
+
+    def test_builtin_tools_callable(self):
+        """All built-in tools are callable."""
+        for name, fn in BUILTIN_TOOLS.items():
+            assert callable(fn), f"Built-in tool '{name}' is not callable"
+
+
+class TestToolSpecBuiltin:
+    """Tests for ToolSpec with builtin field."""
+
+    def test_create_with_builtin(self):
+        """ToolSpec can be created with builtin field."""
+        spec = ToolSpec(
+            name="audit",
+            handler="",
+            description="Run audit",
+            builtin="audit",
+        )
+        assert spec.builtin == "audit"
+        assert spec.handler == ""
+
+    def test_create_without_builtin(self):
+        """ToolSpec defaults builtin to None."""
+        spec = ToolSpec(
+            name="custom",
+            handler="mod:func",
+            description="Custom tool",
+        )
+        assert spec.builtin is None
+
+
+class TestToolRegistryBuiltin:
+    """Tests for ToolRegistry with builtin tools."""
+
+    def test_from_toml_with_builtin(self):
+        """Registry loads builtin tool definitions from TOML."""
+        config = {
+            "mcp": {
+                "tools": {
+                    "audit": {
+                        "builtin": "audit",
+                        "description": "Run audit",
+                    },
+                },
+            },
+        }
+        registry = ToolRegistry.from_toml(config)
+        assert "audit" in registry.tools
+        assert registry.tools["audit"].builtin == "audit"
+        assert registry.tools["audit"].handler == ""
+
+    def test_from_toml_builtin_and_handler_coexist(self):
+        """Registry loads both builtin and handler tools."""
+        config = {
+            "mcp": {
+                "tools": {
+                    "audit": {
+                        "builtin": "audit",
+                        "description": "Built-in audit",
+                    },
+                    "custom_tool": {
+                        "handler": "mymod:func",
+                        "description": "Custom",
+                    },
+                },
+            },
+        }
+        registry = ToolRegistry.from_toml(config)
+        assert len(registry.tools) == 2
+        assert registry.tools["audit"].builtin == "audit"
+        assert registry.tools["custom_tool"].handler == "mymod:func"
+
+    def test_from_toml_skips_no_builtin_no_handler(self):
+        """Registry skips tools with neither builtin nor handler."""
+        config = {
+            "mcp": {
+                "tools": {
+                    "broken": {
+                        "description": "No handler or builtin",
+                    },
+                },
+            },
+        }
+        registry = ToolRegistry.from_toml(config)
+        assert len(registry.tools) == 0
+
+    def test_load_builtin_handler(self):
+        """Loading a builtin tool returns a bound async function."""
+        import asyncio
+
+        spec = ToolSpec(
+            name="audit",
+            handler="",
+            description="Run audit",
+            builtin="audit",
+        )
+        registry = ToolRegistry()
+        handler = registry.load_handler(spec, framework_name="test-framework")
+        assert callable(handler)
+        assert asyncio.iscoroutinefunction(handler)
+
+    def test_load_builtin_unknown_raises(self):
+        """Loading an unknown builtin raises ValueError."""
+        spec = ToolSpec(
+            name="unknown",
+            handler="",
+            description="Unknown builtin",
+            builtin="nonexistent",
+        )
+        registry = ToolRegistry()
+        with pytest.raises(ValueError, match="Unknown builtin tool"):
+            registry.load_handler(spec, framework_name="test")
+
+    def test_load_builtin_no_framework_name_raises(self):
+        """Loading a builtin without framework_name raises ValueError."""
+        spec = ToolSpec(
+            name="audit",
+            handler="",
+            description="Run audit",
+            builtin="audit",
+        )
+        registry = ToolRegistry()
+        with pytest.raises(ValueError, match="requires a framework name"):
+            registry.load_handler(spec, framework_name=None)
+
+    def test_load_builtin_binds_framework_name(self):
+        """Builtin handler receives _framework_name when called."""
+        import asyncio
+
+        spec = ToolSpec(
+            name="audit",
+            handler="",
+            description="Run audit",
+            builtin="audit",
+        )
+        registry = ToolRegistry()
+        handler = registry.load_handler(spec, framework_name="my-framework")
+
+        # Call the handler - it will fail because the framework doesn't exist,
+        # but we can verify it received the framework name from the error message
+        result = asyncio.get_event_loop().run_until_complete(
+            handler(local_path="/nonexistent")
+        )
+        assert "my-framework" in result or "Error" in result

--- a/tests/darnit_example/__init__.py
+++ b/tests/darnit_example/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the darnit-example package."""

--- a/tests/darnit_example/conftest.py
+++ b/tests/darnit_example/conftest.py
@@ -1,0 +1,57 @@
+"""Shared fixtures for darnit-example tests."""
+
+import pytest
+
+from darnit.sieve.models import CheckContext
+
+
+@pytest.fixture
+def make_context(tmp_path):
+    """Factory fixture that creates a CheckContext pointing at a temp directory.
+
+    Usage:
+        ctx = make_context()                    # empty project
+        ctx = make_context({"README.md": "# Hi"})  # project with files
+    """
+
+    def _make(files: dict[str, str] | None = None) -> CheckContext:
+        if files:
+            for name, content in files.items():
+                filepath = tmp_path / name
+                filepath.parent.mkdir(parents=True, exist_ok=True)
+                filepath.write_text(content, encoding="utf-8")
+
+        return CheckContext(
+            owner="test-owner",
+            repo="test-repo",
+            local_path=str(tmp_path),
+            default_branch="main",
+            control_id="TEST",
+        )
+
+    return _make
+
+
+@pytest.fixture
+def empty_project(tmp_path):
+    """A temporary directory with no files (empty project)."""
+    return str(tmp_path)
+
+
+@pytest.fixture
+def full_project(tmp_path):
+    """A temporary directory with all hygiene files present."""
+    files = {
+        "README.md": "# Test Project\n\nThis is a test project for validating hygiene controls.\n\n## Installation\n\nRun `pip install test`.\n\n## Usage\n\nJust use it.\n",
+        "LICENSE": "MIT License\n\nCopyright 2024\n",
+        "SECURITY.md": "# Security Policy\n\n## Reporting\n\nEmail security@example.com\n",
+        ".gitignore": "*.pyc\n__pycache__/\n",
+        ".editorconfig": "root = true\n\n[*]\nindent_style = space\n",
+        "CONTRIBUTING.md": "# Contributing\n\nPRs welcome.\n",
+        ".github/workflows/ci.yml": "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n",
+    }
+    for name, content in files.items():
+        filepath = tmp_path / name
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text(content, encoding="utf-8")
+    return str(tmp_path)

--- a/tests/darnit_example/test_controls.py
+++ b/tests/darnit_example/test_controls.py
@@ -1,0 +1,110 @@
+"""Tests for Python-defined controls in darnit-example."""
+
+import pytest
+
+from darnit.sieve.models import PassOutcome
+
+
+class TestReadmeHasDescription:
+    """Tests for PH-DOC-03: ReadmeHasDescription."""
+
+    @pytest.mark.unit
+    def test_pass_with_description(self, make_context):
+        """README with substantive content should pass."""
+        ctx = make_context({
+            "README.md": "# My Project\n\nThis project provides a tool for managing compliance checks across open source repositories.\n"
+        })
+        # Import the module to register controls, then get the check
+        from darnit.sieve.registry import get_control_registry
+        from darnit_example.controls import level1  # noqa: F401
+
+        registry = get_control_registry()
+        spec = registry.get("PH-DOC-03")
+        assert spec is not None
+
+        # Execute the deterministic pass (first pass)
+        result = spec.passes[0].execute(ctx)
+        assert result.outcome == PassOutcome.PASS
+
+    @pytest.mark.unit
+    def test_fail_with_title_only(self, make_context):
+        """README with only a title should fail."""
+        ctx = make_context({"README.md": "# My Project\n"})
+        from darnit.sieve.registry import get_control_registry
+        from darnit_example.controls import level1  # noqa: F401
+
+        registry = get_control_registry()
+        spec = registry.get("PH-DOC-03")
+        result = spec.passes[0].execute(ctx)
+        assert result.outcome == PassOutcome.FAIL
+
+    @pytest.mark.unit
+    def test_fail_with_no_readme(self, make_context):
+        """No README at all should fail."""
+        ctx = make_context()
+        from darnit.sieve.registry import get_control_registry
+        from darnit_example.controls import level1  # noqa: F401
+
+        registry = get_control_registry()
+        spec = registry.get("PH-DOC-03")
+        result = spec.passes[0].execute(ctx)
+        assert result.outcome == PassOutcome.FAIL
+
+    @pytest.mark.unit
+    def test_pattern_pass_with_good_structure(self, make_context):
+        """README with multiple sections should pass pattern check."""
+        ctx = make_context({
+            "README.md": "# Project\n\nDescription here.\n\n## Installation\n\npip install it\n\n## Usage\n\nUse it.\n"
+        })
+        from darnit.sieve.registry import get_control_registry
+        from darnit_example.controls import level1  # noqa: F401
+
+        registry = get_control_registry()
+        spec = registry.get("PH-DOC-03")
+        # Pattern pass is the second pass
+        result = spec.passes[1].execute(ctx)
+        assert result.outcome == PassOutcome.PASS
+
+
+class TestCIConfigExists:
+    """Tests for PH-CI-01: CIConfigExists."""
+
+    @pytest.mark.unit
+    def test_pass_with_github_actions(self, make_context):
+        """GitHub Actions workflow should be detected."""
+        ctx = make_context({
+            ".github/workflows/ci.yml": "name: CI\non: push\n"
+        })
+        from darnit.sieve.registry import get_control_registry
+        from darnit_example.controls import level1  # noqa: F401
+
+        registry = get_control_registry()
+        spec = registry.get("PH-CI-01")
+        assert spec is not None
+
+        result = spec.passes[0].execute(ctx)
+        assert result.outcome == PassOutcome.PASS
+
+    @pytest.mark.unit
+    def test_pass_with_gitlab_ci(self, make_context):
+        """GitLab CI config should be detected."""
+        ctx = make_context({".gitlab-ci.yml": "stages:\n  - test\n"})
+        from darnit.sieve.registry import get_control_registry
+        from darnit_example.controls import level1  # noqa: F401
+
+        registry = get_control_registry()
+        spec = registry.get("PH-CI-01")
+        result = spec.passes[0].execute(ctx)
+        assert result.outcome == PassOutcome.PASS
+
+    @pytest.mark.unit
+    def test_fail_with_no_ci(self, make_context):
+        """No CI config should fail."""
+        ctx = make_context()
+        from darnit.sieve.registry import get_control_registry
+        from darnit_example.controls import level1  # noqa: F401
+
+        registry = get_control_registry()
+        spec = registry.get("PH-CI-01")
+        result = spec.passes[0].execute(ctx)
+        assert result.outcome == PassOutcome.FAIL

--- a/tests/darnit_example/test_implementation.py
+++ b/tests/darnit_example/test_implementation.py
@@ -1,0 +1,160 @@
+"""Tests for darnit_example implementation."""
+
+import pytest
+
+from darnit.core.plugin import ComplianceImplementation, ControlSpec
+from darnit_example import register
+from darnit_example.implementation import ExampleHygieneImplementation
+
+
+class TestExampleHygieneImplementation:
+    """Tests for ExampleHygieneImplementation class."""
+
+    @pytest.fixture
+    def impl(self):
+        return ExampleHygieneImplementation()
+
+    @pytest.mark.unit
+    def test_properties(self, impl):
+        assert impl.name == "example-hygiene"
+        assert impl.display_name == "Project Hygiene Standard (Example)"
+        assert impl.version == "0.1.0"
+        assert impl.spec_version == "PH v1.0"
+
+    @pytest.mark.unit
+    def test_is_compliance_implementation(self, impl):
+        assert isinstance(impl, ComplianceImplementation)
+
+    @pytest.mark.unit
+    def test_get_all_controls(self, impl):
+        controls = impl.get_all_controls()
+        assert len(controls) == 8
+        levels = {c.level for c in controls}
+        assert levels == {1, 2}
+
+    @pytest.mark.unit
+    def test_get_all_controls_are_control_specs(self, impl):
+        controls = impl.get_all_controls()
+        for control in controls:
+            assert isinstance(control, ControlSpec)
+
+    @pytest.mark.unit
+    def test_get_controls_by_level(self, impl):
+        level1 = impl.get_controls_by_level(1)
+        level2 = impl.get_controls_by_level(2)
+
+        assert len(level1) == 6
+        assert len(level2) == 2
+
+        assert all(c.level == 1 for c in level1)
+        assert all(c.level == 2 for c in level2)
+
+        assert len(level1) + len(level2) == len(impl.get_all_controls())
+
+    @pytest.mark.unit
+    def test_control_ids_are_ph_format(self, impl):
+        controls = impl.get_all_controls()
+        for control in controls:
+            assert control.control_id.startswith("PH-")
+            parts = control.control_id.split("-")
+            assert len(parts) >= 3
+
+    @pytest.mark.unit
+    def test_control_domains(self, impl):
+        controls = impl.get_all_controls()
+        valid_domains = {"DOC", "SEC", "CFG", "QA", "CI"}
+        for control in controls:
+            assert control.domain in valid_domains, f"Invalid domain: {control.domain}"
+
+    @pytest.mark.unit
+    def test_get_rules_catalog(self, impl):
+        catalog = impl.get_rules_catalog()
+        assert isinstance(catalog, dict)
+        assert len(catalog) == 8
+
+    @pytest.mark.unit
+    def test_get_remediation_registry(self, impl):
+        registry = impl.get_remediation_registry()
+        assert isinstance(registry, dict)
+        assert len(registry) > 0
+
+    @pytest.mark.unit
+    def test_get_framework_config_path(self, impl):
+        path = impl.get_framework_config_path()
+        assert path is not None
+        assert path.name == "example-hygiene.toml"
+        assert path.exists()
+
+
+class TestHandlerRegistration:
+    """Tests for handler registration."""
+
+    @pytest.fixture(autouse=True)
+    def clear_registry(self):
+        from darnit.core.handlers import get_handler_registry
+
+        registry = get_handler_registry()
+        registry.clear()
+        yield
+        registry.clear()
+
+    @pytest.mark.unit
+    def test_register_handlers_adds_tools(self):
+        from darnit.core.handlers import get_handler_registry
+
+        impl = ExampleHygieneImplementation()
+        impl.register_handlers()
+
+        registry = get_handler_registry()
+        handlers = registry.list_handlers()
+
+        assert len(handlers) > 0
+        handler_names = {h.name for h in handlers}
+        assert "example_hygiene_check" in handler_names
+
+    @pytest.mark.unit
+    def test_handlers_have_plugin_context(self):
+        from darnit.core.handlers import get_handler_registry
+
+        impl = ExampleHygieneImplementation()
+        impl.register_handlers()
+
+        registry = get_handler_registry()
+        handler_info = registry.get_handler_info("example_hygiene_check")
+
+        assert handler_info is not None
+        assert handler_info.plugin == "example-hygiene"
+
+    @pytest.mark.unit
+    def test_handlers_are_callable(self):
+        from darnit.core.handlers import get_handler_registry
+
+        impl = ExampleHygieneImplementation()
+        impl.register_handlers()
+
+        registry = get_handler_registry()
+        handler = registry.get_handler("example_hygiene_check")
+
+        assert handler is not None
+        assert callable(handler)
+
+
+class TestRegisterFunction:
+    """Tests for the register() entry point function."""
+
+    @pytest.mark.unit
+    def test_register_returns_implementation(self):
+        impl = register()
+        assert isinstance(impl, ExampleHygieneImplementation)
+
+    @pytest.mark.unit
+    def test_register_returns_compliance_implementation(self):
+        impl = register()
+        assert isinstance(impl, ComplianceImplementation)
+
+    @pytest.mark.unit
+    def test_register_returns_consistent_instance(self):
+        impl1 = register()
+        impl2 = register()
+        assert impl1.name == impl2.name
+        assert impl1.version == impl2.version

--- a/tests/darnit_example/test_remediation.py
+++ b/tests/darnit_example/test_remediation.py
@@ -1,0 +1,71 @@
+"""Tests for remediation actions in darnit-example."""
+
+import pytest
+
+from darnit_example.remediation.actions import create_gitignore, create_readme
+
+
+class TestCreateReadme:
+    """Tests for create_readme remediation action."""
+
+    @pytest.mark.unit
+    def test_dry_run(self, empty_project):
+        result = create_readme(empty_project, dry_run=True)
+        assert result["status"] == "dry_run"
+        assert "README.md" in result["message"]
+
+    @pytest.mark.unit
+    def test_creates_file(self, empty_project):
+        result = create_readme(empty_project, dry_run=False)
+        assert result["status"] == "created"
+
+        import os
+        assert os.path.exists(os.path.join(empty_project, "README.md"))
+
+    @pytest.mark.unit
+    def test_skips_existing(self, full_project):
+        result = create_readme(full_project, dry_run=False)
+        assert result["status"] == "skipped"
+
+    @pytest.mark.unit
+    def test_content_has_project_name(self, empty_project):
+        create_readme(empty_project, dry_run=False)
+
+        import os
+        with open(os.path.join(empty_project, "README.md")) as f:
+            content = f.read()
+        # Should include the directory name as the title
+        assert content.startswith("# ")
+        assert len(content) > 10
+
+
+class TestCreateGitignore:
+    """Tests for create_gitignore remediation action."""
+
+    @pytest.mark.unit
+    def test_dry_run(self, empty_project):
+        result = create_gitignore(empty_project, dry_run=True)
+        assert result["status"] == "dry_run"
+
+    @pytest.mark.unit
+    def test_creates_file(self, empty_project):
+        result = create_gitignore(empty_project, dry_run=False)
+        assert result["status"] == "created"
+
+        import os
+        assert os.path.exists(os.path.join(empty_project, ".gitignore"))
+
+    @pytest.mark.unit
+    def test_skips_existing(self, full_project):
+        result = create_gitignore(full_project, dry_run=False)
+        assert result["status"] == "skipped"
+
+    @pytest.mark.unit
+    def test_content_has_common_patterns(self, empty_project):
+        create_gitignore(empty_project, dry_run=False)
+
+        import os
+        with open(os.path.join(empty_project, ".gitignore")) as f:
+            content = f.read()
+        assert "__pycache__" in content
+        assert ".DS_Store" in content

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 members = [
     "darnit",
     "darnit-baseline",
+    "darnit-example",
     "darnit-mcp",
     "darnit-plugins",
     "darnit-testchecks",
@@ -442,12 +443,24 @@ dependencies = [
 requires-dist = [{ name = "darnit", editable = "packages/darnit" }]
 
 [[package]]
+name = "darnit-example"
+version = "0.1.0"
+source = { editable = "packages/darnit-example" }
+dependencies = [
+    { name = "darnit" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "darnit", editable = "packages/darnit" }]
+
+[[package]]
 name = "darnit-mcp"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "darnit" },
     { name = "darnit-baseline" },
+    { name = "darnit-example" },
 ]
 
 [package.optional-dependencies]
@@ -473,6 +486,7 @@ requires-dist = [
     { name = "darnit", editable = "packages/darnit" },
     { name = "darnit", extras = ["attestation"], marker = "extra == 'attestation'", editable = "packages/darnit" },
     { name = "darnit-baseline", editable = "packages/darnit-baseline" },
+    { name = "darnit-example", editable = "packages/darnit-example" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary

- **Built-in MCP tools**: Framework-level audit, list_controls, and remediate handlers that implementations get for free via TOML `[mcp.tools]` config with `builtin:` prefix
- **project_update wiring**: RemediationExecutor updates `.project/project.yaml` after successful remediation actions
- **on_pass context enrichment**: SieveOrchestrator applies `on_pass` config to update `.project/` when controls pass, so subsequent audits have richer context
- **darnit-example plugin**: Complete reference implementation showing how to build a plugin using TOML-first architecture with minimal Python
- **Implementation guide**: Updated docs covering the three-layer architecture (checking, remediation, MCP tools)

## Test plan

- [x] `uv run ruff check .` — all checks pass
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — 793 passed
- [ ] Review built-in tool handler resolution (`builtin:` prefix in ToolRegistry)
- [ ] Review darnit-example as a reference for third-party plugin authors

🤖 Generated with [Claude Code](https://claude.com/claude-code)