### PR TITLE
fix: Add zizmor pass_exit_codes and harden workflow templates

### DIFF
--- a/openspec/changes/fix-br01-and-remediation-templates/.openspec.yaml
+++ b/openspec/changes/fix-br01-and-remediation-templates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-18

--- a/openspec/changes/fix-br01-and-remediation-templates/design.md
+++ b/openspec/changes/fix-br01-and-remediation-templates/design.md
@@ -1,0 +1,58 @@
+## Context
+
+BR-01.01 (SecureWorkflowInputs) has a three-pass pipeline:
+1. **exec** — runs `zizmor --format json --offline $PATH` with CEL expr `!output.json.exists(f, f.ident == "template-injection")`
+2. **pattern** — regex scan for dangerous `${{ github.event.* }}` patterns with CEL expr `!(output.any_match)`
+3. **manual** — fallback verification steps
+
+The universal CEL expr fix (`_apply_cel_expr` in orchestrator.py) and the zizmor integration are both working correctly. However, two issues cause suboptimal behavior:
+
+**Issue 1: Zizmor pass falls through unnecessarily.** The exec pass has no `pass_exit_codes`, so zizmor's exit code 14 (findings present) is treated as INCONCLUSIVE. `_apply_cel_expr` only processes PASS/FAIL verdicts, so the CEL expression never evaluates. The pipeline falls through to the pattern handler, which works but bypasses zizmor's superior static analysis.
+
+**Issue 2: Remediation-generated sast.yml introduces zizmor findings.** The `sast_workflow` template uses unpinned action references (`@v4`, `@v3`) and lacks `persist-credentials: false` on checkout. When zizmor scans the repo after remediation, it finds 4 `unpinned-uses` and 1 `artipacked` finding — all from the template-generated file. While these don't cause BR-01.01 to fail (no `template-injection` findings), they would fail other zizmor-based checks and degrade the repo's security posture.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix zizmor exec pass so the CEL expression actually evaluates (primary checker works as designed)
+- Harden CI workflow templates so generated files pass zizmor audit with zero high-severity findings
+- Add "do no harm" spec requirement for remediation templates
+- Ensure the sast.yml template specifically doesn't introduce `unpinned-uses` or `artipacked` findings
+
+**Non-Goals:**
+- SHA-pinning all template action references (the spec explicitly allows major version tags — changing this is a separate discussion)
+- Adding zizmor checks for other controls beyond BR-01.01
+- Changing the `_apply_cel_expr` behavior for INCONCLUSIVE results (that's a broader framework decision)
+
+## Decisions
+
+### Decision 1: Add `pass_exit_codes` to zizmor exec pass
+
+**Choice:** Add `pass_exit_codes = [0, 10, 11, 12, 13, 14]` to the BR-01.01 exec handler config.
+
+**Rationale:** Zizmor exit codes indicate finding severity (0=none, 10=info, 11=low, 12=medium, 13=high, 14=mixed). All are valid outputs — the CEL expression examines the JSON payload to determine pass/fail, not the exit code. By declaring all codes as "pass", the exec handler returns PASS, which triggers `_apply_cel_expr` to evaluate the actual findings.
+
+**Alternative considered:** Modify `_apply_cel_expr` to also process INCONCLUSIVE results. Rejected because INCONCLUSIVE semantically means "can't determine" and is used as a pipeline-continue signal. Changing this has broader framework implications.
+
+### Decision 2: Add `persist-credentials: false` to all workflow templates
+
+**Choice:** Add `persist-credentials: false` to every `actions/checkout` step in all CI workflow templates.
+
+**Rationale:** This prevents the `artipacked` zizmor finding and is a security best practice (prevents credential leakage via artifacts). All existing kusari workflows already use this pattern. Cost is one extra line per template.
+
+### Decision 3: Do NOT SHA-pin template action references
+
+**Choice:** Keep major version tags (`@v4`, `@v3`) in templates per the existing spec requirement.
+
+**Rationale:** The spec says "SHALL use a major version tag rather than `@latest` or a full SHA." SHA pins would conflict with the spec and create maintenance burden (pins become stale). The `unpinned-uses` zizmor finding is a legitimate security concern but the templates serve as starting points — users should pin when adopting. We should document this trade-off.
+
+### Decision 4: Add "do no harm" spec requirement
+
+**Choice:** Add a requirement to the `ci-workflow-templates` spec: remediation-generated files MUST NOT introduce high-severity findings when scanned by common security tools (zizmor, actionlint).
+
+**Rationale:** The remediation tool should improve compliance, never worsen it. The `artipacked` finding in sast.yml is a concrete example of remediation introducing a new security issue.
+
+## Risks / Trade-offs
+
+- [Templates with major version tags will always trigger `unpinned-uses`] → Document this as known/accepted in templates; users should pin after adoption. The "do no harm" requirement applies to high-severity findings only, and `unpinned-uses` is arguable since the spec explicitly requires version tags.
+- [Adding `pass_exit_codes` means zizmor errors (e.g., invalid JSON) could be treated as PASS then evaluated by CEL] → CEL will fail on invalid JSON → `_apply_cel_expr` returns original PASS result. Mitigate by checking `output.json` exists in the CEL expression (already done: `output.json.exists(...)` implicitly handles null).

--- a/openspec/changes/fix-br01-and-remediation-templates/proposal.md
+++ b/openspec/changes/fix-br01-and-remediation-templates/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The remediation tool can worsen compliance scores: running `remediate_audit_findings()` against kusaridev/kusari-cli generated `sast.yml` for OSPS-VM-06.02, which caused BR-01.01 to report "3 of 3 pattern checks failed" instead of "2 of 2" — the tool's own output added a file that increased the failure count. While the core BR-01.01 checking logic is now correct (the universal CEL expr fix + zizmor integration work properly), the remediation templates need hardening so generated files don't introduce cross-control regressions.
+
+## What Changes
+
+- Audit all CI workflow templates for cross-control safety: verify that remediation-generated files don't trigger failures in other controls (e.g., templates should avoid `${{ }}` expressions in `run:` blocks that could trip BR-01.01)
+- Add a "do no harm" spec requirement: remediation outputs for one control MUST NOT cause regressions in other controls
+- Fix the zizmor exec pass to handle exit codes properly — zizmor returns exit code 14 for findings, but the pass doesn't declare `pass_exit_codes`, so it falls through as INCONCLUSIVE instead of being evaluated by the CEL expression
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `ci-workflow-templates`: Add requirement that generated workflow files must not introduce failures for other controls (do-no-harm principle). Add requirement for zizmor pass exit code handling.
+
+## Impact
+
+- `packages/darnit-baseline/openssf-baseline.toml` — BR-01.01 zizmor pass needs `pass_exit_codes` and `fail_exit_codes`; workflow template content audit
+- `openspec/specs/ci-workflow-templates/spec.md` — new "do no harm" requirement

--- a/openspec/changes/fix-br01-and-remediation-templates/specs/ci-workflow-templates/spec.md
+++ b/openspec/changes/fix-br01-and-remediation-templates/specs/ci-workflow-templates/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Remediation templates must not introduce security findings
+All CI workflow templates SHALL be hardened so that generated files do not introduce high-severity findings when scanned by workflow security tools (e.g., zizmor, actionlint).
+
+#### Scenario: Templates use persist-credentials false
+- **WHEN** any CI workflow template includes an `actions/checkout` step
+- **THEN** the step SHALL include `persist-credentials: false` to prevent credential leakage via artifacts
+
+#### Scenario: Templates do not use expressions in run blocks
+- **WHEN** any CI workflow template includes a `run:` block
+- **THEN** the block SHALL NOT contain `${{ }}` expressions referencing user-controllable GitHub contexts (e.g., `github.event.issue`, `github.event.pull_request`, `github.head_ref`)
+- **AND** if dynamic values are needed in `run:` blocks, the template SHALL use `env:` intermediary variables
+
+#### Scenario: Remediation does not worsen compliance
+- **WHEN** the remediation tool generates a workflow file for one control
+- **THEN** the generated file SHALL NOT introduce failures for other controls in the same audit
+- **AND** the generated file SHALL NOT increase the total finding count from workflow security scanners
+
+### Requirement: Zizmor exec pass declares valid exit codes
+The BR-01.01 zizmor exec pass SHALL declare `pass_exit_codes` covering all valid zizmor exit codes so the CEL expression can evaluate the JSON output.
+
+#### Scenario: Zizmor returns findings
+- **WHEN** zizmor runs and returns a non-zero exit code indicating findings (exit codes 10-14)
+- **THEN** the exec handler SHALL treat the exit code as valid (not INCONCLUSIVE)
+- **AND** the CEL expression SHALL evaluate the JSON output to determine pass/fail based on finding types
+
+#### Scenario: Zizmor is not installed
+- **WHEN** zizmor is not available on the system
+- **THEN** the exec handler SHALL return INCONCLUSIVE
+- **AND** the pipeline SHALL fall through to the pattern-based fallback pass

--- a/openspec/changes/fix-br01-and-remediation-templates/tasks.md
+++ b/openspec/changes/fix-br01-and-remediation-templates/tasks.md
@@ -1,0 +1,20 @@
+## 1. Fix zizmor exec pass exit codes
+
+- [x] 1.1 Add `pass_exit_codes = [0, 10, 11, 12, 13, 14]` to BR-01.01 zizmor exec pass in `openssf-baseline.toml`
+- [x] 1.2 Verify BR-01.01 resolves via zizmor (PASS from CEL expr) instead of falling through to pattern handler — test against kusaridev/kusari-cli
+
+## 2. Harden workflow templates
+
+- [x] 2.1 Add `persist-credentials: false` to `actions/checkout` in `sast_workflow` template
+- [x] 2.2 Add `persist-credentials: false` to `actions/checkout` in `sbom_workflow` template
+- [x] 2.3 Add `persist-credentials: false` to `actions/checkout` in `sca_workflow` template
+- [x] 2.4 Add `persist-credentials: false` to `actions/checkout` in `release_signing_workflow` template
+- [x] 2.5 Add `persist-credentials: false` to `actions/checkout` in `ci_test_workflow` template
+- [x] 2.6 Verify no workflow template has `${{ }}` expressions in `run:` blocks referencing user-controllable contexts
+
+## 3. Validate cross-control safety
+
+- [x] 3.1 Run zizmor against each workflow template content to confirm zero `artipacked` findings
+- [x] 3.2 Run full audit against kusaridev/kusari-cli with hardened templates and confirm BR-01.01 passes via zizmor path
+- [x] 3.3 Run `uv run ruff check .` and `uv run pytest tests/ --ignore=tests/integration/ -q`
+- [x] 3.4 Run `uv run python scripts/validate_sync.py --verbose` and regenerate docs if needed

--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -579,6 +579,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # TODO: Replace with your project's test command
       - name: Run tests
@@ -602,6 +604,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Generate SBOM with Syft
         uses: anchore/sbom-action@v0
@@ -637,6 +641,8 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -664,6 +670,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
@@ -689,6 +697,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
@@ -1293,9 +1303,12 @@ run: |
 """
 
 # Primary: Run zizmor static analysis for template injection
+# Exit codes: 0=clean, 10=info, 11=low, 12=medium, 13=high, 14=mixed severity
+# All are valid — CEL expr evaluates JSON findings, not exit code
 [[controls."OSPS-BR-01.01".passes]]
 handler = "exec"
 command = ["zizmor", "--format", "json", "--offline", "$PATH"]
+pass_exit_codes = [0, 10, 11, 12, 13, 14]
 output_format = "json"
 expr = '!output.json.exists(f, f.ident == "template-injection")'
 timeout = 60


### PR DESCRIPTION
## Summary

- **Fix BR-01.01 zizmor exec pass**: Added `pass_exit_codes = [0, 10, 11, 12, 13, 14]` so zizmor's non-zero exit codes (findings by severity) are treated as valid, allowing the CEL expression to evaluate JSON output directly instead of falling through to the pattern handler as INCONCLUSIVE
- **Harden CI workflow templates**: Added `persist-credentials: false` to `actions/checkout` in all 5 templates (ci_test, sbom, sast, sca, release_signing) to eliminate `artipacked` zizmor findings and prevent credential leakage via artifacts
- **Do-no-harm principle**: Ensures remediation-generated workflow files don't introduce cross-control regressions

## Context

When auditing kusaridev/kusari-cli, BR-01.01's zizmor exec pass returned exit code 14 (findings present). Without `pass_exit_codes`, the exec handler treated this as INCONCLUSIVE — skipping `_apply_cel_expr()` entirely and falling through to the pattern handler. The pattern fallback worked correctly but bypassed zizmor's superior static analysis.

Separately, the `sast_workflow` template lacked `persist-credentials: false`, causing zizmor to report an `artipacked` finding on remediation-generated files — the remediation tool's own output worsened the repo's security posture.

## Test plan

- [x] Verified BR-01.01 resolves via zizmor DETERMINISTIC phase (single pass, no fallthrough to pattern handler)
- [x] Full audit against kusaridev/kusari-cli: 57 PASS / 3 FAIL / 2 WARN — BR-01.01 PASS
- [x] Ran zizmor against all 5 hardened templates: 0 `artipacked`, 0 `template-injection` findings
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — 989 passed (1 pre-existing upstream hash failure)
- [x] `uv run python scripts/validate_sync.py --verbose` — all validations successful
- [x] Generated docs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)