### PR TITLE
fix: Stop context prompts from bypassing user confirmation

### DIFF
--- a/packages/darnit/src/darnit/remediation/context_validator.py
+++ b/packages/darnit/src/darnit/remediation/context_validator.py
@@ -18,6 +18,7 @@ Example workflow:
 """
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from darnit.config.context_schema import ContextSource, ContextValue
@@ -78,6 +79,25 @@ def check_context_requirements(
 
     for req in requirements:
         context_value = get_context_value(local_path, req.key)
+
+        # Check 0: Detect stale file references stored as values.
+        # If a previous run stored a filename like "CODEOWNERS" instead of
+        # the actual parsed values, treat it as missing so we re-detect.
+        if context_value is not None and isinstance(context_value.value, str):
+            definition = _get_context_definition(req.key, framework)
+            hint_sources = definition.hint_sources if definition else []
+            stale_names = set(hint_sources)
+            stale_names.update({
+                "CODEOWNERS", ".github/CODEOWNERS",
+                "MAINTAINERS", "MAINTAINERS.md",
+            })
+            if context_value.value in stale_names:
+                logger.info(
+                    "Stale file reference '%s' stored for '%s', treating as missing",
+                    context_value.value,
+                    req.key,
+                )
+                context_value = None
 
         # Check 1: Is context missing entirely?
         if context_value is None:
@@ -164,8 +184,6 @@ def format_context_prompt(
     Returns:
         Formatted prompt string for the user
     """
-    from pathlib import Path
-
     lines = []
 
     # Header
@@ -199,14 +217,25 @@ def format_context_prompt(
     # 3. If no hints at all → ask user directly
 
     if existing_hint_files:
-        # Case 1: Authoritative file exists - suggest referencing it
+        # Case 1: Authoritative file exists - parse and show values as suggestions
         lines.append("📁 **Found authoritative source(s):**")
         for f in existing_hint_files:
             lines.append(f"   - `{f}`")
         lines.append("")
-        lines.append("**Use this command to reference the file:**")
+
+        # Parse the file to extract actual values for user review
+        parsed_values = _parse_hint_file(repo_path / existing_hint_files[0])
+        if parsed_values:
+            lines.append("**Values found in file (review and confirm with user):**")
+            for val in parsed_values[:10]:
+                lines.append(f"   - `{val}`")
+            if len(parsed_values) > 10:
+                lines.append(f"   - ... and {len(parsed_values) - 10} more")
+            lines.append("")
+
+        lines.append("**⚠️ Ask the user to confirm or correct these values, then use:**")
         lines.append("```")
-        lines.append(f'confirm_project_context({context_key}="{existing_hint_files[0]}")')
+        lines.append(f"confirm_project_context({context_key}=<user-confirmed values>)")
         lines.append("```")
         lines.append("")
     elif allow_sieve_hints and current_value is not None and isinstance(current_value, ContextValue):
@@ -222,12 +251,9 @@ def format_context_prompt(
         else:
             lines.append(f"   {current_value.value}")
         lines.append("")
-        lines.append("**Confirm or correct:**")
+        lines.append("**⚠️ Ask the user to confirm or correct these values, then use:**")
         lines.append("```")
-        if isinstance(current_value.value, list):
-            lines.append(f'confirm_project_context({context_key}={current_value.value})')
-        else:
-            lines.append(f'confirm_project_context({context_key}="{current_value.value}")')
+        lines.append(f"confirm_project_context({context_key}=<user-confirmed values>)")
         lines.append("```")
         lines.append("")
     else:
@@ -263,6 +289,28 @@ def format_context_prompt(
         lines.append("```")
 
     return "\n".join(lines)
+
+
+def _parse_hint_file(file_path: Path) -> list[str] | None:
+    """Parse a hint source file to extract values.
+
+    Uses the appropriate parser based on filename (CODEOWNERS → codeowners parser,
+    .md → markdown list parser, etc.).
+
+    Args:
+        file_path: Path to the hint file
+
+    Returns:
+        List of extracted values, or None if nothing found
+    """
+    from darnit.context.collection import parse_codeowners, parse_markdown_list
+
+    name = file_path.name.upper()
+    if name in ("CODEOWNERS", "MAINTAINERS"):
+        result = parse_codeowners(file_path)
+    else:
+        result = parse_markdown_list(file_path)
+    return result or None
 
 
 def _get_context_definition(

--- a/tests/darnit/remediation/test_context_validator.py
+++ b/tests/darnit/remediation/test_context_validator.py
@@ -272,6 +272,159 @@ class TestFormatContextPrompt:
         assert "@user1, @user2" in prompt
 
 
+    def test_prompt_with_hint_file_shows_parsed_values_and_placeholder(self, temp_repo):
+        """When a hint file exists, prompt should show parsed values but use placeholder command."""
+        # Create a CODEOWNERS file
+        codeowners_path = Path(temp_repo) / "CODEOWNERS"
+        codeowners_path.write_text("* @alice @bob\ndocs/ @charlie\n")
+
+        definition = ContextDefinitionConfig(
+            type="list_or_path",
+            prompt="Who are the project maintainers?",
+            hint_sources=["CODEOWNERS", ".github/CODEOWNERS"],
+            allow_sieve_hints=True,
+        )
+        requirement = ContextRequirement(
+            key="maintainers",
+            required=True,
+            confidence_threshold=0.9,
+            prompt_if_auto_detected=True,
+        )
+
+        prompt = format_context_prompt(
+            context_key="maintainers",
+            definition=definition,
+            requirement=requirement,
+            current_value=None,
+            local_path=temp_repo,
+        )
+
+        # Should show the parsed values from the file
+        assert "@alice" in prompt
+        assert "@bob" in prompt
+        assert "@charlie" in prompt
+        # Should use a placeholder in the command, NOT the filename or actual values
+        assert 'confirm_project_context(maintainers=<user-confirmed values>)' in prompt
+        # Should NOT suggest passing the filename
+        assert 'maintainers="CODEOWNERS"' not in prompt
+
+    def test_prompt_with_sieve_hints_uses_placeholder_command(self):
+        """When sieve hints exist, prompt should show detected values but use placeholder command."""
+        definition = ContextDefinitionConfig(
+            type="list_or_path",
+            prompt="Who are the project maintainers?",
+            allow_sieve_hints=True,
+        )
+        requirement = ContextRequirement(
+            key="maintainers",
+            required=True,
+            confidence_threshold=0.9,
+            prompt_if_auto_detected=True,
+        )
+        current_value = ContextValue(
+            value=["@detected1", "@detected2"],
+            source=ContextSource.AUTO_DETECTED,
+            confidence=0.7,
+        )
+
+        prompt = format_context_prompt(
+            context_key="maintainers",
+            definition=definition,
+            requirement=requirement,
+            current_value=current_value,
+        )
+
+        # Should show the detected values as hints
+        assert "@detected1" in prompt
+        assert "@detected2" in prompt
+        # Should use a placeholder in the command, NOT the actual detected values
+        assert 'confirm_project_context(maintainers=<user-confirmed values>)' in prompt
+        # Should NOT have executable command with actual values
+        assert "['@detected1', '@detected2']" not in prompt
+
+
+class TestStaleValueDetection:
+    """Tests for stale file reference detection in check_context_requirements."""
+
+    @patch("darnit.remediation.context_validator.get_context_value")
+    def test_stale_codeowners_string_treated_as_missing(self, mock_get_context, temp_repo):
+        """Stored 'CODEOWNERS' string should be treated as missing context."""
+        # Simulate a previous run that stored the filename instead of values
+        mock_get_context.return_value = ContextValue(
+            value="CODEOWNERS",
+            source=ContextSource.USER_CONFIRMED,
+            confidence=1.0,
+        )
+
+        requirement = ContextRequirement(
+            key="maintainers",
+            required=True,
+            confidence_threshold=0.9,
+            prompt_if_auto_detected=True,
+        )
+
+        result = check_context_requirements(
+            requirements=[requirement],
+            local_path=temp_repo,
+            framework=None,
+        )
+
+        # Should be not ready — the stale value should be rejected
+        assert result.ready is False
+        assert "maintainers" in result.missing_context
+
+    @patch("darnit.remediation.context_validator.get_context_value")
+    def test_github_codeowners_path_treated_as_stale(self, mock_get_context, temp_repo):
+        """Stored '.github/CODEOWNERS' path should also be treated as stale."""
+        mock_get_context.return_value = ContextValue(
+            value=".github/CODEOWNERS",
+            source=ContextSource.USER_CONFIRMED,
+            confidence=1.0,
+        )
+
+        requirement = ContextRequirement(
+            key="maintainers",
+            required=True,
+            confidence_threshold=0.9,
+            prompt_if_auto_detected=True,
+        )
+
+        result = check_context_requirements(
+            requirements=[requirement],
+            local_path=temp_repo,
+            framework=None,
+        )
+
+        assert result.ready is False
+        assert "maintainers" in result.missing_context
+
+    @patch("darnit.remediation.context_validator.get_context_value")
+    def test_actual_list_value_not_treated_as_stale(self, mock_get_context, temp_repo):
+        """Actual maintainer list should not be treated as stale."""
+        mock_get_context.return_value = ContextValue(
+            value=["@alice", "@bob"],
+            source=ContextSource.USER_CONFIRMED,
+            confidence=1.0,
+        )
+
+        requirement = ContextRequirement(
+            key="maintainers",
+            required=True,
+            confidence_threshold=0.9,
+            prompt_if_auto_detected=True,
+        )
+
+        result = check_context_requirements(
+            requirements=[requirement],
+            local_path=temp_repo,
+            framework=None,
+        )
+
+        # List value should pass through fine
+        assert result.ready is True
+        assert result.missing_context == []
+
+
 class TestGetContextRequirementsForCategory:
     """Tests for get_context_requirements_for_category function."""
 

--- a/tests/darnit_baseline/test_context_validation_dry_run.py
+++ b/tests/darnit_baseline/test_context_validation_dry_run.py
@@ -324,7 +324,7 @@ class TestFileReferenceRecommendation:
     def test_prompt_recommends_file_reference_when_codeowners_exists(
         self, temp_repo_with_codeowners
     ):
-        """When CODEOWNERS exists, prompt should recommend referencing it."""
+        """When CODEOWNERS exists, prompt should show parsed values and placeholder command."""
         from darnit_baseline.remediation.orchestrator import remediate_audit_findings
 
         result = remediate_audit_findings(
@@ -333,11 +333,13 @@ class TestFileReferenceRecommendation:
             dry_run=True,
         )
 
-        # Should reference the existing file as authoritative source
+        # Should mention the CODEOWNERS file as authoritative source
         assert "CODEOWNERS" in result
-        assert 'maintainers="CODEOWNERS"' in result
-        # Should indicate it's an authoritative source
         assert "authoritative" in result.lower()
+        # Should use placeholder command, NOT the filename
+        assert 'maintainers=<user-confirmed values>' in result
+        # Should NOT suggest passing the filename directly
+        assert 'maintainers="CODEOWNERS"' not in result
 
     @pytest.mark.unit
     def test_file_reference_stored_as_string_not_list(self, temp_repo_with_codeowners):


### PR DESCRIPTION
## Summary

- **Fix prompt template**: `format_context_prompt()` was generating ready-to-execute `confirm_project_context()` calls with actual values that LLM clients ran without asking the user. Now shows detected values as suggestions but uses `<user-confirmed values>` placeholder in the command example.
- **Parse hint files**: When a CODEOWNERS/MAINTAINERS file exists, the prompt now parses and displays the extracted handles instead of suggesting the filename be passed directly.
- **Stale value detection**: If a stored maintainers value is a known filename string (`CODEOWNERS`, `MAINTAINERS`, etc.), it is treated as missing — triggering re-detection and user prompting.

## Test plan

- [x] `format_context_prompt()` with hint file shows parsed values + placeholder command
- [x] `format_context_prompt()` with sieve hints shows detected values + placeholder command
- [x] Stale `"CODEOWNERS"` / `".github/CODEOWNERS"` strings treated as missing
- [x] Actual list values (`["@alice", "@bob"]`) pass through normally
- [x] All 897 tests pass (1 pre-existing upstream spec hash failure)
- [x] ruff + validate_sync clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)