### PR TITLE
feat: Audit-aware remediation with FAIL-only filtering

### DIFF
--- a/openspec/changes/audit-aware-remediation/.openspec.yaml
+++ b/openspec/changes/audit-aware-remediation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-16

--- a/openspec/changes/audit-aware-remediation/design.md
+++ b/openspec/changes/audit-aware-remediation/design.md
@@ -1,0 +1,121 @@
+## Context
+
+The MCP tool pipeline flows: `get_pending_context` → `confirm_project_context` → `audit` → `remediate`. Each step writes durable state that subsequent steps read — except audit. Audit results evaporate after the tool returns, so `builtin_remediate` re-runs the entire sieve pipeline from scratch to figure out what failed.
+
+Currently:
+- `builtin_audit` calls `run_sieve_audit()`, which returns `(results: list[dict], summary: dict[str, int])`. These are formatted into markdown and returned. The structured data is discarded.
+- `builtin_remediate` re-runs `SieveOrchestrator.verify()` on every control to collect `failed_ids: set[str]`, then filters remediations to only those IDs.
+- `remediate_audit_findings` (baseline orchestrator) also re-runs the full audit to collect `non_passing_ids`.
+
+The `results` list from `run_sieve_audit()` is already JSON-serializable — each entry comes from `SieveResult.to_legacy_dict()` which produces plain dicts with string/int/float/list values.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Audit results persist as pipeline state so remediate can consume them without re-running the sieve
+- PASS controls are automatically excluded from remediation via the cached results
+- Backward compatible: if no cache exists, remediate falls back to running its own audit
+- Cache invalidation is automatic — stale results don't cause wrong remediations
+
+**Non-Goals:**
+- Long-term audit history or trend tracking — this is ephemeral cache, not an audit log
+- Changing the MCP tool parameter signatures — no new required parameters for LLMs to pass
+- Caching within a single audit run (the `SieveOrchestrator._shared_cache` already handles that)
+
+## Decisions
+
+### 1. Cache location: `.darnit/audit-cache.json`
+
+**Decision:** New `.darnit/` directory for framework ephemeral state, separate from `.project/` which is user-facing project configuration.
+
+**Rationale:** `.project/project.yaml` and `.project/darnit.yaml` are committed to version control and represent project identity. Audit cache is ephemeral, machine-specific, and should be gitignored. Mixing cache with config in `.project/` blurs the boundary.
+
+**Alternatives considered:**
+- `.project/audit-cache.json` — rejected: mixes ephemeral cache with persistent config that's committed to git
+- Temp directory (`/tmp/`) — rejected: not discoverable, cleared on reboot, harder to share across tool calls
+- MCP tool parameter — rejected: pushes complexity onto the LLM, requires the model to shuttle data between calls
+
+**`.gitignore` entry:** `.darnit/` should be added to `.gitignore` templates and documented as framework cache.
+
+### 2. Cache format: JSON with metadata envelope
+
+**Decision:** Store the raw `results` list and `summary` dict from `run_sieve_audit()` inside a metadata envelope:
+
+```json
+{
+  "version": 1,
+  "timestamp": "2026-02-16T12:00:00Z",
+  "commit": "abc1234",
+  "level": 3,
+  "framework": "openssf-baseline",
+  "local_path": "/path/to/repo",
+  "results": [ ... ],
+  "summary": { "PASS": 23, "FAIL": 4, "WARN": 35 }
+}
+```
+
+**Rationale:** The `results` list is already JSON-serializable (comes from `SieveResult.to_legacy_dict()`). JSON is fast to read/write, human-inspectable, and doesn't require new dependencies. The envelope provides staleness metadata.
+
+### 3. Staleness detection: git commit hash
+
+**Decision:** Cache is valid if the current `HEAD` commit matches `cache.commit`. Any commit change (new code, config changes, etc.) invalidates the cache.
+
+**Rationale:** Git commit is the simplest proxy for "has anything changed that could affect audit results." It catches TOML config changes, file additions/deletions, and code changes. It's conservative — some commits won't affect audit results, but a false invalidation just means re-running the audit (safe), while a false cache hit could skip needed remediation (unsafe).
+
+**Edge case:** Uncommitted changes are not reflected in the commit hash. For uncommitted repos or dirty working trees, the cache should include a working-tree indicator (e.g., dirty flag) and invalidate if the dirty state changes.
+
+### 4. Write point: end of `run_sieve_audit()`
+
+**Decision:** The canonical audit pipeline function `run_sieve_audit()` writes the cache after completing the audit, before returning results.
+
+**Rationale:** This is the single chokepoint — both `builtin_audit` and any other caller go through `run_sieve_audit()`. Writing here means every audit automatically populates the cache, regardless of which MCP tool triggered it.
+
+**Alternative considered:** Write in `builtin_audit` — rejected: misses audits triggered by `remediate_audit_findings` or other callers.
+
+### 5. Read point: start of `builtin_remediate` and `remediate_audit_findings`
+
+**Decision:** Both remediation entry points check for a valid cache before running their own audit. If the cache is fresh, they extract `failed_ids` from it and skip the sieve run.
+
+**Flow:**
+```
+remediate() called
+  → load_audit_cache(local_path)
+  → if cache exists AND cache.commit == current HEAD:
+      failed_ids = {r["id"] for r in cache.results if r["status"] == "FAIL"}
+  → else:
+      run sieve audit (existing behavior)
+      # audit writes cache as side effect
+  → proceed with remediation using failed_ids
+```
+
+### 6. New module: `darnit.core.audit_cache`
+
+**Decision:** Single module with three public functions:
+
+- `write_audit_cache(local_path, results, summary, level, framework)` — write cache after audit
+- `read_audit_cache(local_path) -> dict | None` — read cache if valid, None if stale/missing
+- `invalidate_audit_cache(local_path)` — explicitly clear cache (e.g., after remediation changes files)
+
+**Rationale:** Follows the pattern of `context_storage.py` — simple load/save functions, no classes. The module handles all filesystem details (creating `.darnit/`, reading/writing JSON, staleness checks).
+
+### 7. Post-remediation invalidation
+
+**Decision:** After `builtin_remediate` applies changes (not dry-run), it calls `invalidate_audit_cache()` because the repository state has changed and the cached results are no longer accurate.
+
+**Rationale:** Remediation modifies files that auditing checks. A subsequent audit should re-evaluate from scratch rather than returning stale results that say controls still fail.
+
+## Risks / Trade-offs
+
+**[Stale cache on uncommitted changes]** → Git commit hash doesn't capture uncommitted edits. Mitigation: include a `dirty` flag in the cache. If the working tree was dirty when cached, require exact match of dirty state. If tree was clean, invalidate if now dirty. This is imperfect but conservative.
+
+**[Cache file conflicts in multi-tool scenarios]** → If two MCP tool calls run concurrently (unlikely but possible), they could race on the cache file. Mitigation: use atomic write (write to temp file, rename). Read-side tolerance: if JSON is corrupt, treat as cache miss.
+
+**[`.darnit/` directory proliferation]** → Adding a new dotfile directory to repos. Mitigation: only created when audit runs (lazy creation). Document in `.gitignore` templates. Single file for now, expandable later.
+
+**[Remediation changes invalidate cache but not the MCP response]** → After remediation applies fixes, the cache is invalidated, but the LLM still has the old audit results in its conversation. This is existing behavior (not introduced by this change) and is acceptable — the LLM should re-audit after remediation to verify fixes.
+
+## Open Questions
+
+1. **Should `remediate_audit_findings` (baseline orchestrator) also read from cache?** It runs a full `run_sieve_audit()` internally. If `run_sieve_audit` reads cache, both entry points get it for free. But `run_sieve_audit` currently always runs from scratch — making it cache-aware is a larger change than just the remediation tools.
+
+2. **Cache TTL vs commit-only invalidation?** A time-based TTL (e.g., 10 minutes) could catch cases where external state changes without a commit (e.g., GitHub settings modified via web UI). But it adds complexity and may cause unnecessary re-runs.

--- a/openspec/changes/audit-aware-remediation/proposal.md
+++ b/openspec/changes/audit-aware-remediation/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The MCP tool pipeline is designed to flow step-by-step: `get_pending_context` → `confirm_project_context` → `audit` → `remediate`. But the pipeline breaks between audit and remediate — audit results evaporate after the tool returns, forcing `builtin_remediate` and `remediate_audit_findings` to re-run the entire audit from scratch. This wastes time, can produce inconsistent results, and — most importantly — means remediation has no way to know what already passes. The result: remediation proposes changes to files that already exist and pass their checks (e.g., overwriting a valid SECURITY.md or dependabot config with template content).
+
+## What Changes
+
+- Audit results become **cached pipeline state** that persists across tool calls, similar to how `.project/project.yaml` persists context confirmations
+- The `builtin_remediate` tool reads cached audit results automatically — if fresh results exist, it skips re-running the audit and only remediates controls that actually failed
+- Controls with PASS status are excluded from remediation without requiring the LLM to pass data between tool calls
+- The audit tool writes results to a well-known cache location after each run
+- Staleness detection ensures remediate doesn't act on outdated results (falls back to re-running audit if cache is stale)
+
+## Capabilities
+
+### New Capabilities
+- `audit-result-cache`: Audit result persistence and retrieval — write/read/staleness for cached audit results that flow between MCP tool calls
+
+### Modified Capabilities
+- `framework-design`: The builtin `remediate` tool specification changes to consume cached audit results before deciding what to remediate. The `audit` tool specification changes to write results to the cache after each run.
+
+## Impact
+
+- `packages/darnit/src/darnit/server/tools/builtin_remediate.py` — read from cache instead of always re-auditing
+- `packages/darnit/src/darnit/server/tools/builtin_audit.py` — write results to cache after audit completes
+- `packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py` — read from cache in `remediate_audit_findings()`
+- New module for audit result cache (read/write/staleness)
+- `openspec/specs/framework-design/spec.md` — document cache behavior in builtin tool specs
+- Cache location decision: `.project/` directory (alongside project.yaml) or separate ephemeral location

--- a/openspec/changes/audit-aware-remediation/specs/audit-result-cache/spec.md
+++ b/openspec/changes/audit-aware-remediation/specs/audit-result-cache/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Audit cache module location and API
+The framework SHALL provide an `audit_cache` module at `darnit.core.audit_cache` with three public functions: `write_audit_cache()`, `read_audit_cache()`, and `invalidate_audit_cache()`.
+
+#### Scenario: Writing audit results to cache
+- **WHEN** `write_audit_cache(local_path, results, summary, level, framework)` is called
+- **THEN** it SHALL write a JSON file to `<local_path>/.darnit/audit-cache.json`
+- **AND** it SHALL create the `.darnit/` directory if it does not exist
+- **AND** the JSON SHALL contain a metadata envelope with `version`, `timestamp`, `commit`, `level`, `framework`, `results`, and `summary` fields
+
+#### Scenario: Reading valid cache
+- **WHEN** `read_audit_cache(local_path)` is called
+- **AND** a cache file exists at `<local_path>/.darnit/audit-cache.json`
+- **AND** the cache `commit` field matches the current `HEAD` commit
+- **AND** the cache `commit_dirty` field matches the current working tree dirty state
+- **THEN** it SHALL return the parsed cache dict containing `results` and `summary`
+
+#### Scenario: Reading stale or missing cache
+- **WHEN** `read_audit_cache(local_path)` is called
+- **AND** no cache file exists, or the file is corrupt, or the `commit` field does not match current `HEAD`, or the dirty state has changed
+- **THEN** it SHALL return `None`
+
+#### Scenario: Invalidating cache
+- **WHEN** `invalidate_audit_cache(local_path)` is called
+- **THEN** it SHALL delete `<local_path>/.darnit/audit-cache.json` if it exists
+- **AND** it SHALL NOT raise an error if the file does not exist
+
+### Requirement: Cache staleness uses git commit hash
+The cache SHALL use the current `HEAD` commit hash as its primary staleness key. The cache SHALL also track whether the working tree was dirty (uncommitted changes) at write time.
+
+#### Scenario: Commit changes between audit and remediate
+- **WHEN** an audit writes cache with commit `abc123`
+- **AND** a new commit is made before remediate runs
+- **THEN** `read_audit_cache()` SHALL return `None` (cache miss)
+- **AND** the remediation tool SHALL fall back to running a fresh audit
+
+#### Scenario: Working tree becomes dirty after clean audit
+- **WHEN** an audit writes cache with `commit_dirty = false`
+- **AND** the working tree has uncommitted changes when remediate reads the cache
+- **THEN** `read_audit_cache()` SHALL return `None` (cache miss)
+
+#### Scenario: Non-git repository
+- **WHEN** `write_audit_cache()` is called in a directory that is not a git repository
+- **THEN** it SHALL write the cache with `commit` set to `null`
+- **AND** `read_audit_cache()` SHALL treat a `null` commit cache as always stale (return `None`)
+
+### Requirement: Atomic cache writes
+The cache module SHALL write the JSON file atomically to prevent corruption from concurrent access or interrupted writes.
+
+#### Scenario: Concurrent write safety
+- **WHEN** `write_audit_cache()` is called
+- **THEN** it SHALL write to a temporary file in the same directory
+- **AND** it SHALL rename the temporary file to `audit-cache.json` (atomic on POSIX)
+
+#### Scenario: Corrupt cache file
+- **WHEN** `read_audit_cache()` encounters a file that is not valid JSON
+- **THEN** it SHALL return `None` (treat as cache miss)
+- **AND** it SHALL log a debug-level message about the corrupt cache
+
+### Requirement: Cache envelope schema
+The cache JSON file SHALL conform to a versioned envelope schema to support future changes.
+
+#### Scenario: Cache envelope structure
+- **WHEN** `write_audit_cache()` writes the cache
+- **THEN** the JSON SHALL contain these top-level fields:
+  - `version` (integer): Schema version, currently `1`
+  - `timestamp` (string): ISO 8601 UTC timestamp of when the audit ran
+  - `commit` (string or null): Git HEAD commit hash at audit time
+  - `commit_dirty` (boolean): Whether the working tree had uncommitted changes
+  - `level` (integer): Maximum audit level that was evaluated
+  - `framework` (string): Framework name (e.g., `"openssf-baseline"`)
+  - `results` (array): The raw results list from `run_sieve_audit()`
+  - `summary` (dict): Status count summary from `run_sieve_audit()`
+
+#### Scenario: Unknown cache version
+- **WHEN** `read_audit_cache()` reads a cache file with `version` greater than the supported version
+- **THEN** it SHALL return `None` (treat as cache miss)

--- a/openspec/changes/audit-aware-remediation/specs/framework-design/spec.md
+++ b/openspec/changes/audit-aware-remediation/specs/framework-design/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Canonical audit writes to cache
+The `run_sieve_audit()` function SHALL write audit results to the cache after completing the sieve pipeline, before returning results to the caller.
+
+#### Scenario: Audit populates cache automatically
+- **WHEN** `run_sieve_audit()` completes successfully
+- **THEN** it SHALL call `write_audit_cache()` with the `results`, `summary`, `level`, and `framework` name
+- **AND** subsequent calls to `read_audit_cache()` from the same repository SHALL return the cached results (assuming no commit change)
+
+#### Scenario: Audit failure does not write cache
+- **WHEN** `run_sieve_audit()` raises an exception before completing
+- **THEN** it SHALL NOT write to the audit cache
+- **AND** any previously cached results SHALL remain unchanged
+
+### Requirement: Builtin remediate consumes cached audit results
+The `builtin_remediate` MCP tool SHALL check for cached audit results before running its own sieve audit. If valid cached results exist, it SHALL use them to determine which controls failed, skipping the redundant audit.
+
+#### Scenario: Cache hit — skip audit
+- **WHEN** `builtin_remediate()` is called
+- **AND** `read_audit_cache(local_path)` returns valid cached results
+- **THEN** it SHALL extract failed control IDs from the cached results (entries with `status == "FAIL"`)
+- **AND** it SHALL NOT run `SieveOrchestrator.verify()` on any controls
+- **AND** it SHALL proceed to remediation using only the failed control IDs
+
+#### Scenario: Cache miss — fallback to audit
+- **WHEN** `builtin_remediate()` is called
+- **AND** `read_audit_cache(local_path)` returns `None`
+- **THEN** it SHALL run the sieve audit as it does today (existing behavior)
+- **AND** the audit SHALL populate the cache as a side effect (via `run_sieve_audit`)
+
+#### Scenario: PASS controls excluded from remediation
+- **WHEN** `builtin_remediate()` uses cached results
+- **AND** a control has `status == "PASS"` in the cached results
+- **THEN** that control SHALL NOT appear in the remediation plan
+- **AND** it SHALL NOT be passed to the `RemediationExecutor`
+
+### Requirement: Post-remediation cache invalidation
+After `builtin_remediate` applies changes to the repository (not a dry run), it SHALL invalidate the audit cache because the repository state has changed.
+
+#### Scenario: Successful remediation invalidates cache
+- **WHEN** `builtin_remediate()` completes with `dry_run=False`
+- **AND** at least one remediation was applied
+- **THEN** it SHALL call `invalidate_audit_cache(local_path)`
+- **AND** a subsequent `read_audit_cache()` call SHALL return `None`
+
+#### Scenario: Dry run does not invalidate cache
+- **WHEN** `builtin_remediate()` completes with `dry_run=True`
+- **THEN** it SHALL NOT call `invalidate_audit_cache()`
+- **AND** the cached results SHALL remain valid
+
+### Requirement: Remediate audit findings consumes cached results
+The `remediate_audit_findings()` function in the baseline orchestrator SHALL check for cached audit results before running its own audit, following the same cache-hit/miss logic as `builtin_remediate`.
+
+#### Scenario: Orchestrator cache hit
+- **WHEN** `remediate_audit_findings()` is called
+- **AND** valid cached results exist
+- **THEN** it SHALL use the cached results to determine `non_passing_ids`
+- **AND** it SHALL NOT call `run_sieve_audit()` redundantly
+
+#### Scenario: Orchestrator post-remediation invalidation
+- **WHEN** `remediate_audit_findings()` applies changes with `dry_run=False`
+- **THEN** it SHALL call `invalidate_audit_cache(local_path)`

--- a/openspec/changes/audit-aware-remediation/tasks.md
+++ b/openspec/changes/audit-aware-remediation/tasks.md
@@ -1,0 +1,40 @@
+## 1. Audit Cache Module
+
+- [x] 1.1 Create `packages/darnit/src/darnit/core/audit_cache.py` with git helper functions (`_get_head_commit`, `_is_working_tree_dirty`) using subprocess calls to `git rev-parse HEAD` and `git status --porcelain`
+- [x] 1.2 Implement `write_audit_cache(local_path, results, summary, level, framework)` — create `.darnit/` dir, build envelope with version/timestamp/commit/commit_dirty/level/framework/results/summary, atomic write via tempfile+rename
+- [x] 1.3 Implement `read_audit_cache(local_path) -> dict | None` — read JSON, validate version field, compare commit hash and dirty state against current git state, return None on any mismatch/error/corruption
+- [x] 1.4 Implement `invalidate_audit_cache(local_path)` — delete `.darnit/audit-cache.json` if exists, no-op if missing
+- [x] 1.5 Add unit tests for `audit_cache` module: write/read round-trip, stale commit detection, dirty tree detection, corrupt JSON handling, non-git repo handling, unknown version handling, atomic write behavior
+
+## 2. Wire Audit to Write Cache
+
+- [x] 2.1 In `packages/darnit/src/darnit/tools/audit.py`, import `write_audit_cache` and call it at the end of `run_sieve_audit()` after results are assembled, before the return statement — pass `local_path`, `results`, `summary`, `level`, and framework name
+- [x] 2.2 Wrap the cache write in try/except so cache failures never break the audit pipeline (log warning, continue)
+- [x] 2.3 Add test: verify `run_sieve_audit()` produces a `.darnit/audit-cache.json` file with correct envelope structure after completing
+
+## 3. Wire Builtin Remediate to Read Cache
+
+- [x] 3.1 In `packages/darnit/src/darnit/server/tools/builtin_remediate.py`, import `read_audit_cache` and `invalidate_audit_cache`
+- [x] 3.2 At the start of `builtin_remediate()`, call `read_audit_cache(local_path)` — if it returns valid results, extract `failed_ids = {r["id"] for r in cache["results"] if r["status"] == "FAIL"}` and skip the sieve audit loop
+- [x] 3.3 If cache miss, keep existing behavior (run sieve audit, which now writes cache as side effect)
+- [x] 3.4 After successful non-dry-run remediation, call `invalidate_audit_cache(local_path)` — skip invalidation for dry runs
+- [x] 3.5 Add tests: cache hit skips audit, cache miss falls back to audit, PASS controls excluded from remediation plan, dry run preserves cache, non-dry-run invalidates cache
+
+## 4. Wire Baseline Orchestrator to Read Cache
+
+- [x] 4.1 In `packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py`, import `read_audit_cache` and `invalidate_audit_cache`
+- [x] 4.2 In `remediate_audit_findings()`, check cache before calling `run_sieve_audit()` — if valid, extract `non_passing_ids` from cached results (entries where `status != "PASS"`)
+- [x] 4.3 After successful non-dry-run remediation, call `invalidate_audit_cache(local_path)`
+- [x] 4.4 Add tests: orchestrator cache hit skips audit, orchestrator invalidates after applying changes
+
+## 5. Spec Sync and Documentation
+
+- [x] 5.1 Update `openspec/specs/framework-design/spec.md` with the new requirements from `specs/framework-design/spec.md` delta (audit writes cache, remediate reads cache, post-remediation invalidation)
+- [x] 5.2 Run `uv run python scripts/validate_sync.py --verbose` and fix any sync issues
+- [x] 5.3 Run `uv run python scripts/generate_docs.py` and commit any doc changes
+
+## 6. Verification
+
+- [x] 6.1 `uv run ruff check .` — no lint errors
+- [x] 6.2 `uv run pytest tests/ --ignore=tests/integration/ -q` — all tests pass
+- [x] 6.3 Manual end-to-end test: run audit via MCP tool, verify `.darnit/audit-cache.json` is created, then run remediate and verify it uses cache (no second audit in logs), verify PASS controls are skipped

--- a/openspec/specs/framework-design/spec.md
+++ b/openspec/specs/framework-design/spec.md
@@ -1,8 +1,8 @@
 # Darnit Framework Design Specification
 
-> **Version**: 1.0.0-alpha.7
+> **Version**: 1.0.0-alpha.8
 > **Status**: Authoritative
-> **Last Updated**: 2026-02-13
+> **Last Updated**: 2026-02-16
 
 This specification defines the authoritative design of the Darnit framework, including the sieve orchestrator, TOML schema, built-in pass types, remediation actions, and plugin protocol.
 
@@ -989,7 +989,46 @@ All audit entry points that produce markdown output SHALL use `format_results_ma
 - **THEN** it SHALL accept optional `report_title` and `remediation_map` parameters
 - **AND** SHALL NOT contain hardcoded implementation-specific control IDs or branding
 
-### 10.4 Framework Contains No Implementation-Specific Code
+### 10.4 Audit Result Cache
+
+The canonical `run_sieve_audit()` function SHALL write audit results to a cache file after completing the sieve pipeline. The `builtin_remediate` tool and `remediate_audit_findings()` function SHALL check for cached results before running their own audit, using the cache to skip redundant audit passes.
+
+Cache files are stored in the system temp directory (`$TMPDIR/darnit/<repo-hash>/audit-cache.json`), keyed by a hash of the repository's absolute path. This avoids writing any files into the repository itself.
+
+#### Requirement: Canonical audit writes to cache
+- **WHEN** `run_sieve_audit()` completes successfully
+- **THEN** it SHALL call `write_audit_cache()` with the `results`, `summary`, `level`, and `framework` name
+- **AND** subsequent calls to `read_audit_cache()` from the same repository SHALL return the cached results (assuming no commit change)
+- **AND** audit failure (exception before completing) SHALL NOT write to the cache
+
+#### Requirement: Only FAIL controls are remediated
+- **WHEN** remediation tools consume audit results (cached or fresh)
+- **THEN** they SHALL extract only controls with `status == "FAIL"`
+- **AND** controls with `status == "WARN"` SHALL NOT be remediated (WARN means automated verification was inconclusive, not that the control is non-compliant)
+- **AND** controls with `status == "PASS"` SHALL NOT be remediated
+
+#### Requirement: Builtin remediate consumes cached audit results
+- **WHEN** `builtin_remediate()` is called and `read_audit_cache()` returns valid cached results
+- **THEN** it SHALL extract failed control IDs from the cached results (entries with `status == "FAIL"`)
+- **AND** it SHALL NOT run `SieveOrchestrator.verify()` on any controls
+- **WHEN** `read_audit_cache()` returns `None` (cache miss)
+- **THEN** it SHALL run the sieve audit as it does today (existing behavior)
+
+#### Requirement: Post-remediation cache invalidation
+- **WHEN** `builtin_remediate()` completes with `dry_run=False` and at least one remediation was applied
+- **THEN** it SHALL call `invalidate_audit_cache(local_path)`
+- **WHEN** `builtin_remediate()` completes with `dry_run=True`
+- **THEN** it SHALL NOT call `invalidate_audit_cache()`
+
+#### Requirement: Remediate audit findings consumes cached results
+- **WHEN** `remediate_audit_findings()` is called and valid cached results exist
+- **THEN** it SHALL use the cached results to determine failed control IDs
+- **AND** it SHALL NOT call `_run_baseline_checks()` redundantly
+- **AND** it SHALL iterate all remediation categories, letting per-control filtering exclude categories where no controls failed
+- **WHEN** `remediate_audit_findings()` applies changes with `dry_run=False`
+- **THEN** it SHALL call `invalidate_audit_cache(local_path)`
+
+### 10.5 Framework Contains No Implementation-Specific Code
 
 The darnit framework package SHALL NOT contain code, modules, or string literals specific to any particular compliance implementation.
 
@@ -1101,9 +1140,10 @@ The following requirements have been superseded by the handler dispatch architec
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.0.0-alpha.8 | 2026-02-16 | Added audit result cache (Section 10.4): audit writes cache, remediate reads cache, post-remediation invalidation |
 | 1.0.0-alpha.7 | 2026-02-13 | Migrated to handler dispatch architecture: pass classes replaced by named handlers, passes use TOML array-of-tables syntax, register_controls() becomes no-op, removed legacy pass classes (Appendix C) |
 | 1.0.0-alpha.5 | 2026-02-08 | Added locator integration (Section 11), handler registry (Section 12) |
-| 1.0.0-alpha.4 | 2026-02-07 | Added framework purity requirements (Section 10.4), report parameterization |
+| 1.0.0-alpha.4 | 2026-02-07 | Added framework purity requirements (Section 10.5), report parameterization |
 | 1.0.0-alpha.3 | 2026-02-06 | Added audit pipeline requirements (Section 10) |
 | 1.0.0-alpha.2 | 2026-02-05 | Added CEL expressions, handler registration, Sigstore verification |
 | 1.0.0-alpha | 2026-02-04 | Initial authoritative specification |

--- a/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
+++ b/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
@@ -105,15 +105,6 @@ REMEDIATION_CATEGORIES: dict[str, dict[str, Any]] = {
 }
 
 
-def _get_control_to_category_map() -> dict[str, str]:
-    """Build reverse mapping from control ID to remediation category."""
-    mapping: dict[str, str] = {}
-    for category, info in REMEDIATION_CATEGORIES.items():
-        for control_id in info["controls"]:
-            mapping[control_id] = category
-    return mapping
-
-
 # =============================================================================
 # Framework Loading
 # =============================================================================
@@ -593,27 +584,7 @@ def _apply_declarative_remediation(
 
 
 
-def _determine_remediable_categories(non_passing: list[dict[str, Any]]) -> list[str]:
-    """Determine which remediation categories have non-passing controls.
 
-    Categories are included if ANY of their controls are FAIL or WARN.
-    Categories where ALL controls are PASS are excluded.
-
-    Args:
-        non_passing: List of non-passing check results (FAIL, WARN, ERROR)
-
-    Returns:
-        Sorted list of applicable remediation category names
-    """
-    control_map = _get_control_to_category_map()
-    categories = set()
-
-    for result in non_passing:
-        control_id = result.get("id", "")
-        if control_id in control_map:
-            categories.add(control_map[control_id])
-
-    return sorted(categories)
 
 
 def _preflight_context_check(
@@ -825,32 +796,51 @@ def remediate_audit_findings(
         owner = owner or detected_owner
         repo = repo or detected_repo
 
-    # Run audit to determine which controls are non-passing.
-    # This is needed for control-level filtering (skip controls that already pass).
-    non_passing_ids: set[str] | None = None
-    audit_result, error = _run_baseline_checks(
-        owner=owner, repo=repo, local_path=local_path
-    )
+    # Determine which controls failed the audit.
+    # Only FAIL controls are remediated — WARN means "can't verify automatically"
+    # and the existing content may be correct.  PASS is obviously skipped.
+    # First, try the audit cache — avoids re-running the full audit when results
+    # are fresh (e.g. the user just ran audit → remediate in sequence).
+    failed_ids: set[str] | None = None
+    error: str | None = None
 
-    if not error and audit_result:
-        non_passing = [r for r in audit_result.all_results if r.get("status") != "PASS"]
-        non_passing_ids = {r.get("id", "") for r in non_passing}
+    try:
+        from darnit.core.audit_cache import read_audit_cache
+
+        cache = read_audit_cache(local_path)
+    except Exception:
+        cache = None
+
+    if cache is not None:
+        # Cache hit — extract failed IDs without re-running the audit
+        logger.info("Using cached audit results (skipping redundant audit)")
+        failed_ids = {
+            r.get("id", "") for r in cache["results"] if r.get("status") == "FAIL"
+        }
+    else:
+        # Cache miss — fall back to running the audit
+        logger.info("No cached audit results, running audit")
+        audit_result, error = _run_baseline_checks(
+            owner=owner, repo=repo, local_path=local_path
+        )
+
+        if not error and audit_result:
+            failed_ids = {
+                r.get("id", "") for r in audit_result.all_results if r.get("status") == "FAIL"
+            }
 
     # Determine categories to apply
     if not categories or categories == ["all"]:
-        # Audit is required when auto-determining categories
         if error:
             return f"❌ Error running audit: {error}"
 
-        remediable = _determine_remediable_categories(non_passing)
-
-        if not remediable:
+        if not failed_ids:
             return "✅ No remediations needed - all controls with available auto-fixes are passing."
 
-        categories = remediable
+        categories = sorted(REMEDIATION_CATEGORIES.keys())
     elif error:
         # Audit failed but user specified explicit categories — proceed without
-        # control-level filtering (non_passing_ids stays None = legacy behavior)
+        # control-level filtering (failed_ids stays None = legacy behavior)
         logger.warning(f"Audit failed ({error}), proceeding without control-level filtering")
 
     # Pre-flight check: Verify all context requirements BEFORE starting remediation
@@ -875,9 +865,20 @@ def remediate_audit_findings(
             owner=owner,
             repo=repo,
             dry_run=dry_run,
-            non_passing_ids=non_passing_ids,
+            non_passing_ids=failed_ids,
         )
         results.append(result)
+
+    # Invalidate cache after applying changes (not dry-run)
+    if not dry_run:
+        applied_any = any(r.get("status") == "applied" for r in results)
+        if applied_any:
+            try:
+                from darnit.core.audit_cache import invalidate_audit_cache
+
+                invalidate_audit_cache(local_path)
+            except Exception as exc:
+                logger.warning(f"Failed to invalidate audit cache: {exc}")
 
     # Build output
     md = []
@@ -1006,6 +1007,5 @@ def remediate_audit_findings(
 __all__ = [
     "remediate_audit_findings",
     "_apply_remediation",
-    "_determine_remediable_categories",
     "_run_baseline_checks",
 ]

--- a/packages/darnit/src/darnit/core/audit_cache.py
+++ b/packages/darnit/src/darnit/core/audit_cache.py
@@ -1,0 +1,227 @@
+"""Audit result cache for cross-tool-call persistence.
+
+Caches audit results in a temp directory so that the remediate tool can
+skip re-running the audit when results are fresh.  Each repository gets
+its own cache keyed by a short hash of its absolute path:
+
+    $TMPDIR/darnit/<repo-hash>/audit-cache.json
+
+Staleness is tracked via the git HEAD commit hash and working-tree
+dirty state.  Any mismatch → cache miss → remediate falls back to
+running a fresh audit.
+
+Public API:
+    write_audit_cache(local_path, results, summary, level, framework)
+    read_audit_cache(local_path) -> dict | None
+    invalidate_audit_cache(local_path)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from darnit.core.logging import get_logger
+
+logger = get_logger("core.audit_cache")
+
+CACHE_FILENAME = "audit-cache.json"
+CACHE_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Cache location
+# ---------------------------------------------------------------------------
+
+
+def _get_cache_dir(local_path: str) -> Path:
+    """Return the per-repo cache directory under the system temp dir.
+
+    Uses a short SHA-256 hash of the repo's resolved absolute path so
+    that each repository gets an isolated cache directory.
+    """
+    resolved = str(Path(local_path).resolve())
+    repo_hash = hashlib.sha256(resolved.encode()).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / "darnit" / repo_hash
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_head_commit(local_path: str) -> str | None:
+    """Return the current HEAD commit hash, or None if not a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=local_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+def _is_working_tree_dirty(local_path: str) -> bool:
+    """Return True if the working tree has uncommitted changes."""
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=local_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return len(result.stdout.strip()) > 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    # If we can't determine dirty state, assume dirty (conservative)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def write_audit_cache(
+    local_path: str,
+    results: list[dict[str, Any]],
+    summary: dict[str, int],
+    level: int,
+    framework: str,
+) -> None:
+    """Write audit results to the cache.
+
+    Creates the cache directory if it doesn't exist.  Uses atomic write
+    (tempfile + rename) to prevent corruption from interrupted writes.
+
+    Args:
+        local_path: Path to the repository root.
+        results: The raw results list from ``run_sieve_audit()``.
+        summary: Status count summary from ``run_sieve_audit()``.
+        level: Maximum audit level that was evaluated.
+        framework: Framework name (e.g. ``"openssf-baseline"``).
+    """
+    cache_dir = _get_cache_dir(local_path)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    envelope: dict[str, Any] = {
+        "version": CACHE_VERSION,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "commit": _get_head_commit(local_path),
+        "commit_dirty": _is_working_tree_dirty(local_path),
+        "level": level,
+        "framework": framework,
+        "results": results,
+        "summary": summary,
+    }
+
+    cache_path = cache_dir / CACHE_FILENAME
+
+    # Atomic write: write to temp file in same directory, then rename.
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(cache_dir), suffix=".tmp", prefix="audit-cache-"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(envelope, f, indent=2)
+        os.replace(tmp_path, str(cache_path))
+        logger.debug("Wrote audit cache to %s", cache_path)
+    except Exception:
+        # Clean up temp file on failure
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def read_audit_cache(local_path: str) -> dict[str, Any] | None:
+    """Read cached audit results if they are still fresh.
+
+    Returns the full cache envelope (including ``results`` and ``summary``)
+    when the cache exists, is valid JSON, has a supported version, and
+    the git commit + dirty state match the current repository state.
+
+    Returns ``None`` on any mismatch, missing file, or corruption —
+    callers should fall back to running a fresh audit.
+    """
+    cache_path = _get_cache_dir(local_path) / CACHE_FILENAME
+
+    if not cache_path.is_file():
+        logger.debug("No audit cache file at %s", cache_path)
+        return None
+
+    # Parse JSON
+    try:
+        with open(cache_path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.debug("Corrupt or unreadable audit cache: %s", exc)
+        return None
+
+    if not isinstance(data, dict):
+        logger.debug("Audit cache is not a JSON object")
+        return None
+
+    # Version check
+    version = data.get("version")
+    if not isinstance(version, int) or version > CACHE_VERSION:
+        logger.debug("Unknown audit cache version: %s", version)
+        return None
+
+    # Staleness: commit hash
+    cached_commit = data.get("commit")
+    if cached_commit is None:
+        # Written in a non-git repo → always stale
+        logger.debug("Audit cache has null commit — treating as stale")
+        return None
+
+    current_commit = _get_head_commit(local_path)
+    if current_commit != cached_commit:
+        logger.debug(
+            "Audit cache stale: commit %s != current %s",
+            cached_commit,
+            current_commit,
+        )
+        return None
+
+    # Staleness: dirty state
+    cached_dirty = data.get("commit_dirty", False)
+    current_dirty = _is_working_tree_dirty(local_path)
+    if cached_dirty != current_dirty:
+        logger.debug(
+            "Audit cache stale: dirty %s != current %s",
+            cached_dirty,
+            current_dirty,
+        )
+        return None
+
+    logger.debug("Audit cache hit (commit=%s, dirty=%s)", cached_commit, cached_dirty)
+    return data
+
+
+def invalidate_audit_cache(local_path: str) -> None:
+    """Delete the audit cache file if it exists.
+
+    No-op if the file is already missing.
+    """
+    cache_path = _get_cache_dir(local_path) / CACHE_FILENAME
+    try:
+        cache_path.unlink(missing_ok=True)
+        logger.debug("Invalidated audit cache at %s", cache_path)
+    except OSError as exc:
+        logger.debug("Could not remove audit cache: %s", exc)

--- a/packages/darnit/src/darnit/server/tools/builtin_remediate.py
+++ b/packages/darnit/src/darnit/server/tools/builtin_remediate.py
@@ -111,28 +111,39 @@ async def builtin_remediate(
     if not all_controls:
         return "No controls found."
 
-    # Run audit to find failures
+    # Determine which controls failed — use cached audit results if available
+    from darnit.core.audit_cache import invalidate_audit_cache, read_audit_cache
     from darnit.core.utils import detect_owner_repo
 
     owner, repo = detect_owner_repo(str(repo_path))
-    orchestrator = SieveOrchestrator()
     failed_ids: set[str] = set()
 
-    for control in all_controls:
-        context = CheckContext(
-            owner=owner,
-            repo=repo,
-            local_path=str(repo_path),
-            default_branch="main",
-            control_id=control.control_id,
-            control_metadata={
-                "name": control.name,
-                "description": control.description,
-            },
-        )
-        result = orchestrator.verify(control, context)
-        if result.status == "FAIL":
-            failed_ids.add(control.control_id)
+    cache = read_audit_cache(str(repo_path))
+    if cache is not None:
+        # Cache hit — extract failed IDs without re-running the audit
+        logger.info("Using cached audit results (skipping redundant audit)")
+        failed_ids = {
+            r["id"] for r in cache["results"] if r.get("status") == "FAIL"
+        }
+    else:
+        # Cache miss — run inline audit (existing behavior)
+        logger.info("No cached audit results, running audit")
+        orchestrator = SieveOrchestrator()
+        for control in all_controls:
+            context = CheckContext(
+                owner=owner,
+                repo=repo,
+                local_path=str(repo_path),
+                default_branch="main",
+                control_id=control.control_id,
+                control_metadata={
+                    "name": control.name,
+                    "description": control.description,
+                },
+            )
+            result = orchestrator.verify(control, context)
+            if result.status == "FAIL":
+                failed_ids.add(control.control_id)
 
     if not failed_ids:
         return "All controls pass — nothing to remediate."
@@ -174,6 +185,13 @@ async def builtin_remediate(
             _apply_project_update(
                 str(repo_path), rem_cfg.project_update, control_id
             )
+
+    # Invalidate cache after applying changes (not dry-run)
+    if not dry_run and remediation_results:
+        try:
+            invalidate_audit_cache(str(repo_path))
+        except Exception as exc:
+            logger.warning("Failed to invalidate audit cache: %s", exc)
 
     return _format_remediation_report(
         framework_name=_framework_name,

--- a/packages/darnit/src/darnit/tools/audit.py
+++ b/packages/darnit/src/darnit/tools/audit.py
@@ -466,6 +466,21 @@ def run_sieve_audit(
         all_results.append(sieve_result.to_legacy_dict())
 
     summary = summarize_results(all_results)
+
+    # Write results to cache so remediate can skip re-running the audit.
+    # Failures here must never break the audit pipeline.
+    try:
+        from darnit.core.audit_cache import write_audit_cache
+        from darnit.core.discovery import get_default_implementation as _get_impl
+
+        fw_name = ""
+        _impl = _get_impl()
+        if _impl:
+            fw_name = _impl.name
+        write_audit_cache(local_path, all_results, summary, level, fw_name)
+    except Exception as exc:
+        logger.warning("Failed to write audit cache (non-fatal): %s", exc)
+
     return all_results, summary
 
 

--- a/tests/darnit/core/test_audit_cache.py
+++ b/tests/darnit/core/test_audit_cache.py
@@ -1,0 +1,422 @@
+"""Tests for darnit.core.audit_cache module."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from darnit.core.audit_cache import (
+    CACHE_FILENAME,
+    CACHE_VERSION,
+    _get_cache_dir,
+    _get_head_commit,
+    _is_working_tree_dirty,
+    invalidate_audit_cache,
+    read_audit_cache,
+    write_audit_cache,
+)
+
+
+@pytest.fixture
+def sample_results() -> list[dict]:
+    return [
+        {"id": "OSPS-AC-01.01", "status": "PASS", "details": "OK", "level": 1},
+        {"id": "OSPS-DO-02.01", "status": "FAIL", "details": "Missing", "level": 1},
+        {"id": "OSPS-GV-01.01", "status": "WARN", "details": "Manual", "level": 1},
+    ]
+
+
+@pytest.fixture
+def sample_summary() -> dict[str, int]:
+    return {"PASS": 1, "FAIL": 1, "WARN": 1, "N/A": 0, "ERROR": 0, "total": 3}
+
+
+class TestGitHelpers:
+    """Tests for _get_head_commit and _is_working_tree_dirty."""
+
+    @pytest.mark.unit
+    def test_get_head_commit_in_git_repo(self, temp_git_repo: Path):
+        commit = _get_head_commit(str(temp_git_repo))
+        assert commit is not None
+        assert len(commit) == 40  # Full SHA
+
+    @pytest.mark.unit
+    def test_get_head_commit_non_git_dir(self, temp_dir: Path):
+        commit = _get_head_commit(str(temp_dir))
+        assert commit is None
+
+    @pytest.mark.unit
+    def test_is_working_tree_dirty_clean(self, temp_git_repo: Path):
+        dirty = _is_working_tree_dirty(str(temp_git_repo))
+        assert dirty is False
+
+    @pytest.mark.unit
+    def test_is_working_tree_dirty_with_changes(self, temp_git_repo: Path):
+        (temp_git_repo / "new_file.txt").write_text("hello")
+        dirty = _is_working_tree_dirty(str(temp_git_repo))
+        assert dirty is True
+
+
+class TestCacheDir:
+    """Tests for _get_cache_dir."""
+
+    @pytest.mark.unit
+    def test_returns_temp_based_path(self, temp_git_repo: Path):
+        cache_dir = _get_cache_dir(str(temp_git_repo))
+        assert "darnit" in str(cache_dir)
+        assert cache_dir != temp_git_repo  # Not inside repo
+
+    @pytest.mark.unit
+    def test_deterministic_for_same_path(self, temp_git_repo: Path):
+        a = _get_cache_dir(str(temp_git_repo))
+        b = _get_cache_dir(str(temp_git_repo))
+        assert a == b
+
+    @pytest.mark.unit
+    def test_different_for_different_repos(self, tmp_path: Path):
+        repo_a = tmp_path / "repo-a"
+        repo_b = tmp_path / "repo-b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+        a = _get_cache_dir(str(repo_a))
+        b = _get_cache_dir(str(repo_b))
+        assert a != b
+
+
+class TestWriteReadRoundTrip:
+    """Tests for write/read round-trip."""
+
+    @pytest.mark.unit
+    def test_write_then_read(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 3, "openssf-baseline"
+        )
+
+        cache = read_audit_cache(str(temp_git_repo))
+        assert cache is not None
+        assert cache["version"] == CACHE_VERSION
+        assert cache["level"] == 3
+        assert cache["framework"] == "openssf-baseline"
+        assert cache["results"] == sample_results
+        assert cache["summary"] == sample_summary
+        assert cache["commit"] is not None
+        assert isinstance(cache["commit_dirty"], bool)
+        assert "timestamp" in cache
+
+    @pytest.mark.unit
+    def test_creates_cache_directory(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        cache_dir = _get_cache_dir(str(temp_git_repo))
+        assert not cache_dir.exists()
+
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 1, "test"
+        )
+
+        assert cache_dir.is_dir()
+        assert (cache_dir / CACHE_FILENAME).is_file()
+
+    @pytest.mark.unit
+    def test_no_files_in_repo_dir(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        """Cache should be written to temp dir, not the repo itself."""
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 1, "test"
+        )
+        assert not (temp_git_repo / ".darnit").exists()
+
+    @pytest.mark.unit
+    def test_envelope_structure(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 2, "test-fw"
+        )
+        cache_path = _get_cache_dir(str(temp_git_repo)) / CACHE_FILENAME
+        with open(cache_path) as f:
+            data = json.load(f)
+
+        assert set(data.keys()) == {
+            "version",
+            "timestamp",
+            "commit",
+            "commit_dirty",
+            "level",
+            "framework",
+            "results",
+            "summary",
+        }
+
+
+class TestStalenessDetection:
+    """Tests for cache staleness via commit hash and dirty state."""
+
+    @pytest.mark.unit
+    def test_stale_after_new_commit(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 3, "test"
+        )
+
+        # Make a new commit
+        (temp_git_repo / "change.txt").write_text("change")
+        subprocess.run(
+            ["git", "add", "."], cwd=temp_git_repo, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "new commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        assert read_audit_cache(str(temp_git_repo)) is None
+
+    @pytest.mark.unit
+    def test_stale_when_tree_becomes_dirty(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        # Write cache with clean tree
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 3, "test"
+        )
+        assert read_audit_cache(str(temp_git_repo)) is not None
+
+        # Make tree dirty
+        (temp_git_repo / "uncommitted.txt").write_text("dirty")
+
+        assert read_audit_cache(str(temp_git_repo)) is None
+
+    @pytest.mark.unit
+    def test_stale_when_tree_becomes_clean(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        # Make tree dirty, then write cache
+        dirty_file = temp_git_repo / "dirty.txt"
+        dirty_file.write_text("dirty")
+
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 3, "test"
+        )
+        assert read_audit_cache(str(temp_git_repo)) is not None
+
+        # Clean up the tree (add + commit)
+        subprocess.run(
+            ["git", "add", "."], cwd=temp_git_repo, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "clean up"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        # Cache is stale: both commit AND dirty state changed
+        assert read_audit_cache(str(temp_git_repo)) is None
+
+
+class TestNonGitRepo:
+    """Tests for non-git repository handling."""
+
+    @pytest.mark.unit
+    def test_write_with_null_commit(
+        self, temp_dir: Path, sample_results, sample_summary
+    ):
+        write_audit_cache(str(temp_dir), sample_results, sample_summary, 1, "test")
+
+        cache_path = _get_cache_dir(str(temp_dir)) / CACHE_FILENAME
+        with open(cache_path) as f:
+            data = json.load(f)
+
+        assert data["commit"] is None
+
+    @pytest.mark.unit
+    def test_null_commit_always_stale(
+        self, temp_dir: Path, sample_results, sample_summary
+    ):
+        write_audit_cache(str(temp_dir), sample_results, sample_summary, 1, "test")
+        assert read_audit_cache(str(temp_dir)) is None
+
+
+class TestCorruptionHandling:
+    """Tests for corrupt/invalid cache files."""
+
+    @pytest.mark.unit
+    def test_corrupt_json(self, temp_git_repo: Path):
+        cache_dir = _get_cache_dir(str(temp_git_repo))
+        cache_dir.mkdir(parents=True)
+        (cache_dir / CACHE_FILENAME).write_text("not valid json {{{")
+
+        assert read_audit_cache(str(temp_git_repo)) is None
+
+    @pytest.mark.unit
+    def test_unknown_version(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 3, "test"
+        )
+
+        # Bump version beyond supported
+        cache_path = _get_cache_dir(str(temp_git_repo)) / CACHE_FILENAME
+        with open(cache_path) as f:
+            data = json.load(f)
+        data["version"] = CACHE_VERSION + 1
+        with open(cache_path, "w") as f:
+            json.dump(data, f)
+
+        assert read_audit_cache(str(temp_git_repo)) is None
+
+    @pytest.mark.unit
+    def test_not_a_dict(self, temp_git_repo: Path):
+        cache_dir = _get_cache_dir(str(temp_git_repo))
+        cache_dir.mkdir(parents=True)
+        (cache_dir / CACHE_FILENAME).write_text('"just a string"')
+
+        assert read_audit_cache(str(temp_git_repo)) is None
+
+    @pytest.mark.unit
+    def test_missing_cache_file(self, temp_git_repo: Path):
+        assert read_audit_cache(str(temp_git_repo)) is None
+
+
+class TestInvalidateCache:
+    """Tests for invalidate_audit_cache."""
+
+    @pytest.mark.unit
+    def test_invalidate_existing(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 3, "test"
+        )
+        cache_path = _get_cache_dir(str(temp_git_repo)) / CACHE_FILENAME
+        assert cache_path.exists()
+
+        invalidate_audit_cache(str(temp_git_repo))
+        assert not cache_path.exists()
+
+    @pytest.mark.unit
+    def test_invalidate_missing_noop(self, temp_git_repo: Path):
+        # Should not raise
+        invalidate_audit_cache(str(temp_git_repo))
+
+    @pytest.mark.unit
+    def test_read_after_invalidate_returns_none(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 3, "test"
+        )
+        invalidate_audit_cache(str(temp_git_repo))
+        assert read_audit_cache(str(temp_git_repo)) is None
+
+
+class TestAtomicWrite:
+    """Tests for atomic write behavior."""
+
+    @pytest.mark.unit
+    def test_no_partial_file_on_error(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        """If json.dump raises, no cache file should be left behind."""
+        with patch("darnit.core.audit_cache.json.dump", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                write_audit_cache(
+                    str(temp_git_repo),
+                    sample_results,
+                    sample_summary,
+                    3,
+                    "test",
+                )
+
+        cache_path = _get_cache_dir(str(temp_git_repo)) / CACHE_FILENAME
+        assert not cache_path.exists()
+
+    @pytest.mark.unit
+    def test_overwrite_existing_cache(
+        self, temp_git_repo: Path, sample_results, sample_summary
+    ):
+        """Writing twice overwrites the first cache atomically."""
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 1, "first"
+        )
+        write_audit_cache(
+            str(temp_git_repo), sample_results, sample_summary, 2, "second"
+        )
+
+        cache = read_audit_cache(str(temp_git_repo))
+        assert cache is not None
+        assert cache["level"] == 2
+        assert cache["framework"] == "second"
+
+
+class TestRunSieveAuditCacheIntegration:
+    """Test that run_sieve_audit() writes cache as a side effect."""
+
+    @pytest.mark.unit
+    def test_run_sieve_audit_writes_cache(self, temp_git_repo: Path):
+        """Verify run_sieve_audit() produces a cache file with correct structure."""
+        mock_result = MagicMock()
+        mock_result.to_legacy_dict.return_value = {
+            "id": "TEST-01",
+            "status": "PASS",
+            "details": "OK",
+            "level": 1,
+        }
+
+        mock_spec = MagicMock()
+        mock_spec.control_id = "TEST-01"
+        mock_spec.name = "Test Control"
+        mock_spec.description = "A test control"
+        mock_spec.level = 1
+        mock_spec.metadata = {"full": ""}
+        mock_spec.locator_config = None
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.verify.return_value = mock_result
+
+        mock_registry = MagicMock()
+        mock_registry.get_specs_by_level.return_value = [mock_spec]
+
+        sieve_components = {
+            "SieveOrchestrator": lambda **kw: mock_orchestrator,
+            "get_control_registry": lambda: mock_registry,
+            "CheckContext": MagicMock(),
+        }
+
+        with (
+            patch("darnit.tools.audit._get_sieve_components", return_value=sieve_components),
+            patch("darnit.tools.audit._register_toml_controls", return_value=0),
+            patch("darnit.tools.audit.get_excluded_control_ids", return_value={}),
+            patch("darnit.core.discovery.get_default_implementation", return_value=None),
+        ):
+            from darnit.tools.audit import run_sieve_audit
+
+            results, summary = run_sieve_audit(
+                owner="test-owner",
+                repo="test-repo",
+                local_path=str(temp_git_repo),
+                default_branch="main",
+                level=1,
+            )
+
+        # Verify the cache was written (in temp dir, not repo)
+        cache_path = _get_cache_dir(str(temp_git_repo)) / CACHE_FILENAME
+        assert cache_path.exists(), "run_sieve_audit should write audit cache"
+
+        with open(cache_path) as f:
+            data = json.load(f)
+
+        assert data["version"] == CACHE_VERSION
+        assert data["level"] == 1
+        assert data["results"] == results
+        assert data["summary"] == summary
+        assert data["commit"] is not None

--- a/tests/darnit/server/test_builtin_remediate_cache.py
+++ b/tests/darnit/server/test_builtin_remediate_cache.py
@@ -1,0 +1,239 @@
+"""Tests for builtin_remediate audit cache integration.
+
+Verifies that builtin_remediate:
+- Uses cached audit results when available (cache hit)
+- Falls back to running audit when cache is missing (cache miss)
+- Excludes PASS controls from remediation plan
+- Preserves cache on dry run
+- Invalidates cache after non-dry-run remediation
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def cached_results():
+    """Cache envelope with mixed PASS/FAIL results."""
+    return {
+        "version": 1,
+        "timestamp": "2026-02-16T12:00:00Z",
+        "commit": "abc123",
+        "commit_dirty": False,
+        "level": 3,
+        "framework": "openssf-baseline",
+        "results": [
+            {"id": "OSPS-AC-01.01", "status": "PASS", "details": "OK", "level": 1},
+            {"id": "OSPS-DO-02.01", "status": "FAIL", "details": "Missing", "level": 1},
+            {"id": "OSPS-GV-01.01", "status": "FAIL", "details": "Missing", "level": 1},
+            {"id": "OSPS-VM-01.01", "status": "WARN", "details": "Manual", "level": 1},
+        ],
+        "summary": {"PASS": 1, "FAIL": 2, "WARN": 1, "N/A": 0, "ERROR": 0, "total": 4},
+    }
+
+
+def _make_mock_control(control_id: str):
+    ctrl = MagicMock()
+    ctrl.control_id = control_id
+    ctrl.name = f"Control {control_id}"
+    ctrl.description = f"Description for {control_id}"
+    return ctrl
+
+
+def _make_common_patches(cache_return, controls):
+    """Return a dict of patches for the function's lazy imports."""
+    mock_fw = MagicMock()
+    mock_fw.controls = {}
+    mock_fw.templates = {}
+
+    mock_config = MagicMock()
+    mock_config.framework = mock_fw
+
+    mock_impl = MagicMock()
+    mock_impl.name = "openssf-baseline"
+    mock_impl.get_framework_config_path.return_value = None
+
+    return {
+        # Patch at the source module since builtin_remediate uses lazy imports
+        "darnit.core.audit_cache.read_audit_cache": MagicMock(return_value=cache_return),
+        "darnit.core.audit_cache.invalidate_audit_cache": MagicMock(),
+        "darnit.config.load_effective_config_by_name": MagicMock(return_value=mock_config),
+        "darnit.config.load_controls_from_effective": MagicMock(return_value=controls),
+        "darnit.core.discovery.get_implementation": MagicMock(return_value=mock_impl),
+        "darnit.sieve.registry.get_control_registry": MagicMock(
+            return_value=MagicMock(get_all_specs=MagicMock(return_value=[]))
+        ),
+        "darnit.core.utils.detect_owner_repo": MagicMock(return_value=("testorg", "testrepo")),
+    }
+
+
+class TestCacheHit:
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_audit(self, tmp_path, cached_results):
+        """With a cache hit, SieveOrchestrator.verify() should NOT be called."""
+        controls = [_make_mock_control("OSPS-DO-02.01")]
+        patches = _make_common_patches(cached_results, controls)
+
+        mock_orchestrator = MagicMock()
+        patches["darnit.sieve.SieveOrchestrator"] = MagicMock(return_value=mock_orchestrator)
+
+        with patch.dict("sys.modules", {}):  # clear stale module cache
+            pass
+
+        patchers = [patch(k, v) for k, v in patches.items()]
+        for p in patchers:
+            p.start()
+        try:
+            from darnit.server.tools.builtin_remediate import builtin_remediate
+
+            await builtin_remediate(
+                local_path=str(tmp_path),
+                dry_run=True,
+                _framework_name="openssf-baseline",
+            )
+            # SieveOrchestrator should NOT have been called (cache hit path)
+            mock_orchestrator.verify.assert_not_called()
+        finally:
+            for p in patchers:
+                p.stop()
+
+    @pytest.mark.asyncio
+    async def test_pass_controls_excluded(self, tmp_path, cached_results):
+        """PASS controls from cache should NOT appear in remediation output."""
+        controls = [
+            _make_mock_control("OSPS-AC-01.01"),
+            _make_mock_control("OSPS-DO-02.01"),
+        ]
+        patches = _make_common_patches(cached_results, controls)
+        patchers = [patch(k, v) for k, v in patches.items()]
+        for p in patchers:
+            p.start()
+        try:
+            from darnit.server.tools.builtin_remediate import builtin_remediate
+
+            result = await builtin_remediate(
+                local_path=str(tmp_path),
+                dry_run=True,
+                _framework_name="openssf-baseline",
+            )
+            # OSPS-AC-01.01 is PASS — should NOT appear in remediation
+            assert "OSPS-AC-01.01" not in result
+        finally:
+            for p in patchers:
+                p.stop()
+
+
+class TestCacheMiss:
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_runs_audit(self, tmp_path):
+        """With no cache, SieveOrchestrator.verify() should be called."""
+        controls = [_make_mock_control("OSPS-DO-02.01")]
+        patches = _make_common_patches(None, controls)  # None = cache miss
+
+        mock_verify_result = MagicMock()
+        mock_verify_result.status = "FAIL"
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.verify.return_value = mock_verify_result
+        patches["darnit.sieve.SieveOrchestrator"] = MagicMock(return_value=mock_orchestrator)
+
+        patchers = [patch(k, v) for k, v in patches.items()]
+        for p in patchers:
+            p.start()
+        try:
+            from darnit.server.tools.builtin_remediate import builtin_remediate
+
+            await builtin_remediate(
+                local_path=str(tmp_path),
+                dry_run=True,
+                _framework_name="openssf-baseline",
+            )
+            mock_orchestrator.verify.assert_called()
+        finally:
+            for p in patchers:
+                p.stop()
+
+
+class TestCacheInvalidation:
+
+    @pytest.mark.asyncio
+    async def test_dry_run_preserves_cache(self, tmp_path, cached_results):
+        """Dry run should NOT invalidate cache."""
+        controls = [_make_mock_control("OSPS-DO-02.01")]
+        patches = _make_common_patches(cached_results, controls)
+        invalidate_mock = patches["darnit.core.audit_cache.invalidate_audit_cache"]
+
+        patchers = [patch(k, v) for k, v in patches.items()]
+        for p in patchers:
+            p.start()
+        try:
+            from darnit.server.tools.builtin_remediate import builtin_remediate
+
+            await builtin_remediate(
+                local_path=str(tmp_path),
+                dry_run=True,
+                _framework_name="openssf-baseline",
+            )
+            invalidate_mock.assert_not_called()
+        finally:
+            for p in patchers:
+                p.stop()
+
+    @pytest.mark.asyncio
+    async def test_non_dry_run_invalidates_cache(self, tmp_path, cached_results):
+        """Non-dry-run with applied remediations should invalidate cache."""
+        controls = [_make_mock_control("OSPS-DO-02.01")]
+        patches = _make_common_patches(cached_results, controls)
+
+        # Set up executor to report success
+        mock_exec_result = MagicMock()
+        mock_exec_result.success = True
+        mock_exec_result.control_id = "OSPS-DO-02.01"
+        mock_exec_result.message = "Created file"
+
+        mock_executor = MagicMock()
+        mock_executor.execute.return_value = mock_exec_result
+        patches["darnit.remediation.executor.RemediationExecutor"] = MagicMock(
+            return_value=mock_executor
+        )
+
+        # Need fw.controls with a remediation config for DO-02.01
+        mock_rem_cfg = MagicMock()
+        mock_rem_cfg.file_create = [MagicMock()]
+        mock_rem_cfg.exec = None
+        mock_rem_cfg.api_call = None
+        mock_rem_cfg.handler = None
+        mock_rem_cfg.project_update = None
+
+        mock_control_cfg = MagicMock()
+        mock_control_cfg.remediation = mock_rem_cfg
+
+        mock_fw = MagicMock()
+        mock_fw.controls = {"OSPS-DO-02.01": mock_control_cfg}
+        mock_fw.templates = {}
+
+        mock_config = MagicMock()
+        mock_config.framework = mock_fw
+        patches["darnit.config.load_effective_config_by_name"] = MagicMock(
+            return_value=mock_config
+        )
+
+        invalidate_mock = patches["darnit.core.audit_cache.invalidate_audit_cache"]
+
+        patchers = [patch(k, v) for k, v in patches.items()]
+        for p in patchers:
+            p.start()
+        try:
+            from darnit.server.tools.builtin_remediate import builtin_remediate
+
+            await builtin_remediate(
+                local_path=str(tmp_path),
+                dry_run=False,
+                _framework_name="openssf-baseline",
+            )
+            invalidate_mock.assert_called_once()
+        finally:
+            for p in patchers:
+                p.stop()

--- a/tests/darnit_baseline/test_remediation_cache.py
+++ b/tests/darnit_baseline/test_remediation_cache.py
@@ -1,0 +1,306 @@
+"""Tests for remediate_audit_findings() cache integration.
+
+Verifies that the orchestrator:
+- Uses cached audit results when available (cache hit)
+- Falls back to _run_baseline_checks when cache is missing (cache miss)
+- Only remediates FAIL controls (WARN/PASS are excluded)
+- Invalidates cache after applying changes (non-dry-run)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def cached_results():
+    """Cache envelope with mixed PASS/FAIL/WARN results."""
+    return {
+        "version": 1,
+        "timestamp": "2026-02-16T12:00:00Z",
+        "commit": "abc123",
+        "commit_dirty": False,
+        "level": 3,
+        "framework": "openssf-baseline",
+        "results": [
+            {"id": "OSPS-AC-01.01", "status": "PASS", "details": "OK", "level": 1},
+            {"id": "OSPS-DO-02.01", "status": "FAIL", "details": "Missing", "level": 1},
+            {"id": "OSPS-DO-03.01", "status": "FAIL", "details": "Missing", "level": 1},
+            {"id": "OSPS-VM-01.01", "status": "WARN", "details": "Manual", "level": 1},
+        ],
+        "summary": {"PASS": 1, "FAIL": 2, "WARN": 1, "N/A": 0, "ERROR": 0, "total": 4},
+    }
+
+
+class TestOrchestratorCacheHit:
+    """When cache has valid results, skip _run_baseline_checks."""
+
+    def test_cache_hit_skips_audit(self, tmp_path, cached_results):
+        """With a cache hit, _run_baseline_checks should NOT be called."""
+        run_checks_mock = MagicMock()
+        apply_mock = MagicMock(
+            return_value={"status": "would_apply", "category": "support_doc"},
+        )
+
+        with (
+            patch(
+                "darnit.core.audit_cache.read_audit_cache",
+                return_value=cached_results,
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator.validate_local_path",
+                return_value=(str(tmp_path), None),
+            ),
+            patch(
+                "darnit.core.utils.detect_owner_repo",
+                return_value=("testorg", "testrepo"),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._run_baseline_checks",
+                run_checks_mock,
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._preflight_context_check",
+                return_value=(True, {}),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._apply_remediation",
+                apply_mock,
+            ),
+        ):
+            from darnit_baseline.remediation.orchestrator import remediate_audit_findings
+
+            remediate_audit_findings(
+                local_path=str(tmp_path),
+                dry_run=True,
+            )
+
+            # _run_baseline_checks should NOT have been called
+            run_checks_mock.assert_not_called()
+
+    def test_cache_hit_passes_only_fail_ids(self, tmp_path, cached_results):
+        """Cache hit should pass only FAIL IDs (not WARN) to _apply_remediation."""
+        apply_mock = MagicMock(
+            return_value={"status": "would_apply", "category": "test"},
+        )
+
+        with (
+            patch(
+                "darnit.core.audit_cache.read_audit_cache",
+                return_value=cached_results,
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator.validate_local_path",
+                return_value=(str(tmp_path), None),
+            ),
+            patch(
+                "darnit.core.utils.detect_owner_repo",
+                return_value=("testorg", "testrepo"),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._preflight_context_check",
+                return_value=(True, {}),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._apply_remediation",
+                apply_mock,
+            ),
+        ):
+            from darnit_baseline.remediation.orchestrator import remediate_audit_findings
+
+            remediate_audit_findings(
+                local_path=str(tmp_path),
+                dry_run=True,
+            )
+
+            # Every call to _apply_remediation should receive only FAIL IDs
+            for call in apply_mock.call_args_list:
+                passed_ids = call.kwargs.get("non_passing_ids") or call[1].get(
+                    "non_passing_ids"
+                )
+                assert passed_ids == {"OSPS-DO-02.01", "OSPS-DO-03.01"}, (
+                    f"Expected only FAIL IDs, got {passed_ids}"
+                )
+                # WARN control should NOT be included
+                assert "OSPS-VM-01.01" not in passed_ids
+
+
+class TestOrchestratorCacheMiss:
+    """When no cache exists, fall back to _run_baseline_checks."""
+
+    def test_cache_miss_runs_audit(self, tmp_path):
+        """With no cache, _run_baseline_checks SHOULD be called."""
+        mock_audit_result = MagicMock()
+        mock_audit_result.all_results = [
+            {"id": "OSPS-DO-02.01", "status": "FAIL", "details": "Missing"},
+        ]
+
+        with (
+            patch(
+                "darnit.core.audit_cache.read_audit_cache",
+                return_value=None,
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator.validate_local_path",
+                return_value=(str(tmp_path), None),
+            ),
+            patch(
+                "darnit.core.utils.detect_owner_repo",
+                return_value=("testorg", "testrepo"),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._run_baseline_checks",
+                return_value=(mock_audit_result, None),
+            ) as run_checks_mock,
+            patch(
+                "darnit_baseline.remediation.orchestrator._preflight_context_check",
+                return_value=(True, {}),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._apply_remediation",
+                return_value={"status": "would_apply", "category": "support_doc"},
+            ),
+        ):
+            from darnit_baseline.remediation.orchestrator import remediate_audit_findings
+
+            remediate_audit_findings(
+                local_path=str(tmp_path),
+                dry_run=True,
+            )
+
+            run_checks_mock.assert_called_once()
+
+    def test_cache_miss_filters_to_fail_only(self, tmp_path):
+        """Cache miss path should also filter to FAIL-only (not WARN)."""
+        mock_audit_result = MagicMock()
+        mock_audit_result.all_results = [
+            {"id": "OSPS-DO-02.01", "status": "FAIL", "details": "Missing"},
+            {"id": "OSPS-VM-01.01", "status": "WARN", "details": "Manual"},
+            {"id": "OSPS-AC-01.01", "status": "PASS", "details": "OK"},
+        ]
+
+        apply_mock = MagicMock(
+            return_value={"status": "would_apply", "category": "test"},
+        )
+
+        with (
+            patch(
+                "darnit.core.audit_cache.read_audit_cache",
+                return_value=None,
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator.validate_local_path",
+                return_value=(str(tmp_path), None),
+            ),
+            patch(
+                "darnit.core.utils.detect_owner_repo",
+                return_value=("testorg", "testrepo"),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._run_baseline_checks",
+                return_value=(mock_audit_result, None),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._preflight_context_check",
+                return_value=(True, {}),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._apply_remediation",
+                apply_mock,
+            ),
+        ):
+            from darnit_baseline.remediation.orchestrator import remediate_audit_findings
+
+            remediate_audit_findings(
+                local_path=str(tmp_path),
+                dry_run=True,
+            )
+
+            for call in apply_mock.call_args_list:
+                passed_ids = call.kwargs.get("non_passing_ids") or call[1].get(
+                    "non_passing_ids"
+                )
+                assert passed_ids == {"OSPS-DO-02.01"}
+                assert "OSPS-VM-01.01" not in passed_ids
+
+
+class TestOrchestratorCacheInvalidation:
+    """Cache invalidation after applying changes."""
+
+    def test_invalidates_after_applied_changes(self, tmp_path, cached_results):
+        """Non-dry-run with applied remediations should invalidate cache."""
+        invalidate_mock = MagicMock()
+
+        with (
+            patch(
+                "darnit.core.audit_cache.read_audit_cache",
+                return_value=cached_results,
+            ),
+            patch(
+                "darnit.core.audit_cache.invalidate_audit_cache",
+                invalidate_mock,
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator.validate_local_path",
+                return_value=(str(tmp_path), None),
+            ),
+            patch(
+                "darnit.core.utils.detect_owner_repo",
+                return_value=("testorg", "testrepo"),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._preflight_context_check",
+                return_value=(True, {}),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._apply_remediation",
+                return_value={"status": "applied", "category": "support_doc"},
+            ),
+        ):
+            from darnit_baseline.remediation.orchestrator import remediate_audit_findings
+
+            remediate_audit_findings(
+                local_path=str(tmp_path),
+                dry_run=False,
+            )
+
+            invalidate_mock.assert_called_once()
+
+    def test_dry_run_preserves_cache(self, tmp_path, cached_results):
+        """Dry run should NOT invalidate cache."""
+        invalidate_mock = MagicMock()
+
+        with (
+            patch(
+                "darnit.core.audit_cache.read_audit_cache",
+                return_value=cached_results,
+            ),
+            patch(
+                "darnit.core.audit_cache.invalidate_audit_cache",
+                invalidate_mock,
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator.validate_local_path",
+                return_value=(str(tmp_path), None),
+            ),
+            patch(
+                "darnit.core.utils.detect_owner_repo",
+                return_value=("testorg", "testrepo"),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._preflight_context_check",
+                return_value=(True, {}),
+            ),
+            patch(
+                "darnit_baseline.remediation.orchestrator._apply_remediation",
+                return_value={"status": "would_apply", "category": "support_doc"},
+            ),
+        ):
+            from darnit_baseline.remediation.orchestrator import remediate_audit_findings
+
+            remediate_audit_findings(
+                local_path=str(tmp_path),
+                dry_run=True,
+            )
+
+            invalidate_mock.assert_not_called()


### PR DESCRIPTION
## Summary

- **Audit result cache**: `run_sieve_audit()` now writes results to `$TMPDIR/darnit/<repo-hash>/audit-cache.json` after completing. Staleness tracked via git commit hash + working-tree dirty state. Both `builtin_remediate()` and `remediate_audit_findings()` check the cache before re-running the audit.
- **FAIL-only remediation**: Only controls with `status == "FAIL"` are remediated. WARN controls (inconclusive automated verification) are left alone — existing files may be correct and shouldn't be overwritten with templates. Previously all non-PASS controls were remediated.
- **Removed dead abstractions**: `_determine_remediable_categories()` and `_get_control_to_category_map()` — redundant now that all categories are iterated and per-control filtering handles exclusion.

## Test plan

- [x] 26 unit tests for `audit_cache` module (write/read round-trip, staleness detection, corruption handling, atomic writes, temp-dir isolation)
- [x] 5 tests for `builtin_remediate` cache integration (cache hit/miss, FAIL-only filtering, invalidation)
- [x] 6 tests for orchestrator cache integration (cache hit/miss, FAIL-only filtering, invalidation, dry-run preservation)
- [x] 4 existing remediation filtering tests still pass
- [x] Full suite: 946 passed, 1 skipped
- [x] E2E verified: audit → cache written → remediate uses cache (no second audit) → only FAIL controls in plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)