### PR TITLE
cleanup: Fix stale docs and remove dead code (round 3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -255,7 +255,6 @@ All defined in `packages/darnit/src/darnit/sieve/models.py`:
 | `PassAttempt` | Record of what a pass attempted, for transparency |
 | `SieveResult` | Complete result: status (PASS/FAIL/WARN/NA/ERROR/PENDING_LLM), conclusive_phase, pass_history |
 | `ControlSpec` | Control definition: control_id, level, domain, name, description, passes[], tags, metadata |
-| `LLMConsultationRequest` | Structured request for Phase 3 LLM analysis |
 | `LLMConsultationResponse` | Parsed LLM response with confidence and reasoning |
 
 ### Evidence Accumulation
@@ -264,7 +263,7 @@ Each pass can return `evidence` (a dict) in its `PassResult`. This evidence is m
 
 ### LLM Consultation Protocol
 
-Phase 3 returns a `PENDING_LLM` status with a `LLMConsultationRequest` in the details. The calling AI assistant analyzes the evidence and returns a structured `LLMConsultationResponse`. The sieve never calls an LLM directly — it delegates to whoever invoked the audit.
+Phase 3 returns a `PENDING_LLM` status with consultation details. The calling AI assistant analyzes the evidence and returns a structured `LLMConsultationResponse`. The sieve never calls an LLM directly — it delegates to whoever invoked the audit.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,12 @@ packages/
 │
 ├── darnit-baseline/         # OpenSSF Baseline implementation
 │   └── src/darnit_baseline/
-│       ├── controls/        # Python-defined control checks
-│       ├── checks/          # Legacy check functions
-│       ├── remediation/     # Auto-fix actions
-│       └── rules/           # SARIF rule catalog
+│       ├── attestation/     # In-toto attestation support
+│       ├── config/          # Project context configuration
+│       ├── formatters/      # Output formatting (Markdown, JSON, SARIF)
+│       ├── remediation/     # Remediation orchestration
+│       ├── rules/           # SARIF rule definitions (from TOML)
+│       └── threat_model/    # Threat model generation
 │
 └── darnit-testchecks/       # Test implementation (for testing)
 ```
@@ -68,11 +70,10 @@ impl.version                     # str: Implementation version
 impl.spec_version                # str: Spec version implemented
 impl.get_all_controls()          # List[ControlSpec]: All controls
 impl.get_controls_by_level(n)    # List[ControlSpec]: Controls at level n
-impl.get_check_functions()       # Dict: Legacy check functions
 impl.get_rules_catalog()         # Dict: SARIF rule definitions
 impl.get_remediation_registry()  # Dict: Auto-fix mappings
 impl.get_framework_config_path() # Path | None: TOML config location
-impl.register_controls()         # None: Register Python controls
+impl.register_controls()         # None: Register TOML controls
 ```
 
 ## Plugin System
@@ -120,7 +121,7 @@ class MyFrameworkImplementation:
         return Path(__file__).parent / "my-framework.toml"
 
     def register_controls(self) -> None:
-        from .controls import checks  # noqa: F401
+        pass  # Controls are defined in TOML; no Python registration needed
 ```
 
 2. Add the registration function:
@@ -141,13 +142,13 @@ my-framework = "my_framework:register"
 
 ## Sieve Pattern
 
-The verification pipeline follows a 4-phase pattern:
+The verification pipeline follows a 4-phase pattern using built-in handlers:
 
 ```
-DETERMINISTIC → PATTERN → LLM → MANUAL
-     ↓              ↓        ↓       ↓
-  Exact checks   Heuristics  AI    Human
-  (high conf)    (med conf)  eval  review
+file_must_exist → exec/regex → llm_eval → manual
+       ↓              ↓           ↓         ↓
+  File presence   Commands &   AI-based   Human
+  checks          patterns     eval       review
 ```
 
 Each control can define passes at each phase. The orchestrator stops at the first conclusive result.
@@ -180,9 +181,9 @@ This is a compliance auditing tool. Incorrect results are worse than incomplete 
 
 ### Adding New Controls
 
-1. Define the control in the framework TOML file
-2. Optionally add Python pass definitions in `controls/level*.py`
-3. Register using the `@register_control` decorator
+1. Define the control in `openssf-baseline.toml` with passes and metadata
+2. Optionally add plugin Python handlers for complex logic
+3. Run `uv run python scripts/validate_sync.py --verbose` to verify sync
 
 ### Testing
 
@@ -246,13 +247,11 @@ uv run python scripts/generate_docs.py
 git diff docs/generated/
 ```
 
-### Legacy Code Migration
+### TOML-First Architecture
 
-The `rules/catalog.py` is deprecated. SARIF metadata now reads from TOML:
-- Primary source: `openssf-baseline.toml` control definitions
-- Fallback: `rules/catalog.py` (for unmigrated controls)
-
-When adding new controls, define all metadata in TOML.
+All controls are defined in `openssf-baseline.toml`. The `rules/catalog.py` file
+is a deprecated fallback that remains for backward compatibility but is not
+actively used. All new controls must be defined entirely in TOML.
 
 ## TOML Schema Features
 

--- a/docs/DARNIT_FRAMEWORK_DESIGN.md
+++ b/docs/DARNIT_FRAMEWORK_DESIGN.md
@@ -1403,31 +1403,18 @@ project.toml does NOT change when an audit runs.
 
 Audit results are **ephemeral** and belong in separate output:
 
-```
-project-root/
-├── project.toml              # Configuration (user-managed, stable)
-│
-├── .darnit/                  # Darnit working directory
-│   ├── cache/                # Cached data for performance
-│   │   └── last-audit.json   # Most recent audit for quick lookup
-│   │
-│   ├── reports/              # Historical audit reports
-│   │   ├── audit-2025-12-01T10-30-00.json
-│   │   ├── audit-2025-12-01T10-30-00.sarif
-│   │   └── audit-2025-12-01T10-30-00.md
-│   │
-│   └── attestations/         # Signed compliance proofs
-│       └── baseline-2025-12-01.intoto.jsonl
-│
-└── (or output to stdout/return value for MCP tools)
-```
+- **Audit cache**: Stored in `$TMPDIR/darnit/<repo-hash>/` (not in the repo)
+- **Attestations**: Output to stdout or returned via MCP tool response
+- **Reports**: Returned directly from MCP tools or written to stdout
+
+No `.darnit/` directory is created in the repository.
 
 ### 6.4 LLM/AI Guidelines
 
 **When an AI agent uses Darnit tools, it MUST:**
 
 1. **Never write audit results to project.toml**
-   - Results go to `.darnit/reports/`, stdout, or are returned from MCP tools
+   - Results go to stdout or are returned from MCP tools
    - The AI should present results to the user, not persist them to config
 
 2. **Only modify project.toml for configuration changes**
@@ -1533,7 +1520,7 @@ Tools MUST check this version and handle unknown versions gracefully.
 # project.toml - Darnit Security Configuration
 #
 # IMPORTANT: This file contains CONFIGURATION only.
-# Audit results belong in .darnit/reports/ or tool output.
+# Audit results belong in tool output (stdout or MCP response).
 #
 # This file is the canonical source of truth for:
 # - Project metadata

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -287,7 +287,7 @@ generate_attestation(
 - In-toto attestation format
 - Sigstore signing (OIDC-based)
 - Cryptographic proof of compliance status
-- Saved to `.darnit/attestations/`
+- Output to stdout or returned via MCP tool response
 
 ---
 

--- a/docs/generated/ARCHITECTURE.md
+++ b/docs/generated/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Darnit Framework Architecture
 
 > Generated from framework specification
-> Spec Version: Unknown
+> Spec Version: 1.0.0-alpha.8
 
 This document describes the architecture of the Darnit framework, including
 the sieve orchestrator, plugin system, and TOML configuration schema.

--- a/docs/generated/SCHEMA_REFERENCE.md
+++ b/docs/generated/SCHEMA_REFERENCE.md
@@ -1,7 +1,7 @@
 # Darnit TOML Schema Reference
 
 > Generated from framework specification
-> Spec Version: Unknown
+> Spec Version: 1.0.0-alpha.8
 
 This document provides a complete reference for the TOML configuration schema
 used to define controls, passes, and remediations.

--- a/docs/generated/USAGE_GUIDE.md
+++ b/docs/generated/USAGE_GUIDE.md
@@ -1,7 +1,7 @@
 # Darnit Framework Usage Guide
 
 > Generated from framework specification
-> Spec Version: Unknown
+> Spec Version: 1.0.0-alpha.8
 
 This guide explains how to use the Darnit framework for compliance auditing.
 

--- a/packages/darnit-baseline/src/darnit_baseline/config/mappings.py
+++ b/packages/darnit-baseline/src/darnit_baseline/config/mappings.py
@@ -238,45 +238,6 @@ DEFAULT_FILE_LOCATIONS: dict[str, list[str]] = {
 }
 
 
-def get_config_path(config: ProjectConfig, section: str, field: str) -> str | None:
-    """Get a path from config, checking both standard and extension sections.
-
-    This is a convenience wrapper around config.get_path() that handles
-    the section/field resolution for OSPS controls.
-
-    Args:
-        config: ProjectConfig instance
-        section: Section name (e.g., "security", "governance")
-        field: Field name (e.g., "policy", "maintainers")
-
-    Returns:
-        Path string or None if not found
-    """
-    return config.get_path(section, field)
-
-
-def resolve_control_path(config: ProjectConfig, control_id: str) -> str | None:
-    """Resolve the file path for a control from the config.
-
-    Args:
-        config: ProjectConfig instance
-        control_id: OSPS control ID (e.g., "OSPS-DO-02.01")
-
-    Returns:
-        Path string or None if not found
-    """
-    ref_path = CONTROL_REFERENCE_MAPPING.get(control_id)
-    if not ref_path:
-        return None
-
-    parts = ref_path.split(".", 1)
-    if len(parts) != 2:
-        return None
-
-    section, field = parts
-    return config.get_path(section, field)
-
-
 __all__ = [
     # Re-exports from darnit
     "ProjectType",
@@ -291,7 +252,4 @@ __all__ = [
     "PROJECT_TYPE_EXCLUSIONS",
     "CONTROL_REFERENCE_MAPPING",
     "DEFAULT_FILE_LOCATIONS",
-    # Helpers
-    "get_config_path",
-    "resolve_control_path",
 ]

--- a/packages/darnit/src/darnit/sieve/models.py
+++ b/packages/darnit/src/darnit/sieve/models.py
@@ -74,19 +74,6 @@ class PassAttempt:
 
 
 @dataclass
-class LLMConsultationRequest:
-    """Request for LLM analysis when Pass 3 needs help."""
-
-    control_id: str
-    control_name: str
-    control_description: str
-    prompt: str
-    context: dict[str, Any]
-    analysis_hints: list[str]
-    expected_response: str  # JSON schema or format description
-
-
-@dataclass
 class LLMConsultationResponse:
     """Parsed response from LLM consultation."""
 

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -141,6 +141,14 @@ def parse_spec(spec_path: Path) -> tuple[dict[str, Any], str]:
                     metadata[key.strip()] = value.strip()
             content = content[end_idx + 3 :].strip()
 
+    # Also parse blockquote metadata (> **Key**: Value) used in spec files
+    blockquote_pattern = r"^>\s*\*\*(\w[\w\s]*)\*\*:\s*(.+)$"
+    for match in re.finditer(blockquote_pattern, content, re.MULTILINE):
+        key = match.group(1).strip()
+        value = match.group(2).strip()
+        if key not in metadata:  # Don't override front matter
+            metadata[key] = value
+
     return metadata, content
 
 

--- a/tests/darnit/core/test_plugin.py
+++ b/tests/darnit/core/test_plugin.py
@@ -90,9 +90,6 @@ class MockImplementation:
     def get_controls_by_level(self, level: int) -> list[ControlSpec]:
         return [c for c in self.get_all_controls() if c.level == level]
 
-    def get_check_functions(self) -> dict[str, Any]:
-        return {"level1": lambda: [], "level2": lambda: []}
-
     def get_rules_catalog(self) -> dict[str, Any]:
         return {"MOCK-01": {"name": "Mock Control 1"}}
 
@@ -144,15 +141,6 @@ class TestComplianceImplementation:
         assert level1[0].control_id == "MOCK-01"
         assert len(level2) == 1
         assert level2[0].control_id == "MOCK-02"
-
-    @pytest.mark.unit
-    def test_get_check_functions(self):
-        """Test get_check_functions method."""
-        impl = MockImplementation()
-        funcs = impl.get_check_functions()
-        assert "level1" in funcs
-        assert "level2" in funcs
-        assert callable(funcs["level1"])
 
     @pytest.mark.unit
     def test_get_rules_catalog(self):


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Update package structure tree, protocol method list, sieve diagram, example code, and legacy migration section to reflect current TOML-first architecture
- **generate_docs.py**: Fix metadata parser to handle blockquote format (`> **Key**: Value`), resolving "Spec Version: Unknown" → "1.0.0-alpha.8" in all 3 generated docs
- **Design docs**: Replace stale `.darnit/` directory references with current behavior ($TMPDIR cache, stdout/MCP output)
- **Dead code**: Remove `LLMConsultationRequest` (models.py), `get_config_path()`/`resolve_control_path()` (mappings.py), `get_check_functions` mock+test (test_plugin.py) — 74 lines total

## Test plan

- [x] `uv run ruff check .` — no lint errors
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — 945 passed, 1 skipped
- [x] `uv run python scripts/validate_sync.py --verbose` — all validations pass
- [x] Generated docs show "Spec Version: 1.0.0-alpha.8" (not "Unknown")
- [x] `grep -r '\.darnit/' docs/` — only valid SECURITY_GUIDE references remain
- [x] `grep -r 'get_check_functions' .` — zero results
- [x] `grep -r 'LLMConsultationRequest' .` — zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)