### PR TITLE
feat: Wire environment-aware context pipeline for when-clause evaluation

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -977,6 +977,7 @@ timeout = 30
 name = "RequireMFA"
 description = "Require multi-factor authentication for organization members"
 tags = { level = 1, domain = "AC", security_severity = 9.0, access-control = true, authentication = true }
+when = { platform = "github" }
 docs_url = "https://baseline.openssf.org/versions/2025-10-10#OSPS-AC-01.01"
 help_md = """Enable MFA for all organization members with elevated permissions.
 
@@ -1032,6 +1033,7 @@ context_hints = ["org_admin_access"]
 name = "AllowForking"
 description = "Allow repository forking for public collaboration"
 tags = { level = 1, domain = "AC", access-control = true, collaboration = true }
+when = { platform = "github" }
 
 # ExecPass: Check if forking is allowed via GitHub API
 [[controls."OSPS-AC-02.01".passes]]
@@ -1073,6 +1075,7 @@ docs_url = "https://docs.github.com/en/repositories/managing-your-repositorys-se
 name = "PreventDirectCommits"
 description = "Prevent direct commits to primary branch"
 tags = { level = 1, domain = "AC", security_severity = 8.0, access-control = true, branch-protection = true }
+when = { platform = "github" }
 docs_url = "https://baseline.openssf.org/versions/2025-10-10#OSPS-AC-03.01"
 help_md = """Enable branch protection to require pull requests.
 
@@ -1119,6 +1122,7 @@ payload_template = "branch_protection_payload"
 name = "PreventBranchDeletion"
 description = "Prevent deletion of primary branch"
 tags = { level = 1, domain = "AC", access-control = true, branch-protection = true }
+when = { platform = "github" }
 
 # ExecPass: Check if branch deletion is prevented via branch protection
 [[controls."OSPS-AC-03.02".passes]]
@@ -1257,6 +1261,7 @@ context_hints = ["ci.provider"]
 name = "SecureRepositoryURL"
 description = "Repository URL uses HTTPS"
 tags = { level = 1, domain = "BR", build = true, security = true }
+when = { platform = "github" }
 
 # ExecPass: Verify repository URL uses HTTPS
 [[controls."OSPS-BR-03.01".passes]]
@@ -1336,7 +1341,7 @@ overwrite = false
 name = "UniqueVersionIdentifiers"
 description = "Assign unique version identifiers to each official release"
 tags = { level = 2, domain = "BR", build = true, releases = true }
-when = { has_releases = true }
+when = { has_releases = true, platform = "github" }
 
 # ExecPass: Check GitHub releases have unique version tags
 [[controls."OSPS-BR-02.01".passes]]
@@ -1372,7 +1377,7 @@ context_hints = ["build.has_releases"]
 name = "ReleaseChangelog"
 description = "Releases include log of functional and security modifications"
 tags = { level = 2, domain = "BR", build = true, releases = true, documentation = true }
-when = { has_releases = true }
+when = { has_releases = true, platform = "github" }
 help_md = """This control can be satisfied in two ways:
 
 1. **GitHub Releases with notes** (preferred for projects using GitHub releases):
@@ -1653,6 +1658,7 @@ steps = [
 name = "PublicDiscussion"
 description = "Enable public discussion mechanisms"
 tags = { level = 1, domain = "GV", governance = true, community = true }
+when = { platform = "github" }
 
 # ExecPass: Check if Issues or Discussions are enabled
 [[controls."OSPS-GV-02.01".passes]]
@@ -1753,6 +1759,7 @@ set = { "legal.license.path" = "LICENSE" }
 name = "OSIApprovedLicense"
 description = "License is OSI-approved"
 tags = { level = 1, domain = "LE", legal = true, license = true }
+when = { platform = "github" }
 
 # ExecPass: Check if license is OSI-approved via GitHub's license detection
 [[controls."OSPS-LE-02.01".passes]]
@@ -1777,6 +1784,7 @@ steps = [
 name = "ReleaseLicense"
 description = "Releases include license information"
 tags = { level = 1, domain = "LE", legal = true, license = true }
+when = { platform = "github" }
 
 # Check that releases have license info (via release notes or included files)
 [[controls."OSPS-LE-02.02".passes]]
@@ -1820,7 +1828,7 @@ steps = [
 name = "LicenseInReleases"
 description = "License file included in releases"
 tags = { level = 1, domain = "LE", legal = true, license = true }
-when = { has_releases = true }
+when = { has_releases = true, platform = "github" }
 inferred_from = "OSPS-LE-03.01"  # If LICENSE exists in repo, GitHub auto-includes it in source archives
 
 # Check that release assets include license file
@@ -1848,6 +1856,7 @@ steps = [
 name = "PublicRepository"
 description = "Repository is publicly accessible"
 tags = { level = 1, domain = "QA", quality = true, transparency = true }
+when = { platform = "github" }
 
 # ExecPass: Use gh CLI to check repository visibility
 [[controls."OSPS-QA-01.01".passes]]
@@ -1891,6 +1900,7 @@ docs_url = "https://docs.github.com/en/repositories/managing-your-repositorys-se
 name = "PublicCommitHistory"
 description = "Commit history is publicly visible"
 tags = { level = 1, domain = "QA", quality = true, transparency = true }
+when = { platform = "github" }
 
 # ExecPass: Check that commit history is accessible
 [[controls."OSPS-QA-01.02".passes]]
@@ -1959,11 +1969,7 @@ steps = [
 name = "DocumentSubprojects"
 description = "Subprojects are documented"
 tags = { level = 1, domain = "QA", quality = true, documentation = true }
-
-# Context-dependent: Only applies to projects with subprojects
-[controls."OSPS-QA-04.01".context]
-requires = "has_subprojects"
-not_applicable_if_false = true
+when = { has_subprojects = true }
 
 # Pattern: Look for subproject/module documentation
 [[controls."OSPS-QA-04.01".passes]]
@@ -2266,6 +2272,7 @@ overwrite = false
 name = "RequiredStatusChecks"
 description = "Branch protection requires status checks"
 tags = { level = 2, domain = "QA", quality = true, ci-cd = true }
+when = { platform = "github" }
 depends_on = ["OSPS-AC-03.01"]  # Requires branch protection to be enabled
 
 # ExecPass: Use gh CLI to check required status checks
@@ -2398,6 +2405,7 @@ docs_url = "https://docs.github.com/en/code-security/security-advisories/guidanc
 name = "PrivateReporting"
 description = "Private vulnerability reporting is enabled"
 tags = { level = 2, domain = "VM", security = true, vulnerability-management = true }
+when = { platform = "github" }
 
 [controls."OSPS-VM-03.01".locator]
 project_path = "security.policy"
@@ -2460,6 +2468,7 @@ docs_url = "https://docs.github.com/en/code-security/security-advisories/working
 name = "SecurityAdvisories"
 description = "Repository supports security advisories"
 tags = { level = 2, domain = "VM", security = true, vulnerability-management = true }
+when = { platform = "github" }
 
 # ExecPass: Check if security advisories are supported (requires Issues enabled)
 [[controls."OSPS-VM-04.01".passes]]
@@ -2542,6 +2551,7 @@ context_hints = ["ci.provider"]
 name = "ClearAssetAssociation"
 description = "Clearly associate all release assets with release identifiers"
 tags = { level = 3, domain = "BR", build = true, releases = true }
+when = { platform = "github" }
 
 # ExecPass: Check that releases have assets associated with tags
 [[controls."OSPS-BR-02.02".passes]]
@@ -2657,11 +2667,7 @@ context_hints = ["has_compiled_assets", "has_releases"]
 name = "SubprojectSecurity"
 description = "Subprojects enforce security as strict as primary codebase"
 tags = { level = 3, domain = "QA", quality = true, security = true }
-
-# Context-dependent: Only applies to projects with subprojects
-[controls."OSPS-QA-04.02".context]
-requires = "has_subprojects"
-not_applicable_if_false = true
+when = { has_subprojects = true }
 
 # Pattern: Check for consistent security configuration across subprojects
 [[controls."OSPS-QA-04.02".passes]]
@@ -2698,6 +2704,7 @@ context_hints = ["has_subprojects"]
 name = "RequiredApprovals"
 description = "Pull requests require approval before merge"
 tags = { level = 3, domain = "QA", quality = true, code-review = true }
+when = { platform = "github" }
 
 # ExecPass: Check if branch protection requires approvals
 [[controls."OSPS-QA-07.01".passes]]

--- a/packages/darnit/src/darnit/config/context_storage.py
+++ b/packages/darnit/src/darnit/config/context_storage.py
@@ -95,6 +95,15 @@ def load_context(local_path: str) -> ContextByCategory:
         if ci_context:
             context_by_category["ci"] = ci_context
 
+        # Platform category (auto-detected or user-confirmed)
+        platform_context: dict[str, ContextValue] = {}
+        if ctx.platform is not None:
+            platform_context["platform"] = ContextValue.user_confirmed(ctx.platform)
+        if ctx.primary_language is not None:
+            platform_context["primary_language"] = ContextValue.user_confirmed(ctx.primary_language)
+        if platform_context:
+            context_by_category["platform"] = platform_context
+
         # Governance category
         governance_context: dict[str, ContextValue] = {}
         if ctx.maintainers is not None:
@@ -112,6 +121,32 @@ def load_context(local_path: str) -> ContextByCategory:
             context_by_category["security"] = security_context
 
     return context_by_category
+
+
+def flatten_user_context(context_by_category: ContextByCategory) -> dict[str, Any]:
+    """Flatten categorized context into bare keys for ``when`` clause evaluation.
+
+    The ``when`` clause system uses bare keys like ``ci_provider``, ``has_releases``,
+    ``platform``, etc.  But :func:`load_context` returns categories like
+    ``{"ci": {"provider": ContextValue(...)}, "build": {"has_releases": ...}}``.
+
+    This helper resolves the mismatch by mapping ``category.key`` → bare key:
+    - ``ci.provider`` → ``ci_provider``
+    - Everything else keeps its stored key as-is (already bare)
+
+    Returns:
+        Flat dict mapping bare key → raw value.
+    """
+    flat: dict[str, Any] = {}
+    # Mapping of (category, stored_key) → bare key used in when clauses
+    remap = {
+        ("ci", "provider"): "ci_provider",
+    }
+    for category_name, category_values in context_by_category.items():
+        for stored_key, ctx_value in category_values.items():
+            bare_key = remap.get((category_name, stored_key), stored_key)
+            flat[bare_key] = ctx_value.value
+    return flat
 
 
 def get_context_value(
@@ -243,6 +278,9 @@ def save_context_value(
         "has_compiled_assets": "has_compiled_assets",
         "ci_provider": "ci_provider",
         "provider": "ci_provider",  # Alias for ci context
+        # Auto-detectable context
+        "platform": "platform",
+        "primary_language": "primary_language",
         # New governance and security context keys
         "maintainers": "maintainers",
         "security_contact": "security_contact",

--- a/packages/darnit/src/darnit/config/schema.py
+++ b/packages/darnit/src/darnit/config/schema.py
@@ -301,6 +301,13 @@ class ProjectContext(BaseModel):
     has_compiled_assets: bool | None = None
     ci_provider: str | None = None
 
+    # Auto-detectable context (factual, safe to infer from filesystem)
+    platform: str | None = None
+    """Hosting platform - github, gitlab, bitbucket, or None."""
+
+    primary_language: str | None = None
+    """Primary programming language - python, go, rust, javascript, etc."""
+
     # New context keys for governance and security
     maintainers: list[str] | str | None = None
     """Project maintainers - list of GitHub usernames or path to MAINTAINERS file."""

--- a/packages/darnit/src/darnit/context/auto_detect.py
+++ b/packages/darnit/src/darnit/context/auto_detect.py
@@ -1,0 +1,181 @@
+"""Auto-detection of factual project context from the filesystem.
+
+Detects platform (github/gitlab/bitbucket), CI provider, and primary language
+by inspecting git remotes and checking for manifest/config files. No API calls,
+no subprocess calls other than `git remote get-url`.
+
+These are factual, non-sensitive values safe to auto-detect without user
+confirmation. They feed into `when` clause evaluation so the right checks
+run in the right environments.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import Any
+
+from darnit.core.logging import get_logger
+
+logger = get_logger("context.auto_detect")
+
+
+def detect_platform(local_path: str) -> str | None:
+    """Detect hosting platform from git remote URL.
+
+    Checks upstream remote first, then origin.
+
+    Returns:
+        "github", "gitlab", "bitbucket", or None if unknown.
+    """
+    for remote in ("upstream", "origin"):
+        url = _get_remote_url(remote, local_path)
+        if not url:
+            continue
+
+        hostname = _extract_hostname(url)
+        if not hostname:
+            continue
+
+        if "github.com" in hostname:
+            return "github"
+        if "gitlab.com" in hostname or "gitlab" in hostname:
+            return "gitlab"
+        if "bitbucket.org" in hostname or "bitbucket" in hostname:
+            return "bitbucket"
+
+    return None
+
+
+def detect_ci_provider(local_path: str) -> str | None:
+    """Detect CI provider from config file presence.
+
+    Returns:
+        "github", "gitlab", "jenkins", "circleci", "azure", "travis", or None.
+    """
+    checks: list[tuple[str, str]] = [
+        (".github/workflows", "github"),
+        (".gitlab-ci.yml", "gitlab"),
+        ("Jenkinsfile", "jenkins"),
+        (".circleci/config.yml", "circleci"),
+        (".circleci/config.yaml", "circleci"),
+        ("azure-pipelines.yml", "azure"),
+        ("azure-pipelines.yaml", "azure"),
+        (".travis.yml", "travis"),
+    ]
+
+    for path_fragment, provider in checks:
+        full_path = os.path.join(local_path, path_fragment)
+        if os.path.exists(full_path):
+            # For directories (e.g. .github/workflows), check it has files
+            if os.path.isdir(full_path):
+                try:
+                    entries = os.listdir(full_path)
+                    if any(
+                        e.endswith((".yml", ".yaml")) for e in entries
+                    ):
+                        return provider
+                except OSError:
+                    continue
+            else:
+                return provider
+
+    return None
+
+
+def detect_primary_language(local_path: str) -> str | None:
+    """Detect primary language from manifest files.
+
+    Returns:
+        "python", "go", "rust", "javascript", "typescript", "java", or None.
+    """
+    # Order matters: check more specific indicators first
+    checks: list[tuple[str, str]] = [
+        ("go.mod", "go"),
+        ("Cargo.toml", "rust"),
+        ("pyproject.toml", "python"),
+        ("setup.py", "python"),
+        ("setup.cfg", "python"),
+        ("pom.xml", "java"),
+        ("build.gradle", "java"),
+        ("build.gradle.kts", "java"),
+        ("package.json", "javascript"),  # May be overridden by tsconfig
+    ]
+
+    detected = None
+    for filename, language in checks:
+        if os.path.isfile(os.path.join(local_path, filename)):
+            detected = language
+            break
+
+    # Refine: if package.json detected, check for TypeScript
+    if detected == "javascript" and os.path.isfile(
+        os.path.join(local_path, "tsconfig.json")
+    ):
+        detected = "typescript"
+
+    return detected
+
+
+def collect_auto_context(local_path: str) -> dict[str, Any]:
+    """Collect all auto-detectable context. Returns flat dict with bare keys.
+
+    Only includes keys where detection succeeded. Keys use the same names
+    as ``when`` clause keys (e.g. ``platform``, ``ci_provider``).
+    """
+    context: dict[str, Any] = {}
+
+    platform = detect_platform(local_path)
+    if platform:
+        context["platform"] = platform
+
+    ci_provider = detect_ci_provider(local_path)
+    if ci_provider:
+        context["ci_provider"] = ci_provider
+
+    primary_language = detect_primary_language(local_path)
+    if primary_language:
+        context["primary_language"] = primary_language
+
+    if context:
+        logger.debug("Auto-detected context: %s", context)
+
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_remote_url(remote_name: str, cwd: str) -> str | None:
+    """Get the URL of a named git remote."""
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", remote_name],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+def _extract_hostname(url: str) -> str | None:
+    """Extract hostname from a git remote URL (HTTPS or SSH)."""
+    # HTTPS: https://github.com/owner/repo.git
+    https_match = re.match(r"https?://([^/]+)", url)
+    if https_match:
+        return https_match.group(1).lower()
+
+    # SSH: git@github.com:owner/repo.git
+    ssh_match = re.match(r"[^@]+@([^:]+):", url)
+    if ssh_match:
+        return ssh_match.group(1).lower()
+
+    return None

--- a/packages/darnit/src/darnit/server/tools/builtin_remediate.py
+++ b/packages/darnit/src/darnit/server/tools/builtin_remediate.py
@@ -111,6 +111,27 @@ async def builtin_remediate(
     if not all_controls:
         return "No controls found."
 
+    # Build project_context for when-clause evaluation (same as audit pipeline)
+    project_context: dict[str, Any] = {}
+    try:
+        from darnit.context.auto_detect import collect_auto_context
+
+        project_context = collect_auto_context(str(repo_path))
+    except Exception as e:
+        logger.debug("Auto-detect context failed (non-fatal): %s", e)
+
+    try:
+        from darnit.config.context_storage import (
+            flatten_user_context,
+            load_context,
+        )
+
+        user_context = load_context(str(repo_path))
+        if user_context:
+            project_context.update(flatten_user_context(user_context))
+    except Exception as e:
+        logger.debug("User context load failed (non-fatal): %s", e)
+
     # Determine which controls failed — use cached audit results if available
     from darnit.core.audit_cache import invalidate_audit_cache, read_audit_cache
     from darnit.core.utils import detect_owner_repo
@@ -140,6 +161,7 @@ async def builtin_remediate(
                     "name": control.name,
                     "description": control.description,
                 },
+                project_context=dict(project_context),
             )
             result = orchestrator.verify(control, context)
             if result.status == "FAIL":
@@ -165,6 +187,15 @@ async def builtin_remediate(
         if not control_cfg or not control_cfg.remediation:
             skipped.append((control_id, "no remediation defined"))
             continue
+
+        # Skip remediation if when clause doesn't match the environment
+        when_clause = getattr(control_cfg, "when", None)
+        if when_clause:
+            from darnit.sieve.orchestrator import evaluate_when_clause
+
+            if not evaluate_when_clause(when_clause, project_context):
+                skipped.append((control_id, f"N/A (when: {when_clause})"))
+                continue
 
         rem_cfg = control_cfg.remediation
 

--- a/packages/darnit/src/darnit/sieve/orchestrator.py
+++ b/packages/darnit/src/darnit/sieve/orchestrator.py
@@ -25,6 +25,48 @@ from .models import (
 logger = get_logger("sieve.orchestrator")
 
 
+def evaluate_when_clause(when: dict[str, Any], context: dict[str, Any]) -> bool:
+    """Evaluate a ``when`` clause against a context dict.
+
+    Missing context keys → True (conservative: run the control).
+    Mismatched value → False (skip the control).
+
+    This is the single implementation used by both the audit pipeline
+    and the remediation pipeline.
+
+    Currently supports simple key-value equality with AND semantics.
+
+    .. todo::
+        Explore CEL expression support for ``when`` clauses to enable
+        OR conditions (``platform == "github" || platform == "gitlab"``),
+        negation (``platform != "bitbucket"``), and complex logic.
+        The schema would need to accept ``dict | str`` and route string
+        values through ``cel_evaluator.evaluate_cel()``.
+
+    Args:
+        when: Dict of key → expected_value from the TOML ``when`` field.
+        context: Flat dict of context values (e.g. from ``collect_auto_context``
+                 merged with user-confirmed context).
+
+    Returns:
+        True if the control should run, False if it should be skipped (N/A).
+    """
+    for key, expected in when.items():
+        actual = context.get(key)
+        if actual is None:
+            # Missing context key → run normally (conservative)
+            logger.debug(
+                "when key '%s' missing from context, running normally", key,
+            )
+            continue
+        if actual != expected:
+            logger.debug(
+                "when condition failed (%s=%r, expected %r)", key, actual, expected,
+            )
+            return False
+    return True
+
+
 class SieveOrchestrator:
     """
     Orchestrates the verification pipeline via handler dispatch.
@@ -64,38 +106,15 @@ class SieveOrchestrator:
         """Evaluate when clause for conditional applicability.
 
         Returns True if the control should run, False if N/A.
-        Missing context keys → control runs normally (conservative).
+        Delegates to the module-level :func:`evaluate_when_clause`.
         """
         when = control_spec.metadata.get("when")
         if not when:
             return True
 
-        for key, expected in when.items():
-            # Check project_context first, then control_metadata
-            actual = context.project_context.get(key)
-            if actual is None:
-                actual = context.control_metadata.get(key)
-
-            if actual is None:
-                # Missing context key → run normally (conservative)
-                logger.debug(
-                    "Control %s: when key '%s' missing from context, running normally",
-                    control_spec.control_id,
-                    key,
-                )
-                continue
-
-            if actual != expected:
-                logger.debug(
-                    "Control %s: when condition failed (%s=%r, expected %r)",
-                    control_spec.control_id,
-                    key,
-                    actual,
-                    expected,
-                )
-                return False
-
-        return True
+        # Merge project_context and control_metadata for lookup
+        merged = {**context.control_metadata, **context.project_context}
+        return evaluate_when_clause(when, merged)
 
     def _check_inferred_from(
         self, control_spec: ControlSpec

--- a/packages/darnit/src/darnit/tools/audit.py
+++ b/packages/darnit/src/darnit/tools/audit.py
@@ -418,6 +418,33 @@ def run_sieve_audit(
     orchestrator = SieveOrchestrator(stop_on_llm=stop_on_llm)
     all_results = []
 
+    # Build project_context once for all controls.
+    # Auto-detected values (platform, ci_provider, language) are overridden
+    # by user-confirmed values from .project.yaml.
+    project_context: dict[str, Any] = {}
+    try:
+        from darnit.context.auto_detect import collect_auto_context
+
+        project_context = collect_auto_context(local_path)
+    except Exception as e:
+        logger.debug("Auto-detect context failed (non-fatal): %s", e)
+
+    try:
+        from darnit.config.context_storage import (
+            flatten_user_context,
+            load_context,
+        )
+
+        user_context = load_context(local_path)
+        if user_context:
+            # User-confirmed values override auto-detected ones
+            project_context.update(flatten_user_context(user_context))
+    except Exception as e:
+        logger.debug("User context load failed (non-fatal): %s", e)
+
+    if project_context:
+        logger.info("Project context for when-clause evaluation: %s", project_context)
+
     # Create UnifiedLocator for .project/-aware file resolution
     locator = None
     try:
@@ -457,6 +484,7 @@ def run_sieve_audit(
             },
             locator=locator,
             locator_config=spec.locator_config,
+            project_context=dict(project_context),
         )
 
         # Run sieve verification

--- a/tests/darnit/context/test_auto_detect.py
+++ b/tests/darnit/context/test_auto_detect.py
@@ -1,0 +1,159 @@
+"""Tests for darnit.context.auto_detect module."""
+
+import os
+
+from darnit.context.auto_detect import (
+    _extract_hostname,
+    collect_auto_context,
+    detect_ci_provider,
+    detect_platform,
+    detect_primary_language,
+)
+
+
+class TestExtractHostname:
+    def test_https_github(self):
+        assert _extract_hostname("https://github.com/owner/repo.git") == "github.com"
+
+    def test_ssh_github(self):
+        assert _extract_hostname("git@github.com:owner/repo.git") == "github.com"
+
+    def test_https_gitlab(self):
+        assert _extract_hostname("https://gitlab.com/owner/repo.git") == "gitlab.com"
+
+    def test_ssh_gitlab(self):
+        assert _extract_hostname("git@gitlab.com:owner/repo.git") == "gitlab.com"
+
+    def test_https_bitbucket(self):
+        assert _extract_hostname("https://bitbucket.org/owner/repo.git") == "bitbucket.org"
+
+    def test_invalid_url(self):
+        assert _extract_hostname("not-a-url") is None
+
+
+class TestDetectPlatform:
+    def test_detects_github_from_origin(self, tmp_path):
+        """detect_platform returns 'github' for a repo with github.com origin."""
+        # Set up a bare git repo with an origin remote
+        os.system(f"git init {tmp_path} --quiet")
+        os.system(f"git -C {tmp_path} remote add origin https://github.com/owner/repo.git")
+
+        assert detect_platform(str(tmp_path)) == "github"
+
+    def test_detects_gitlab_from_origin(self, tmp_path):
+        os.system(f"git init {tmp_path} --quiet")
+        os.system(f"git -C {tmp_path} remote add origin https://gitlab.com/owner/repo.git")
+
+        assert detect_platform(str(tmp_path)) == "gitlab"
+
+    def test_prefers_upstream_over_origin(self, tmp_path):
+        os.system(f"git init {tmp_path} --quiet")
+        os.system(f"git -C {tmp_path} remote add origin https://gitlab.com/owner/repo.git")
+        os.system(f"git -C {tmp_path} remote add upstream https://github.com/owner/repo.git")
+
+        assert detect_platform(str(tmp_path)) == "github"
+
+    def test_returns_none_for_no_remotes(self, tmp_path):
+        os.system(f"git init {tmp_path} --quiet")
+        assert detect_platform(str(tmp_path)) is None
+
+    def test_returns_none_for_non_git_dir(self, tmp_path):
+        assert detect_platform(str(tmp_path)) is None
+
+
+class TestDetectCIProvider:
+    def test_github_actions(self, tmp_path):
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("on: push")
+
+        assert detect_ci_provider(str(tmp_path)) == "github"
+
+    def test_github_actions_empty_dir(self, tmp_path):
+        """Empty .github/workflows/ dir (no .yml files) should not match."""
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+
+        assert detect_ci_provider(str(tmp_path)) is None
+
+    def test_gitlab_ci(self, tmp_path):
+        (tmp_path / ".gitlab-ci.yml").write_text("stages: [build]")
+
+        assert detect_ci_provider(str(tmp_path)) == "gitlab"
+
+    def test_jenkinsfile(self, tmp_path):
+        (tmp_path / "Jenkinsfile").write_text("pipeline {}")
+
+        assert detect_ci_provider(str(tmp_path)) == "jenkins"
+
+    def test_circleci(self, tmp_path):
+        circleci = tmp_path / ".circleci"
+        circleci.mkdir()
+        (circleci / "config.yml").write_text("version: 2")
+
+        assert detect_ci_provider(str(tmp_path)) == "circleci"
+
+    def test_no_ci(self, tmp_path):
+        assert detect_ci_provider(str(tmp_path)) is None
+
+
+class TestDetectPrimaryLanguage:
+    def test_python_pyproject(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]")
+        assert detect_primary_language(str(tmp_path)) == "python"
+
+    def test_go_mod(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com")
+        assert detect_primary_language(str(tmp_path)) == "go"
+
+    def test_rust_cargo(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]")
+        assert detect_primary_language(str(tmp_path)) == "rust"
+
+    def test_javascript_package_json(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        assert detect_primary_language(str(tmp_path)) == "javascript"
+
+    def test_typescript_override(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "tsconfig.json").write_text("{}")
+        assert detect_primary_language(str(tmp_path)) == "typescript"
+
+    def test_java_pom(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project/>")
+        assert detect_primary_language(str(tmp_path)) == "java"
+
+    def test_no_language(self, tmp_path):
+        assert detect_primary_language(str(tmp_path)) is None
+
+
+class TestCollectAutoContext:
+    def test_collects_all(self, tmp_path):
+        # Set up git + GitHub remote + Python + GitHub Actions
+        os.system(f"git init {tmp_path} --quiet")
+        os.system(f"git -C {tmp_path} remote add origin https://github.com/owner/repo.git")
+        (tmp_path / "pyproject.toml").write_text("[project]")
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("on: push")
+
+        result = collect_auto_context(str(tmp_path))
+
+        assert result["platform"] == "github"
+        assert result["ci_provider"] == "github"
+        assert result["primary_language"] == "python"
+
+    def test_empty_for_bare_dir(self, tmp_path):
+        result = collect_auto_context(str(tmp_path))
+        assert result == {}
+
+    def test_omits_undetectable(self, tmp_path):
+        """Keys with None detection are omitted from the result."""
+        os.system(f"git init {tmp_path} --quiet")
+        os.system(f"git -C {tmp_path} remote add origin https://github.com/owner/repo.git")
+        # No language files, no CI files
+
+        result = collect_auto_context(str(tmp_path))
+        assert result == {"platform": "github"}
+        assert "ci_provider" not in result
+        assert "primary_language" not in result

--- a/tests/darnit/sieve/test_when_clause.py
+++ b/tests/darnit/sieve/test_when_clause.py
@@ -1,0 +1,99 @@
+"""Tests for evaluate_when_clause and context pipeline integration."""
+
+from darnit.sieve.orchestrator import evaluate_when_clause
+
+
+class TestEvaluateWhenClause:
+    """Test the module-level evaluate_when_clause function."""
+
+    def test_empty_when_returns_true(self):
+        assert evaluate_when_clause({}, {}) is True
+
+    def test_matching_value_returns_true(self):
+        assert evaluate_when_clause(
+            {"platform": "github"},
+            {"platform": "github"},
+        ) is True
+
+    def test_mismatched_value_returns_false(self):
+        assert evaluate_when_clause(
+            {"platform": "github"},
+            {"platform": "gitlab"},
+        ) is False
+
+    def test_missing_key_returns_true(self):
+        """Missing context key → conservative, run the control."""
+        assert evaluate_when_clause(
+            {"platform": "github"},
+            {},
+        ) is True
+
+    def test_multiple_keys_all_match(self):
+        assert evaluate_when_clause(
+            {"has_releases": True, "platform": "github"},
+            {"has_releases": True, "platform": "github"},
+        ) is True
+
+    def test_multiple_keys_one_mismatch(self):
+        assert evaluate_when_clause(
+            {"has_releases": True, "platform": "github"},
+            {"has_releases": True, "platform": "gitlab"},
+        ) is False
+
+    def test_multiple_keys_one_missing(self):
+        """One matching, one missing → still True (conservative)."""
+        assert evaluate_when_clause(
+            {"has_releases": True, "platform": "github"},
+            {"has_releases": True},
+        ) is True
+
+    def test_boolean_true(self):
+        assert evaluate_when_clause(
+            {"has_subprojects": True},
+            {"has_subprojects": True},
+        ) is True
+
+    def test_boolean_false(self):
+        assert evaluate_when_clause(
+            {"has_subprojects": True},
+            {"has_subprojects": False},
+        ) is False
+
+
+class TestFlattenUserContext:
+    """Test the flatten_user_context helper."""
+
+    def test_ci_provider_remapped(self):
+        from darnit.config.context_schema import ContextValue
+        from darnit.config.context_storage import flatten_user_context
+
+        context = {
+            "ci": {"provider": ContextValue.user_confirmed("github")},
+        }
+        flat = flatten_user_context(context)
+        assert flat == {"ci_provider": "github"}
+
+    def test_bare_keys_preserved(self):
+        from darnit.config.context_schema import ContextValue
+        from darnit.config.context_storage import flatten_user_context
+
+        context = {
+            "build": {
+                "has_releases": ContextValue.user_confirmed(True),
+                "has_compiled_assets": ContextValue.user_confirmed(False),
+            },
+            "platform": {
+                "platform": ContextValue.user_confirmed("github"),
+                "primary_language": ContextValue.user_confirmed("python"),
+            },
+        }
+        flat = flatten_user_context(context)
+        assert flat["has_releases"] is True
+        assert flat["has_compiled_assets"] is False
+        assert flat["platform"] == "github"
+        assert flat["primary_language"] == "python"
+
+    def test_empty_context(self):
+        from darnit.config.context_storage import flatten_user_context
+
+        assert flatten_user_context({}) == {}


### PR DESCRIPTION
## Summary

- **Fix broken when-clause pipeline**: `CheckContext.project_context` was never populated, so `when` conditions in TOML controls were dead — always returned True
- **Add auto-detection**: New `auto_detect.py` module detects platform (github/gitlab/bitbucket), CI provider, and primary language from git remotes and filesystem
- **Wire context into audit + remediation**: Both pipelines now build `project_context` (auto-detected + user-confirmed), pass it to `CheckContext`, and respect `when` clauses
- **Tag 18 GitHub-specific controls**: Controls using `gh` CLI now have `when = { platform = "github" }` so they skip (N/A) on non-GitHub repos
- **Consolidate dead `requires` blocks**: 2 controls converted from unused `[context]` sub-table to working `when = { has_subprojects = true }`

## Changes

| File | What |
|------|------|
| `context/auto_detect.py` | New: detect_platform, detect_ci_provider, detect_primary_language |
| `config/schema.py` | Add `platform` and `primary_language` to ProjectContext |
| `config/context_storage.py` | Add `flatten_user_context()`, storage support for new fields |
| `sieve/orchestrator.py` | Extract `evaluate_when_clause()` as shared module-level function |
| `tools/audit.py` | Wire project_context into run_sieve_audit() |
| `server/tools/builtin_remediate.py` | Wire project_context + when-clause check into remediation |
| `openssf-baseline.toml` | 18 controls get `platform = "github"`, 2 `requires` → `when` |
| `test_auto_detect.py` | 27 tests for auto-detection |
| `test_when_clause.py` | 12 tests for when-clause evaluation and context flattening |

## Test plan

- [x] `uv run ruff check .` — all clean
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — 984 passed, 1 skipped
- [x] `uv run python scripts/validate_sync.py --verbose` — all validations pass
- [x] Generated docs unchanged
- [ ] Manual: run audit on this repo — GitHub-specific controls should PASS (platform detected as "github")
- [ ] Manual: run audit on a non-GitHub repo — GitHub-specific controls should show N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)