### PR TITLE
refactor: Extract canonical run_sieve_audit() and eliminate audit loop duplication

### DIFF
--- a/openspec/changes/extract-sieve-audit-loop/.openspec.yaml
+++ b/openspec/changes/extract-sieve-audit-loop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-07

--- a/openspec/changes/extract-sieve-audit-loop/design.md
+++ b/openspec/changes/extract-sieve-audit-loop/design.md
@@ -1,0 +1,100 @@
+## Context
+
+The sieve verification loop is implemented 3 times:
+
+1. **`darnit/tools/audit.py`** — `_run_sieve_checks()` (100 lines). The richest version: creates `UnifiedLocator`, passes `locator_config` to `CheckContext`, iterates by level via registry. Called by `run_checks()` which adds user config exclusions.
+2. **`darnit/server/tools/builtin_audit.py`** — `builtin_audit()` inline loop (15 lines). Simpler: flat iteration over pre-loaded controls, no locator, no exclusions.
+3. **`darnit-baseline/tools.py`** — `audit_openssf_baseline()` inline loop (20 lines). Similar to #2, also rebuilds summary dict inline instead of calling `summarize_results()`.
+
+Additionally, `detect_workflow_checks()` is duplicated between `darnit/remediation/helpers.py` and `darnit/remediation/github.py`.
+
+The existing public API from `darnit.tools` exports: `prepare_audit`, `run_checks`, `calculate_compliance`, `summarize_results`, `format_results_markdown`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Single sieve execution path so bug fixes and features (locator, exclusions) apply everywhere
+- All callers get `UnifiedLocator` integration and user config exclusion support
+- Reduce total code by ~120 lines (inline loops + duplicate formatter + duplicate utility)
+- Codify the pattern in the framework-design spec so future contributors don't re-introduce duplication
+
+**Non-Goals:**
+- Changing the sieve orchestrator internals (`SieveOrchestrator.verify()`)
+- Modifying how controls are loaded from TOML (that stays in config module)
+- Consolidating the broader report formatting system (summary tables, emoji mappings) — that's a separate change
+- Changing the `_run_baseline_checks()` in the remediation orchestrator — it already delegates to `prepare_audit()` + `run_checks()`
+
+## Decisions
+
+### Decision 1: Extract `run_sieve_audit()` from existing `_run_sieve_checks()`
+
+**Choice:** Rename `_run_sieve_checks()` to `run_sieve_audit()`, make it public, and broaden its signature to accept optional pre-loaded controls.
+
+**Alternatives considered:**
+- *Create a new function alongside `_run_sieve_checks`* — rejected because it would add yet another function; the existing one already does 90% of what's needed.
+- *Have callers use `run_checks()` directly* — rejected because `run_checks()` couples control loading with execution; callers that already loaded/filtered controls would need to reload.
+
+**Signature:**
+```python
+def run_sieve_audit(
+    owner: str,
+    repo: str,
+    local_path: str,
+    default_branch: str,
+    level: int = 3,
+    *,
+    controls: list[ControlSpec] | None = None,
+    tags: list[str] | None = None,
+    apply_user_config: bool = True,
+    stop_on_llm: bool = True,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+```
+
+Returns `(results, summary)` so callers don't need to call `summarize_results()` separately.
+
+### Decision 2: Keep `run_checks()` as a thin wrapper
+
+**Choice:** `run_checks()` becomes a thin wrapper that calls `run_sieve_audit()` and adds the skipped-controls dict to match its existing return type `(results, skipped_controls)`.
+
+**Rationale:** Preserves backward compatibility for the CLI path and the remediation orchestrator which both use `run_checks()`.
+
+### Decision 3: `builtin_audit()` delegates instead of reimplementing
+
+**Choice:** Rewrite `builtin_audit()` to:
+1. Load config and controls (existing code)
+2. Call `run_sieve_audit(controls=loaded_controls, ...)`
+3. Call `format_results_markdown()` for output
+
+Delete `_format_audit_report()` entirely (~90 lines).
+
+### Decision 4: `audit_openssf_baseline()` delegates instead of reimplementing
+
+**Choice:** Rewrite the sieve loop section to:
+1. Keep existing config/control loading and tag filtering
+2. Replace the inline loop + summary calculation with `run_sieve_audit(controls=filtered_controls, ...)`
+3. Continue using `format_results_markdown()` (already does this)
+
+### Decision 5: Delete `detect_workflow_checks` from `helpers.py`
+
+**Choice:** Delete the simpler version in `helpers.py` (~80 lines), keep the more complete version in `github.py` that handles matrix builds and job names.
+
+**Verification:** Grep for all imports of `detect_workflow_checks` from `helpers` and redirect to `github`.
+
+### Decision 6: Add spec requirements for audit pipeline pattern
+
+**Choice:** Add a new "Audit Pipeline" section to the framework-design spec that codifies:
+- All audit entry points MUST delegate to `run_sieve_audit()`
+- No module SHALL reimplement the sieve loop
+- Utility functions MUST NOT be duplicated within the framework package
+
+This serves both human developers and LLM coding agents who read the spec before writing code.
+
+## Risks / Trade-offs
+
+**[Signature change to `_run_sieve_checks`]** → The function is currently private (underscore prefix). Renaming to `run_sieve_audit` and making it public is safe since no external consumers depend on the private name. Internal callers (`run_checks`) are updated in the same change.
+
+**[`builtin_audit` loses its simpler formatter]** → The full `format_results_markdown()` produces longer output with remediation guidance and next steps. This is strictly better for MCP users since they get the same rich output regardless of entry point. If a minimal format is ever needed, it can be added as a `compact` parameter to the existing formatter.
+
+**[`run_checks()` return type unchanged]** → The existing `(results, skipped_controls)` return type is different from `run_sieve_audit()`'s `(results, summary)`. This is intentional — `run_checks` serves the CLI/orchestrator path that needs skipped control info, while `run_sieve_audit` serves MCP tools that need summaries.
+
+**[`detect_workflow_checks` removal from helpers]** → Any code importing from `helpers` will break. Mitigation: grep for all imports and update them before deleting. The function is only used in `github.py` itself and the remediation orchestrator.

--- a/openspec/changes/extract-sieve-audit-loop/proposal.md
+++ b/openspec/changes/extract-sieve-audit-loop/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The sieve verification loop — load controls, iterate, call `orchestrator.verify()`, collect results — is implemented 3 separate times in the codebase. Bugs fixed in one path don't reach the others. User config exclusions and UnifiedLocator support only exist in one path. The `detect_workflow_checks()` function is also duplicated within the same package. This creates maintenance burden and inconsistent behavior across entry points.
+
+## What Changes
+
+- Extract a single `run_sieve_audit()` function in `darnit/tools/audit.py` that encapsulates: control loading, registration, sieve iteration, result collection, and summary calculation
+- Refactor `audit_openssf_baseline()` in `darnit-baseline/tools.py` to delegate to the new function instead of reimplementing the loop
+- Refactor `builtin_audit()` in `darnit/server/tools/builtin_audit.py` to delegate to the new function
+- Delete `_format_audit_report()` from `builtin_audit.py` — use the existing `format_results_markdown()` instead
+- Delete the duplicate `detect_workflow_checks()` from `darnit/remediation/helpers.py` — keep the more complete version in `github.py`
+- Update framework-design spec to codify the single-pipeline rule so future code (by humans or LLMs) doesn't re-introduce duplication
+
+## Capabilities
+
+### New Capabilities
+- `audit-pipeline`: A unified audit pipeline function that all entry points use. Supports optional parameters for tag filtering, user config exclusions, UnifiedLocator integration, and stop-on-LLM behavior.
+
+### Modified Capabilities
+- `framework-design`: Add requirement that all audit entry points MUST delegate to the canonical audit pipeline. No module SHALL reimplement the sieve verification loop.
+
+## Impact
+
+- **`darnit/tools/audit.py`**: New `run_sieve_audit()` extracted from existing `_run_sieve_checks()` + `run_checks()`, broadened to accept pre-loaded controls
+- **`darnit/server/tools/builtin_audit.py`**: Simplified to ~30 lines — loads config, calls `run_sieve_audit()`, formats with `format_results_markdown()`
+- **`darnit-baseline/tools.py`**: `audit_openssf_baseline()` simplified — delegates to `run_sieve_audit()` instead of inline loop
+- **`darnit/remediation/helpers.py`**: `detect_workflow_checks()` deleted (~80 lines)
+- **`darnit-baseline/remediation/orchestrator.py`**: `_run_baseline_checks()` already delegates correctly, no change needed
+- **`openspec/specs/framework-design/spec.md`**: New section on audit pipeline requirements

--- a/openspec/changes/extract-sieve-audit-loop/specs/audit-pipeline/spec.md
+++ b/openspec/changes/extract-sieve-audit-loop/specs/audit-pipeline/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Single audit pipeline function
+The framework SHALL provide a single `run_sieve_audit()` function in `darnit.tools.audit` that encapsulates the full sieve verification loop: control iteration, `CheckContext` construction, `SieveOrchestrator.verify()` invocation, and result collection. All code paths that run audits MUST delegate to this function.
+
+#### Scenario: Framework builtin audit delegates to pipeline
+- **WHEN** `builtin_audit()` in `darnit/server/tools/builtin_audit.py` is called
+- **THEN** it SHALL call `run_sieve_audit()` instead of implementing its own sieve loop
+- **AND** the inline `for control in all_controls: ... orchestrator.verify(...)` loop SHALL be removed
+
+#### Scenario: Implementation audit delegates to pipeline
+- **WHEN** `audit_openssf_baseline()` in `darnit-baseline/tools.py` is called
+- **THEN** it SHALL call `run_sieve_audit()` instead of implementing its own sieve loop
+- **AND** the inline summary calculation (lines building `summary` dict) SHALL be removed
+
+#### Scenario: CLI audit delegates to pipeline
+- **WHEN** the CLI `cmd_audit()` runs checks
+- **THEN** it SHALL reach the pipeline through the existing `run_checks()` → `_run_sieve_checks()` chain (no change needed)
+
+### Requirement: Pipeline accepts pre-loaded controls
+The `run_sieve_audit()` function SHALL accept a list of pre-loaded `ControlSpec` objects, so callers that have already loaded and filtered controls do not need to reload them.
+
+#### Scenario: Caller provides controls
+- **WHEN** `run_sieve_audit()` is called with a `controls` parameter
+- **THEN** it SHALL use those controls directly without loading from TOML or registry
+
+#### Scenario: Caller does not provide controls
+- **WHEN** `run_sieve_audit()` is called without a `controls` parameter
+- **THEN** it SHALL load controls from the framework TOML and Python registry (existing behavior of `_run_sieve_checks`)
+
+### Requirement: Pipeline supports optional features
+The `run_sieve_audit()` function SHALL support optional parameters for features that not all callers need, with sensible defaults.
+
+#### Scenario: User config exclusions
+- **WHEN** `apply_user_config=True` (default)
+- **THEN** controls excluded in `.baseline.toml` SHALL be marked as `N/A` in results
+
+#### Scenario: UnifiedLocator integration
+- **WHEN** the pipeline runs
+- **THEN** it SHALL create a `UnifiedLocator` for `.project/` file resolution and pass it to each `CheckContext`
+
+#### Scenario: Tag filtering
+- **WHEN** a `tags` parameter is provided
+- **THEN** controls SHALL be filtered by the specified tags before sieve execution
+
+#### Scenario: Stop on LLM
+- **WHEN** `stop_on_llm=True` (default)
+- **THEN** LLM passes SHALL return `PENDING_LLM` for external consultation
+
+### Requirement: Pipeline returns structured results
+The `run_sieve_audit()` function SHALL return both the list of result dicts and a summary dict, so callers do not need to recompute summaries.
+
+#### Scenario: Return value structure
+- **WHEN** `run_sieve_audit()` completes
+- **THEN** it SHALL return a tuple of `(results: list[dict], summary: dict)` where summary contains counts for each status (PASS, FAIL, WARN, ERROR, N/A, PENDING_LLM, total)
+
+### Requirement: Single report formatter
+All audit entry points that produce markdown output SHALL use `format_results_markdown()` from `darnit.tools.audit`. No other module SHALL maintain a separate audit report formatter.
+
+#### Scenario: Builtin audit formatting
+- **WHEN** `builtin_audit()` formats output
+- **THEN** it SHALL call `format_results_markdown()` and the private `_format_audit_report()` function SHALL be deleted
+
+#### Scenario: Implementation audit formatting
+- **WHEN** `audit_openssf_baseline()` formats output
+- **THEN** it SHALL call `format_results_markdown()` (already does this — no change needed)
+
+### Requirement: No duplicate utility functions
+Functions that exist in multiple copies within the same package SHALL be consolidated to a single implementation.
+
+#### Scenario: detect_workflow_checks consolidation
+- **WHEN** workflow check detection is needed
+- **THEN** callers SHALL use `detect_workflow_checks()` from `darnit.remediation.github`
+- **AND** the duplicate in `darnit.remediation.helpers` SHALL be deleted

--- a/openspec/changes/extract-sieve-audit-loop/specs/framework-design/spec.md
+++ b/openspec/changes/extract-sieve-audit-loop/specs/framework-design/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Canonical Audit Pipeline
+All code that runs sieve-based compliance audits MUST delegate to the canonical `run_sieve_audit()` function in `darnit.tools.audit`. No other module SHALL reimplement the sieve verification loop (iterating controls, constructing `CheckContext`, calling `SieveOrchestrator.verify()`).
+
+This requirement prevents the duplication pattern where multiple entry points independently implement the audit loop, causing feature drift and inconsistent behavior.
+
+#### Scenario: New audit entry point
+- **WHEN** a developer (human or LLM) adds a new MCP tool or CLI command that runs compliance audits
+- **THEN** it MUST call `run_sieve_audit()` from `darnit.tools.audit`
+- **AND** it MUST NOT contain its own `for control in controls: orchestrator.verify(control, context)` loop
+
+#### Scenario: Implementation-specific audit tool
+- **WHEN** an implementation package (e.g., `darnit-baseline`) provides its own audit MCP tool
+- **THEN** it MUST delegate to `run_sieve_audit()` for the sieve execution
+- **AND** it MAY add implementation-specific pre-processing (config loading, tag filtering) and post-processing (attestation, custom formatting)
+
+### Requirement: No duplicate utility functions within a package
+A given function signature and purpose MUST NOT appear more than once within the `darnit` framework package. When a utility function is needed in multiple modules, it SHALL be defined in one canonical location and imported elsewhere.
+
+#### Scenario: Identifying duplication
+- **WHEN** two functions in `packages/darnit/` have the same name and similar behavior
+- **THEN** one SHALL be deleted and callers SHALL import from the canonical location

--- a/openspec/changes/extract-sieve-audit-loop/tasks.md
+++ b/openspec/changes/extract-sieve-audit-loop/tasks.md
@@ -1,0 +1,41 @@
+## 1. Extract `run_sieve_audit()` from existing code
+
+- [x] 1.1 Rename `_run_sieve_checks()` to `run_sieve_audit()` in `packages/darnit/src/darnit/tools/audit.py`, broaden signature to accept optional `controls: list[ControlSpec] | None`, `tags: list[str] | None`, `apply_user_config: bool = True`, `stop_on_llm: bool = True`
+- [x] 1.2 When `controls` parameter is provided, skip the TOML/registry loading and use provided controls directly; when `None`, preserve existing loading behavior
+- [x] 1.3 Add `summarize_results()` call at the end of `run_sieve_audit()` so it returns `(results, summary)` tuple
+- [x] 1.4 Add `run_sieve_audit` to the public exports in `darnit/tools/__init__.py`
+
+## 2. Update `run_checks()` as thin wrapper
+
+- [x] 2.1 Rewrite `run_checks()` to call `run_sieve_audit()` internally, converting its return from `(results, summary)` to the existing `(results, skipped_controls)` return type
+- [x] 2.2 Verify CLI path (`cmd_audit`) and remediation orchestrator (`_run_baseline_checks`) still work through `run_checks()` — run existing tests
+
+## 3. Refactor `builtin_audit()` to delegate
+
+- [x] 3.1 Rewrite `builtin_audit()` in `packages/darnit/src/darnit/server/tools/builtin_audit.py` to call `run_sieve_audit(controls=loaded_controls, ...)` instead of inline sieve loop
+- [x] 3.2 Replace `_format_audit_report()` call with `format_results_markdown()` from `darnit.tools.audit`
+- [x] 3.3 Delete `_format_audit_report()` function (~90 lines)
+
+## 4. Refactor `audit_openssf_baseline()` to delegate
+
+- [x] 4.1 Rewrite the sieve loop section in `audit_openssf_baseline()` in `packages/darnit-baseline/src/darnit_baseline/tools.py` to call `run_sieve_audit(controls=filtered_controls, ...)` instead of inline loop + summary calculation
+- [x] 4.2 Keep existing config/control loading and tag filtering before the call
+- [x] 4.3 Keep existing `format_results_markdown()` usage after the call
+
+## 5. Delete duplicate `detect_workflow_checks`
+
+- [x] 5.1 Grep for all imports of `detect_workflow_checks` from `darnit.remediation.helpers` and redirect them to `darnit.remediation.github`
+- [x] 5.2 Delete `detect_workflow_checks()` from `packages/darnit/src/darnit/remediation/helpers.py` (~80 lines)
+- [x] 5.3 Verify no remaining references to the deleted function
+
+## 6. Update framework-design spec
+
+- [x] 6.1 Add "Audit Pipeline" section to `openspec/specs/framework-design/spec.md` codifying: all audit entry points MUST delegate to `run_sieve_audit()`, no module SHALL reimplement the sieve loop, utility functions MUST NOT be duplicated within the framework package
+
+## 7. Tests and verification
+
+- [x] 7.1 Run `uv run ruff check .` — all linting passes
+- [x] 7.2 Run `uv run pytest tests/ --ignore=tests/integration/ -q` — all tests pass
+- [x] 7.3 Grep for any remaining inline `orchestrator.verify()` loops outside `run_sieve_audit()` — should be zero
+- [x] 7.4 Grep for `_format_audit_report` — should be zero hits
+- [x] 7.5 Grep for `detect_workflow_checks` in `helpers.py` — should be zero hits

--- a/openspec/specs/framework-design/spec.md
+++ b/openspec/specs/framework-design/spec.md
@@ -854,9 +854,40 @@ help_md = "..."
 
 ---
 
+## 10. Audit Pipeline
+
+### 10.1 Canonical Audit Function
+
+All code that runs sieve-based compliance audits MUST delegate to the canonical `run_sieve_audit()` function in `darnit.tools.audit`. No other module SHALL reimplement the sieve verification loop (iterating controls, constructing `CheckContext`, calling `SieveOrchestrator.verify()`).
+
+#### Requirement: Single audit pipeline
+- **WHEN** a developer (human or LLM) adds a new MCP tool or CLI command that runs compliance audits
+- **THEN** it MUST call `run_sieve_audit()` from `darnit.tools.audit`
+- **AND** it MUST NOT contain its own `for control in controls: orchestrator.verify(control, context)` loop
+
+#### Requirement: Implementation-specific audit tools delegate
+- **WHEN** an implementation package (e.g., `darnit-baseline`) provides its own audit MCP tool
+- **THEN** it MUST delegate to `run_sieve_audit()` for the sieve execution
+- **AND** it MAY add implementation-specific pre-processing (config loading, tag filtering) and post-processing (attestation, custom formatting)
+
+### 10.2 No Duplicate Utility Functions
+
+A given function signature and purpose MUST NOT appear more than once within the `darnit` framework package. When a utility function is needed in multiple modules, it SHALL be defined in one canonical location and imported elsewhere.
+
+#### Requirement: Identifying duplication
+- **WHEN** two functions in `packages/darnit/` have the same name and similar behavior
+- **THEN** one SHALL be deleted and callers SHALL import from the canonical location
+
+### 10.3 Single Report Formatter
+
+All audit entry points that produce markdown output SHALL use `format_results_markdown()` from `darnit.tools.audit`. No other module SHALL maintain a separate audit report formatter.
+
+---
+
 ## Version History
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.0.0-alpha.3 | 2026-02-06 | Added audit pipeline requirements (Section 10) |
 | 1.0.0-alpha.2 | 2026-02-05 | Added CEL expressions, handler registration, Sigstore verification |
 | 1.0.0-alpha | 2026-02-04 | Initial authoritative specification |

--- a/packages/darnit-baseline/src/darnit_baseline/tools.py
+++ b/packages/darnit-baseline/src/darnit_baseline/tools.py
@@ -55,9 +55,11 @@ def audit_openssf_baseline(
         load_controls_from_effective,
         load_effective_config_by_name,
     )
-    from darnit.filtering import filter_controls, parse_tags_arg
-    from darnit.sieve import CheckContext, SieveOrchestrator
-    from darnit.tools.audit import format_results_markdown
+    from darnit.tools.audit import (
+        calculate_compliance,
+        format_results_markdown,
+        run_sieve_audit,
+    )
 
     # Resolve path
     repo_path = Path(local_path).resolve()
@@ -83,49 +85,31 @@ def audit_openssf_baseline(
     controls = load_controls_from_effective(config)
     controls = [c for c in controls if c.level <= level]
 
-    # Apply tag-based filtering if specified
+    if not controls:
+        return "❌ No controls loaded"
+
+    # Normalize tags
+    tags_list: list[str] | None = None
     if tags:
-        # Normalize tags to a list
         if isinstance(tags, str):
             tags_list = [tags]
         else:
             tags_list = list(tags)
-        tag_filters = parse_tags_arg(tags_list)
-        controls = filter_controls(controls, filters=tag_filters)
 
-    if not controls:
-        return "❌ No controls loaded"
-
-    # Run checks via sieve
-    orchestrator = SieveOrchestrator()
     default_branch = _detect_default_branch(repo_path)
 
-    results = []
-    for control in controls:
-        context = CheckContext(
-            owner=owner,
-            repo=repo,
-            local_path=str(repo_path),
-            default_branch=default_branch,
-            control_id=control.control_id,
-            control_metadata={
-                "name": control.name,
-                "description": control.description,
-            },
-        )
-        result = orchestrator.verify(control, context)
-        results.append(result.to_legacy_dict())
-
-    # Calculate summary (uppercase keys for format_results_markdown compatibility)
-    summary = {
-        "total": len(results),
-        "PASS": len([r for r in results if r.get("status") == "PASS"]),
-        "FAIL": len([r for r in results if r.get("status") == "FAIL"]),
-        "WARN": len([r for r in results if r.get("status") == "WARN"]),
-        "N/A": len([r for r in results if r.get("status") == "NA"]),
-        "ERROR": len([r for r in results if r.get("status") == "ERROR"]),
-        "PENDING_LLM": len([r for r in results if r.get("status") == "PENDING_LLM"]),
-    }
+    # Delegate to canonical audit pipeline
+    results, summary = run_sieve_audit(
+        owner=owner,
+        repo=repo,
+        local_path=str(repo_path),
+        default_branch=default_branch,
+        level=level,
+        controls=controls,
+        tags=tags_list,
+        apply_user_config=True,
+        stop_on_llm=True,
+    )
 
     # Format output
     if output_format == "json":
@@ -137,12 +121,13 @@ def audit_openssf_baseline(
             "results": results,
         }, indent=2)
     else:
+        compliance = calculate_compliance(results, level)
         return format_results_markdown(
             owner=owner,
             repo=repo,
             results=results,
             summary=summary,
-            compliance={},
+            compliance=compliance,
             level=level,
             local_path=str(repo_path),
         )

--- a/packages/darnit/src/darnit/cli.py
+++ b/packages/darnit/src/darnit/cli.py
@@ -135,7 +135,6 @@ def cmd_audit(args: argparse.Namespace) -> int:
         load_effective_config_by_name,
     )
     from darnit.filtering import filter_controls, parse_tags_arg
-    from darnit.sieve import CheckContext, SieveOrchestrator
 
     # Warn about limited functionality in terminal mode
     logger.warning(
@@ -184,31 +183,25 @@ def cmd_audit(args: argparse.Namespace) -> int:
 
     logger.info(f"Auditing {repo_path} with {len(controls)} controls")
 
-    # Create orchestrator and run checks
-    orchestrator = SieveOrchestrator()
-
     # Detect owner/repo from git if available
     from darnit.core.utils import detect_owner_repo
 
     owner, repo = detect_owner_repo(str(repo_path))
     default_branch = _detect_default_branch(repo_path)
 
-    results = []
-    for control in controls:
-        context = CheckContext(
-            owner=owner,
-            repo=repo,
-            local_path=str(repo_path),
-            default_branch=default_branch,
-            control_id=control.control_id,
-            control_metadata={
-                "name": control.name,
-                "description": control.description,
-            },
-        )
+    # Delegate to canonical audit pipeline
+    from darnit.tools.audit import run_sieve_audit
 
-        result = orchestrator.verify(control, context)
-        results.append(result.to_legacy_dict())
+    results, _summary = run_sieve_audit(
+        owner=owner,
+        repo=repo,
+        local_path=str(repo_path),
+        default_branch=default_branch,
+        level=3,
+        controls=controls,
+        apply_user_config=False,  # CLI already applied filters above
+        stop_on_llm=True,
+    )
 
     # Output results
     if args.output == "json":

--- a/packages/darnit/src/darnit/remediation/__init__.py
+++ b/packages/darnit/src/darnit/remediation/__init__.py
@@ -20,11 +20,11 @@ from .executor import (
     RemediationResult,
 )
 from .github import (
+    detect_workflow_checks,
     enable_branch_protection,
 )
 from .helpers import (
     check_file_exists,
-    detect_workflow_checks,
     ensure_directory,
     format_error,
     format_success,

--- a/packages/darnit/src/darnit/remediation/helpers.py
+++ b/packages/darnit/src/darnit/remediation/helpers.py
@@ -108,88 +108,6 @@ def get_repo_maintainers(owner: str, repo: str) -> list[str]:
     return maintainers
 
 
-def detect_workflow_checks(local_path: str) -> list[dict[str, Any]]:
-    """Detect potential status check names from GitHub Actions workflows.
-
-    Args:
-        local_path: Path to repository
-
-    Returns:
-        List of dicts with workflow/job info
-    """
-    import re
-
-    workflow_dir = os.path.join(local_path, ".github", "workflows")
-    checks = []
-
-    if not os.path.exists(workflow_dir):
-        return checks
-
-    try:
-        import yaml
-        has_yaml = True
-    except ImportError:
-        has_yaml = False
-
-    for filename in os.listdir(workflow_dir):
-        if not filename.endswith(('.yml', '.yaml')):
-            continue
-
-        try:
-            content = read_file(workflow_dir, filename) or ""
-
-            if has_yaml:
-                try:
-                    workflow = yaml.safe_load(content)
-                except yaml.YAMLError:
-                    workflow = None
-
-                if workflow and isinstance(workflow, dict):
-                    workflow_name = workflow.get('name', filename.replace('.yml', '').replace('.yaml', ''))
-                    jobs = workflow.get('jobs', {})
-
-                    for job_id, job_config in jobs.items():
-                        if isinstance(job_config, dict):
-                            job_name = job_config.get('name', job_id)
-                            checks.append({
-                                'workflow': workflow_name,
-                                'job_id': job_id,
-                                'job_name': job_name,
-                                'check_name': f"{workflow_name} / {job_name}" if workflow_name != job_name else job_name,
-                                'file': filename
-                            })
-                else:
-                    # Regex fallback
-                    job_matches = re.findall(r'^\s{2}(\w+):\s*$', content, re.MULTILINE)
-                    workflow_name = filename.replace('.yml', '').replace('.yaml', '')
-                    for job_id in job_matches:
-                        if job_id not in ('on', 'name', 'env', 'permissions', 'defaults', 'concurrency'):
-                            checks.append({
-                                'workflow': workflow_name,
-                                'job_id': job_id,
-                                'job_name': job_id,
-                                'check_name': job_id,
-                                'file': filename
-                            })
-            else:
-                # No yaml module - use regex
-                job_matches = re.findall(r'^\s{2}(\w+):\s*$', content, re.MULTILINE)
-                workflow_name = filename.replace('.yml', '').replace('.yaml', '')
-                for job_id in job_matches:
-                    if job_id not in ('on', 'name', 'env', 'permissions', 'defaults', 'concurrency'):
-                        checks.append({
-                            'workflow': workflow_name,
-                            'job_id': job_id,
-                            'job_name': job_id,
-                            'check_name': job_id,
-                            'file': filename
-                        })
-
-        except (OSError, KeyError, TypeError, AttributeError):
-            continue
-
-    return checks
-
 
 def format_success(message: str, details: dict[str, Any], controls: list[str]) -> str:
     """Format a success message for remediation output.
@@ -240,7 +158,6 @@ __all__ = [
     "write_file_safe",
     "check_file_exists",
     "get_repo_maintainers",
-    "detect_workflow_checks",
     "format_success",
     "format_error",
     "format_warning",

--- a/packages/darnit/src/darnit/server/tools/builtin_audit.py
+++ b/packages/darnit/src/darnit/server/tools/builtin_audit.py
@@ -12,7 +12,6 @@ Usage in TOML:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from darnit.core.logging import get_logger
 
@@ -30,7 +29,7 @@ async def builtin_audit(
     """Run a compliance audit on a repository.
 
     Loads controls from the framework TOML, runs each through the sieve
-    verification pipeline, and returns a formatted report.
+    verification pipeline via run_sieve_audit(), and returns a formatted report.
 
     Args:
         local_path: Path to the repository to audit.
@@ -49,8 +48,12 @@ async def builtin_audit(
         load_effective_config_by_name,
     )
     from darnit.core.discovery import get_implementation
-    from darnit.sieve import CheckContext, SieveOrchestrator
     from darnit.sieve.registry import get_control_registry
+    from darnit.tools.audit import (
+        calculate_compliance,
+        format_results_markdown,
+        run_sieve_audit,
+    )
 
     repo_path = Path(local_path).resolve()
     if not repo_path.exists():
@@ -89,22 +92,6 @@ async def builtin_audit(
     ]
 
     all_controls = toml_controls + python_controls
-
-    # Filter by level
-    all_controls = [c for c in all_controls if (c.level or 0) <= level]
-
-    # Filter by tags if specified
-    if tags:
-        try:
-            from darnit.filtering import filter_controls, parse_tags_arg
-
-            parsed_tags = parse_tags_arg(tags) if isinstance(tags, str) else tags
-            all_controls = filter_controls(all_controls, parsed_tags)
-        except ImportError:
-            logger.debug("Filtering module not available, skipping tag filter")
-        except Exception as e:
-            return f"Error filtering controls: {e}"
-
     all_controls.sort(key=lambda c: c.control_id)
 
     if not all_controls:
@@ -115,127 +102,41 @@ async def builtin_audit(
 
     owner, repo = detect_owner_repo(str(repo_path))
 
-    # Run sieve verification
-    orchestrator = SieveOrchestrator()
-    results: list[dict[str, Any]] = []
+    # Normalize tags
+    tags_list: list[str] | None = None
+    if tags:
+        if isinstance(tags, str):
+            tags_list = [tags]
+        else:
+            tags_list = list(tags)
 
-    for control in all_controls:
-        context = CheckContext(
-            owner=owner,
-            repo=repo,
-            local_path=str(repo_path),
-            default_branch="main",
-            control_id=control.control_id,
-            control_metadata={
-                "name": control.name,
-                "description": control.description,
-            },
-        )
-        result = orchestrator.verify(control, context)
-        results.append(result.to_legacy_dict())
+    # Delegate to canonical audit pipeline
+    results, summary = run_sieve_audit(
+        owner=owner,
+        repo=repo,
+        local_path=str(repo_path),
+        default_branch="main",
+        level=level,
+        controls=all_controls,
+        tags=tags_list,
+        apply_user_config=True,
+        stop_on_llm=True,
+    )
 
     # Format output
     if output_format == "json":
         return json_mod.dumps(results, indent=2, default=str)
 
-    return _format_audit_report(
-        framework_name=_framework_name,
-        repo_path=str(repo_path),
-        level=level,
+    compliance = calculate_compliance(results, level)
+    return format_results_markdown(
+        owner=owner,
+        repo=repo,
         results=results,
+        summary=summary,
+        compliance=compliance,
+        level=level,
+        local_path=str(repo_path),
     )
-
-
-
-def _format_audit_report(
-    framework_name: str,
-    repo_path: str,
-    level: int,
-    results: list[dict[str, Any]],
-) -> str:
-    """Format audit results as a markdown report."""
-    passed = [r for r in results if r.get("status") == "PASS"]
-    failed = [r for r in results if r.get("status") == "FAIL"]
-    warned = [r for r in results if r.get("status") == "WARN"]
-    other = [r for r in results if r.get("status") not in ("PASS", "FAIL", "WARN")]
-
-    lines: list[str] = []
-    lines.append(f"# {framework_name} Audit Report")
-    lines.append("")
-    lines.append(f"**Path:** {repo_path}")
-    lines.append(f"**Level Assessed:** {level}")
-    lines.append("")
-
-    # Summary
-    lines.append("## Summary")
-    lines.append("")
-    lines.append("| Status | Count |")
-    lines.append("|--------|-------|")
-    lines.append(f"| Pass | {len(passed)} |")
-    lines.append(f"| Fail | {len(failed)} |")
-    if warned:
-        lines.append(f"| Needs Verification | {len(warned)} |")
-    if other:
-        lines.append(f"| Other | {len(other)} |")
-    lines.append(f"| **Total** | **{len(results)}** |")
-    lines.append("")
-
-    # Detailed results
-    lines.append("## Results")
-    lines.append("")
-
-    if failed:
-        lines.append(f"### FAIL ({len(failed)})")
-        lines.append("")
-        for r in failed:
-            cid = r.get("id", "?")
-            lvl = r.get("level", "?")
-            detail = r.get("details", "No details")
-            lines.append(f"- **{cid}** (L{lvl}): {detail}")
-        lines.append("")
-
-    if warned:
-        lines.append(f"### NEEDS VERIFICATION ({len(warned)})")
-        lines.append("")
-        for r in warned:
-            cid = r.get("id", "?")
-            lvl = r.get("level", "?")
-            detail = r.get("details", "")
-            lines.append(f"- **{cid}** (L{lvl}): {detail}")
-        lines.append("")
-
-    if passed:
-        lines.append(f"### PASS ({len(passed)})")
-        lines.append("")
-        for r in passed:
-            cid = r.get("id", "?")
-            lvl = r.get("level", "?")
-            detail = r.get("details", "")
-            lines.append(f"- **{cid}** (L{lvl}): {detail}")
-        lines.append("")
-
-    if other:
-        lines.append(f"### OTHER ({len(other)})")
-        lines.append("")
-        for r in other:
-            cid = r.get("id", "?")
-            lvl = r.get("level", "?")
-            status = r.get("status", "?")
-            detail = r.get("details", "")
-            lines.append(f"- **{cid}** (L{lvl}) [{status}]: {detail}")
-        lines.append("")
-
-    # Remediation guidance
-    if failed:
-        lines.append("## Remediation")
-        lines.append("")
-        lines.append(
-            "Run the `remediate` tool to auto-fix controls with "
-            "TOML-defined templates."
-        )
-        lines.append("")
-
-    return "\n".join(lines)
 
 
 __all__ = ["builtin_audit"]

--- a/packages/darnit/src/darnit/tools/__init__.py
+++ b/packages/darnit/src/darnit/tools/__init__.py
@@ -40,6 +40,7 @@ from .audit import (
     list_available_checks,
     prepare_audit,
     run_checks,
+    run_sieve_audit,
     summarize_results,
 )
 
@@ -79,6 +80,7 @@ __all__ = [
     # Audit
     "AuditOptions",
     "prepare_audit",
+    "run_sieve_audit",
     "run_checks",
     "calculate_compliance",
     "summarize_results",

--- a/packages/darnit/src/darnit/tools/audit.py
+++ b/packages/darnit/src/darnit/tools/audit.py
@@ -290,8 +290,9 @@ def run_checks(
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
     """Run OSPS baseline checks at the specified level.
 
-    All checks are defined in TOML with optional Python functions for complex
-    checks referenced via config_check.
+    Thin wrapper around run_sieve_audit() that returns the
+    (results, skipped_controls) tuple expected by CLI and
+    remediation orchestrator callers.
 
     Args:
         owner: GitHub org/user
@@ -306,50 +307,33 @@ def run_checks(
         Tuple of (check_results, skipped_controls)
         where skipped_controls maps control_id to reason
     """
-    # Load user config exclusions if enabled
-    skipped_controls: dict[str, str] = {}
-    excluded_ids: set[str] = set()
+    skipped_controls = get_excluded_control_ids(local_path) if apply_user_config else {}
 
-    if apply_user_config:
-        skipped_controls = get_excluded_control_ids(local_path)
-        excluded_ids = set(skipped_controls.keys())
-        if excluded_ids:
-            logger.info(f"Skipping {len(excluded_ids)} controls per user config")
-
-    # Use TOML-based sieve execution
-    results = _run_sieve_checks(
-        owner, repo, local_path, default_branch, level, stop_on_llm
+    results, _summary = run_sieve_audit(
+        owner, repo, local_path, default_branch, level,
+        apply_user_config=apply_user_config,
+        stop_on_llm=stop_on_llm,
     )
-
-    # Filter out excluded controls and mark them as N/A
-    if excluded_ids:
-        filtered_results = []
-        for r in results:
-            control_id = r.get("id", "")
-            if control_id in excluded_ids:
-                # Replace result with N/A status
-                filtered_results.append({
-                    "id": control_id,
-                    "status": "N/A",
-                    "details": f"Excluded via .baseline.toml: {skipped_controls.get(control_id, 'User override')}",
-                    "level": r.get("level", 1),
-                })
-            else:
-                filtered_results.append(r)
-        results = filtered_results
 
     return results, skipped_controls
 
 
-def _run_sieve_checks(
+def run_sieve_audit(
     owner: str,
     repo: str,
     local_path: str,
     default_branch: str,
-    level: int,
-    stop_on_llm: bool,
-) -> list[dict[str, Any]]:
-    """Run checks using the progressive sieve verification pipeline.
+    level: int = 3,
+    *,
+    controls: list | None = None,
+    tags: list[str] | None = None,
+    apply_user_config: bool = True,
+    stop_on_llm: bool = True,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """Run a sieve-based compliance audit — the canonical audit pipeline.
+
+    All code paths that run audits MUST delegate to this function.
+    No other module SHALL reimplement the sieve verification loop.
 
     This implements the 4-phase verification model:
     1. DETERMINISTIC - File existence, API checks, config lookups, external commands
@@ -357,19 +341,21 @@ def _run_sieve_checks(
     3. LLM - LLM-assisted analysis (returns PENDING_LLM for consultation)
     4. MANUAL - Always returns WARN with verification steps
 
-    Controls are defined in TOML (openssf-baseline.toml) with optional Python
-    functions for complex checks referenced via config_check.
-
     Args:
         owner: GitHub org/user
         repo: Repository name
         local_path: Path to repository
         default_branch: Default branch name
         level: Maximum level to check (1, 2, or 3)
-        stop_on_llm: Return PENDING_LLM for LLM consultation
+        controls: Pre-loaded ControlSpec objects. If None, loads from
+            TOML/registry automatically.
+        tags: Tag filters to apply to controls (e.g., ["domain=AC"]).
+        apply_user_config: Apply .baseline.toml user config exclusions.
+        stop_on_llm: Return PENDING_LLM for LLM consultation.
 
     Returns:
-        List of check results in legacy format
+        Tuple of (results, summary) where results is a list of check result
+        dicts and summary contains status counts (PASS, FAIL, WARN, etc.).
     """
     sieve = _get_sieve_components()
     if not sieve:
@@ -382,26 +368,55 @@ def _run_sieve_checks(
     SieveOrchestrator = sieve["SieveOrchestrator"]
     CheckContext = sieve["CheckContext"]
 
-    # Register Python-defined controls via plugin system
-    # These provide complex check functions referenced by TOML config_check
-    try:
-        from darnit.core.discovery import get_default_implementation
+    # Load user config exclusions if enabled
+    excluded_ids: set[str] = set()
+    if apply_user_config:
+        skipped = get_excluded_control_ids(local_path)
+        excluded_ids = set(skipped.keys())
+        if excluded_ids:
+            logger.info(f"Skipping {len(excluded_ids)} controls per user config")
 
-        impl = get_default_implementation()
-        if impl and hasattr(impl, "register_controls"):
-            impl.register_controls()
-            logger.debug(f"Registered Python control definitions from {impl.name}")
-        elif impl:
-            logger.debug(f"Implementation {impl.name} does not provide register_controls()")
-        else:
-            logger.debug("No compliance implementation found for control registration")
-    except Exception as e:
-        logger.debug(f"Python control modules not available: {e}")
+    # Resolve controls: use provided list or load from TOML/registry
+    if controls is not None:
+        all_controls = list(controls)
+    else:
+        # Register Python-defined controls via plugin system
+        try:
+            from darnit.core.discovery import get_default_implementation
 
-    # Register controls from TOML framework definition (primary source of truth)
-    _register_toml_controls()
+            impl = get_default_implementation()
+            if impl and hasattr(impl, "register_controls"):
+                impl.register_controls()
+                logger.debug(f"Registered Python control definitions from {impl.name}")
+            elif impl:
+                logger.debug(f"Implementation {impl.name} does not provide register_controls()")
+            else:
+                logger.debug("No compliance implementation found for control registration")
+        except Exception as e:
+            logger.debug(f"Python control modules not available: {e}")
 
-    registry = get_control_registry()
+        # Register controls from TOML framework definition (primary source of truth)
+        _register_toml_controls()
+
+        registry = get_control_registry()
+        all_controls = []
+        for lvl in range(1, level + 1):
+            all_controls.extend(registry.get_specs_by_level(lvl))
+
+    # Filter by level (applies to both provided and loaded controls)
+    all_controls = [c for c in all_controls if (c.level or 0) <= level]
+
+    # Filter by tags if specified
+    if tags:
+        try:
+            from darnit.filtering import filter_controls, parse_tags_arg
+            tag_filters = parse_tags_arg(tags) if isinstance(tags, (str, list)) else tags
+            if isinstance(tag_filters, str):
+                tag_filters = [tag_filters]
+            all_controls = filter_controls(all_controls, tag_filters)
+        except ImportError:
+            logger.debug("Filtering module not available, skipping tag filter")
+
     orchestrator = SieveOrchestrator(stop_on_llm=stop_on_llm)
     all_results = []
 
@@ -416,33 +431,44 @@ def _run_sieve_checks(
     except (RuntimeError, ValueError, TypeError, KeyError, AttributeError, OSError) as e:
         logger.warning(f"Failed to create UnifiedLocator: {e}")
 
-    # Get all control specs for requested levels from registry
-    for lvl in range(1, level + 1):
-        specs = registry.get_specs_by_level(lvl)
-        for spec in specs:
-            # Create check context
-            context = CheckContext(
-                owner=owner,
-                repo=repo,
-                local_path=local_path,
-                default_branch=default_branch,
-                control_id=spec.control_id,
-                control_metadata={
-                    "name": spec.name,
-                    "description": spec.description,
-                    "full": spec.metadata.get("full", ""),
-                },
-                locator=locator,
-                locator_config=spec.locator_config,
-            )
+    # Run sieve verification for each control
+    for spec in all_controls:
+        control_id = spec.control_id
 
-            # Run sieve verification
-            sieve_result = orchestrator.verify(spec, context)
+        # Handle user config exclusions
+        if control_id in excluded_ids:
+            all_results.append({
+                "id": control_id,
+                "status": "N/A",
+                "details": "Excluded via .baseline.toml",
+                "level": spec.level or 1,
+            })
+            continue
 
-            # Convert to legacy dict format
-            all_results.append(sieve_result.to_legacy_dict())
+        # Create check context
+        context = CheckContext(
+            owner=owner,
+            repo=repo,
+            local_path=local_path,
+            default_branch=default_branch,
+            control_id=control_id,
+            control_metadata={
+                "name": spec.name,
+                "description": spec.description,
+                "full": spec.metadata.get("full", ""),
+            },
+            locator=locator,
+            locator_config=spec.locator_config,
+        )
 
-    return all_results
+        # Run sieve verification
+        sieve_result = orchestrator.verify(spec, context)
+
+        # Convert to legacy dict format
+        all_results.append(sieve_result.to_legacy_dict())
+
+    summary = summarize_results(all_results)
+    return all_results, summary
 
 
 def calculate_compliance(
@@ -927,6 +953,7 @@ def list_available_checks() -> dict[str, list[dict[str, Any]]]:
 __all__ = [
     "AuditOptions",
     "prepare_audit",
+    "run_sieve_audit",
     "run_checks",
     "calculate_compliance",
     "summarize_results",

--- a/tests/darnit/remediation/test_helpers.py
+++ b/tests/darnit/remediation/test_helpers.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 import pytest
 
+from darnit.remediation.github import detect_workflow_checks
 from darnit.remediation.helpers import (
     check_file_exists,
-    detect_workflow_checks,
     ensure_directory,
     format_error,
     format_success,


### PR DESCRIPTION
## Summary

- Extract `run_sieve_audit()` as the single canonical audit pipeline function that all entry points delegate to
- Eliminate 3 duplicate sieve verification loops (`builtin_audit`, `audit_openssf_baseline`, `cli.py`) plus inline summary calculation
- Delete `_format_audit_report()` (~90 lines) — all callers now use `format_results_markdown()`
- Delete duplicate `detect_workflow_checks()` from `helpers.py` (~80 lines) — keep the more complete version in `github.py`
- Add Audit Pipeline requirements to framework-design spec (Section 10)

**Net reduction:** ~190 lines of duplicate code. All callers now get UnifiedLocator integration and user config exclusion support automatically.

## Motivation

The sieve verification loop — load controls, iterate, call `orchestrator.verify()`, collect results — was implemented in 4 separate places. Bugs fixed in one path didn't reach others. Features like UnifiedLocator and `.baseline.toml` exclusions only existed in the richest path (`_run_sieve_checks`).

## Test plan

- [x] `uv run ruff check .` — all linting passes
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — 828 tests pass, 0 failures
- [x] Grep verification: zero `_format_audit_report` hits, zero `detect_workflow_checks` in helpers.py
- [x] Only `run_sieve_audit()` contains the sieve loop; all other audit entry points delegate

🤖 Generated with [Claude Code](https://claude.com/claude-code)