### PR TITLE
fix: Manual-only TOML remediations no longer fall through to legacy path

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
+++ b/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
@@ -320,7 +320,7 @@ def _apply_remediation(
             "message": "All controls marked as N/A in .project.yaml",
         }
 
-    # Try declarative remediation first (only for applicable controls)
+    # Try executable declarative remediation first (only for applicable controls)
     for control_id in applicable_controls:
         remediation_config, templates = _get_declarative_remediation(control_id)
         if remediation_config:
@@ -339,6 +339,21 @@ def _apply_remediation(
             if skipped_controls:
                 result["skipped_controls"] = skipped_controls
             return result
+
+    # Try manual-only declarative remediation before legacy fallthrough
+    manual_result = _get_manual_remediation(applicable_controls)
+    if manual_result:
+        result = {
+            "category": category,
+            "status": "manual",
+            "description": info["description"],
+            "controls": info["controls"],
+            "result": manual_result,
+            "declarative": True,
+        }
+        if skipped_controls:
+            result["skipped_controls"] = skipped_controls
+        return result
 
     # Fall back to legacy Python functions
     result = _apply_legacy_remediation(


### PR DESCRIPTION
## Summary

- Controls with only `remediation.manual` in TOML (like OSPS-QA-03.01) were falling through to the legacy Python function lookup, which fails with "function not implemented" for controls that have no legacy handler
- The orchestrator now checks for manual-only declarative remediation after executable types (file_create, exec, api_call) but before the legacy fallthrough

## Details

The remediation dispatch order is now:
1. **Executable declarative** (file_create, exec, api_call) — unchanged
2. **Manual-only declarative** — **NEW** — returns TOML-defined manual steps directly
3. **Legacy Python functions** — unchanged fallback

This fixes OSPS-QA-03.01 (RequiredStatusChecks) which previously had an `api_call` remediation requiring an unresolvable `ci.required_checks` context key. That was already replaced with `remediation.manual` in the TOML, but the orchestrator wasn't picking it up.

Note: 3 of the 4 items in the original plan were already fixed on main. This PR addresses the remaining issue.

## Test plan

- [x] All 828 tests pass (no regressions)
- [x] `uv run ruff check .` clean
- [ ] Manual: run `remediate_audit_findings` on a repo where QA-03.01 fails — should return manual steps instead of "function not implemented"

🤖 Generated with [Claude Code](https://claude.com/claude-code)