### PR TITLE
fix: Resolve use_locator in effective config path

### DIFF
--- a/packages/darnit/src/darnit/config/merger.py
+++ b/packages/darnit/src/darnit/config/merger.py
@@ -277,8 +277,21 @@ def merge_control(
             effective.remediation_config = dict(framework_control.remediation.config)
 
         # Store passes config for sieve (flat list of handler invocations)
+        # Resolve use_locator before dumping so handlers get files lists
         if framework_control.passes:
-            effective.passes_config = [p.model_dump() for p in framework_control.passes]
+            from .control_loader import _resolve_handler_invocations
+
+            locator_discover = None
+            if framework_control.locator and framework_control.locator.discover:
+                locator_discover = framework_control.locator.discover
+
+            resolved = _resolve_handler_invocations(
+                framework_control.passes,
+                {},  # shared_handlers resolved separately
+                locator_discover,
+                control_id,
+            )
+            effective.passes_config = [p.model_dump() for p in resolved]
 
     else:
         # Custom control from user - name and description required, level/domain optional

--- a/tests/darnit/sieve/test_handler_architecture.py
+++ b/tests/darnit/sieve/test_handler_architecture.py
@@ -717,6 +717,48 @@ class TestUseLocatorAndOnPass:
         assert "security.policy.path" in on_pass.project_update
 
     @pytest.mark.unit
+    def test_use_locator_resolved_through_effective_config(self):
+        """use_locator must be resolved when loading via effective config path.
+
+        Regression test: the merger must resolve use_locator before dumping
+        passes to dicts, otherwise the handler gets files=[] and returns
+        INCONCLUSIVE instead of PASS/FAIL.
+        """
+        from darnit.config.framework_schema import (
+            ControlConfig,
+            FrameworkDefaults,
+            HandlerInvocation,
+            LocatorConfig,
+        )
+        from darnit.config.merger import merge_control
+
+        control = ControlConfig(
+            name="Test file check",
+            description="Check a file exists",
+            level=1,
+            passes=[
+                HandlerInvocation(handler="file_exists", use_locator=True),
+                HandlerInvocation(handler="manual", steps=["Verify manually"]),
+            ],
+            locator=LocatorConfig(
+                discover=["SECURITY.md", ".github/SECURITY.md"],
+                kind="file",
+            ),
+        )
+        defaults = FrameworkDefaults()
+
+        effective = merge_control("T-01", control, None, defaults)
+
+        # The passes_config should have files resolved from locator
+        assert effective.passes_config is not None
+        file_exists_pass = effective.passes_config[0]
+        assert file_exists_pass["handler"] == "file_exists"
+        assert file_exists_pass.get("files") == [
+            "SECURITY.md",
+            ".github/SECURITY.md",
+        ], f"use_locator not resolved! files={file_exists_pass.get('files')}"
+
+    @pytest.mark.unit
     def test_auto_derive_on_pass_skips_when_explicit(self):
         """Auto-derive skips when on_pass is already set."""
         from darnit.config.control_loader import _auto_derive_on_pass

--- a/tests/darnit_baseline/test_handler_dispatch_integration.py
+++ b/tests/darnit_baseline/test_handler_dispatch_integration.py
@@ -412,3 +412,52 @@ class TestFlatListOrdering:
         assert result.status == "PASS"
         assert result.evidence.get("found_file") == "/path/to/SECURITY.md"
         assert result.evidence.get("checked_file") == "/path/to/SECURITY.md"
+
+
+# =============================================================================
+# Regression: use_locator must resolve through effective config path
+# =============================================================================
+
+
+class TestUseLocatorEffectivePath:
+    """Regression test: use_locator must be resolved when loading via effective config.
+
+    The effective config path (merger → control_from_effective) must resolve
+    use_locator=true before passing handler invocations to the orchestrator.
+    Without this, file_exists handlers get files=[] and return INCONCLUSIVE.
+    """
+
+    @pytest.mark.unit
+    def test_use_locator_controls_have_files_in_effective_config(self):
+        """All use_locator=true controls must have files populated after effective loading."""
+        from pathlib import Path
+
+        from darnit.config import load_controls_from_effective, load_effective_config_by_name
+
+        config = load_effective_config_by_name("openssf-baseline", Path("."))
+        controls = load_controls_from_effective(config)
+
+        # Known controls that use use_locator=true
+        use_locator_controls = {
+            "OSPS-BR-07.01", "OSPS-DO-01.01", "OSPS-DO-02.01", "OSPS-GV-03.01",
+            "OSPS-LE-01.01", "OSPS-LE-03.01", "OSPS-QA-02.01", "OSPS-VM-02.01",
+            "OSPS-GV-01.01", "OSPS-VM-05.03", "OSPS-DO-03.01", "OSPS-SA-03.02",
+        }
+
+        for ctrl in controls:
+            if ctrl.control_id not in use_locator_controls:
+                continue
+
+            invocations = ctrl.metadata.get("handler_invocations", [])
+            assert invocations, f"{ctrl.control_id}: no handler_invocations in metadata"
+
+            # Find file_exists handler
+            for inv in invocations:
+                inv_dict = inv if isinstance(inv, dict) else inv.model_dump()
+                if inv_dict.get("handler") == "file_exists":
+                    files = inv_dict.get("files")
+                    assert files and len(files) > 0, (
+                        f"{ctrl.control_id}: file_exists handler has no files - "
+                        f"use_locator not resolved! Got: {inv_dict}"
+                    )
+                    break


### PR DESCRIPTION
## Summary

- **Fix**: The merger was dumping handler invocations via `model_dump()` before resolving `use_locator=true`, so `file_exists` handlers got `files=[]` through the effective config path (used by the actual audit). This caused 12 controls to return INCONCLUSIVE instead of PASS/FAIL, regressing audit results from 24 pass / 4 fail to 16 pass / 0 fail.
- **Root cause**: `load_controls_from_framework` resolved `use_locator` correctly, but `merge_control` → `control_from_effective` (the path the audit actually uses) skipped resolution entirely.
- **Regression tests**: Added 2 tests — one unit test on `merge_control` and one integration test verifying all 12 `use_locator=true` baseline controls have files populated through the effective config path.

## Test plan

- [x] All 847 tests pass
- [x] `ruff check .` clean
- [x] `validate_sync.py` passes
- [x] `generate_docs.py` produces no changes
- [x] New regression test fails without fix, passes with fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)