### PR TITLE
feat: Add handler-level when clause for conditional dispatch

### DIFF
--- a/openspec/changes/handler-when-clause/.openspec.yaml
+++ b/openspec/changes/handler-when-clause/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-19

--- a/openspec/changes/handler-when-clause/design.md
+++ b/openspec/changes/handler-when-clause/design.md
@@ -1,0 +1,104 @@
+## Context
+
+Today, both the sieve orchestrator (`orchestrator.py:235`) and the remediation executor (`executor.py:369`) iterate `HandlerInvocation` lists unconditionally — every handler in the list is dispatched regardless of project characteristics. The only conditional mechanism is the control-level `when` clause on `ControlConfig`, which skips an entire control.
+
+Meanwhile, the auto-detection system already collects `primary_language`, `platform`, and `ci_provider` at audit time. The `when` evaluation logic exists for control-level applicability. The pieces are in place — they just need to be connected at the handler level.
+
+The key insertion points are:
+- **Sieve orchestrator**: `_dispatch_handler_invocations()` loop at `orchestrator.py:235`
+- **Remediation executor**: `_execute_handler_invocations()` loop at `executor.py:369`
+- **Context availability**: Both loops already have access to `project_context` via `HandlerContext`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable TOML authors to write conditional handlers with `when = { primary_language = "go" }` or `when = { languages = "go" }` on any `HandlerInvocation`
+- Support list-valued context matching (`"go" in ["go", "typescript"]`) for forward-compatible monorepo support
+- Provide `first_match` strategy on `RemediationConfig` so conflicting language-specific remediations don't all fire
+- Detect all languages in a repo as `languages: list[str]` alongside the existing `primary_language: str`
+- Reuse the `when` evaluation logic across both sieve passes and remediation handlers
+
+**Non-Goals:**
+- **Directory-level language locations** (`language_locations: dict[str, list[str]]`) — deferred to a future monorepo change
+- **`${language_root}` substitution variable** in remediation templates — deferred; hardcoded paths work for v1
+- **`when` using CEL expressions** — the `when` clause stays a simple key-value dict, not a full expression language. CEL is available via `expr` for post-handler evaluation, which is a separate concern.
+- **Strategy on sieve passes** — the sieve orchestrator already has "stop at first conclusive result" semantics. Adding `strategy` is only needed for remediation where "run all" is the default.
+
+## Decisions
+
+### Decision 1: Shared `evaluate_when()` function
+
+**Choice**: Extract a single `evaluate_when(when_clause, context) -> bool` function in a new module `darnit/config/when_evaluator.py`.
+
+**Rationale**: Both the sieve orchestrator and the remediation executor need the same evaluation logic. Putting it in `config/` makes it available to both without creating a circular dependency (both `sieve/` and `remediation/` already import from `config/`).
+
+**Alternatives considered**:
+- Inline in each dispatch loop → duplication, inconsistent behavior
+- In `sieve/` → remediation would need to import from sieve, muddying the layer boundary
+
+**Evaluation rules**:
+| Context value type | `when` value type | Match rule |
+|--------------------|-------------------|------------|
+| `str` | `str` | Exact equality |
+| `str` | `list[str]` | Context value is in the list (existing control-level behavior) |
+| `bool` | `bool` | Exact equality |
+| `list[str]` | `str` | **Scalar is contained in the list** (new — enables `when = { languages = "go" }`) |
+| `list[str]` | `list[str]` | All when-values are contained in context list (subset check) |
+| Missing key | any | **Condition not met → handler skipped** (conservative) |
+
+Multiple keys in a single `when` clause are AND-ed (all must match), consistent with control-level `when`.
+
+### Decision 2: `when` field on `HandlerInvocation` (not a new model)
+
+**Choice**: Add `when: dict[str, Any] | None = None` as an explicit field on `HandlerInvocation`.
+
+**Rationale**: `HandlerInvocation` uses `extra="allow"`, so `when` would technically work as a pass-through field already. But making it explicit means:
+- It's documented in the schema
+- It's not accidentally passed to handlers as config
+- The orchestrator/executor can access it directly via `invocation.when` instead of fishing through `model_extra`
+
+**Impact**: The orchestrator/executor must strip `when` from the handler config dict they build from `model_extra`, so handlers don't receive it as config. Since `when` is now an explicit field, it won't appear in `model_extra` — Pydantic handles this automatically.
+
+### Decision 3: `strategy` field on `RemediationConfig`
+
+**Choice**: Add `strategy: Literal["all", "first_match"] = "all"` to `RemediationConfig`.
+
+**Rationale**:
+- `"all"` (default): Run all matching handlers in order. This preserves existing behavior — today every handler runs. For cases like "create file AND update project config", you want both.
+- `"first_match"`: Stop after the first handler whose `when` matches (or has no `when`). For cases like "create go.mod OR pyproject.toml OR Cargo.toml", you want exactly one.
+
+**Note**: `first_match` only affects handlers that have a `when` clause. A handler without `when` always matches. So `first_match` with a list of conditional handlers followed by a `manual` fallback means: try the conditional ones, fall through to manual if none match.
+
+**Sieve passes don't need `strategy`**: The sieve already stops at the first conclusive result. The `when` clause just adds "skip this handler if condition isn't met" before dispatch — the existing stop-on-conclusive logic handles the rest.
+
+### Decision 4: `detect_languages()` alongside `detect_primary_language()`
+
+**Choice**: Add `detect_languages(local_path) -> list[str]` that scans for all manifest files (not stopping at the first match), and call it from `collect_auto_context()`.
+
+**Rationale**:
+- `primary_language` stays as-is for backward compatibility — controls using `when = { primary_language = "go" }` continue working
+- `languages` is a new list-valued key that captures the full picture
+- Detection reuses the same manifest-file checks, just doesn't `break` on first match
+- Both are auto-detected (factual, safe, no user confirmation needed)
+
+**TypeScript refinement**: If `package.json` is found and `tsconfig.json` exists, the list includes `"typescript"` rather than `"javascript"` (same logic as today, applied per-detection).
+
+### Decision 5: Context assembly for `when` evaluation
+
+**Choice**: Build the `when` evaluation context from the same sources already available in both dispatch loops, merging auto-detected context with user-confirmed context.
+
+In the sieve orchestrator, `HandlerContext.project_context` already contains the merged context. In the remediation executor, `self._project_values` and `self._context_values` provide the same.
+
+The `when` evaluator receives a flat `dict[str, Any]` — it doesn't need to know where values came from. The caller is responsible for assembling it. Both call sites already have this data.
+
+## Risks / Trade-offs
+
+**[Risk] Handler authors put `when` in `model_extra` on old code** → Since `when` becomes an explicit field, Pydantic will extract it from `model_extra` automatically. Existing TOML that already has `when` in a handler invocation (none exists today) will just work.
+
+**[Risk] `first_match` with no matching handler produces confusing results** → Mitigation: If `strategy = "first_match"` and no handler's `when` matches, the executor returns a "no applicable remediation" result with a message listing the unmatched conditions. This is analogous to how the sieve returns WARN when all phases are inconclusive.
+
+**[Risk] `languages` detection is imprecise for monorepos** → Mitigation: v1 only scans root-level manifests (same as today). This handles the common case (Go + TS at root) but not deeply nested monorepos. The `primary_language` fallback works for single-language repos. Future `language_locations` support can add depth when needed.
+
+**[Trade-off] `when` evaluation is simple dict matching, not CEL** → This is intentional. CEL is powerful but heavyweight and would require the CEL evaluator at handler dispatch time (before the handler runs). The simple dict-matching approach covers the expected use cases (language, platform, CI provider) without adding complexity. If future use cases require expression evaluation, `expr` (post-handler CEL) or a new `when_expr` field could be added later.
+
+**[Trade-off] No `strategy` on sieve passes** → The sieve's "stop at first conclusive" already handles the common case. If a sieve author writes three `file_exists` handlers with different `when` clauses, the first match that returns PASS stops the pipeline. This is naturally `first_match` behavior without needing an explicit field.

--- a/openspec/changes/handler-when-clause/proposal.md
+++ b/openspec/changes/handler-when-clause/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Remediation handlers and sieve pass handlers are unconditional today — every handler in a pipeline runs regardless of project characteristics like language, platform, or CI provider. This means we cannot express "create `go.mod` for Go projects" vs "create `pyproject.toml` for Python projects" as alternative handlers for the same control. The building blocks exist (language auto-detection in `auto_detect.py`, `when` clauses on `ControlConfig`, `languages` in the context model) but they aren't wired to the handler invocation level where remediation dispatch actually happens.
+
+## What Changes
+
+- **`when` clause on `HandlerInvocation`**: Add an optional `when: dict[str, Any]` field to the `HandlerInvocation` model. Before dispatching a handler, the executor evaluates the `when` clause against auto-detected + user-confirmed context. If the condition is not met, the handler is skipped.
+- **`when` evaluation supports list-valued context**: Extend `when` evaluation to handle list-valued context keys. When the context value is a list and the `when` value is a scalar, match if the scalar is contained in the list (e.g., `when = { languages = "go" }` matches `languages = ["go", "typescript"]`). This is forward-compatible with monorepo scenarios where multiple languages coexist.
+- **Remediation strategy field**: Add `strategy` to `RemediationConfig` with values `"all"` (default, run all matching handlers — existing behavior) and `"first_match"` (stop after the first handler whose `when` matches). This prevents running multiple conflicting remediations for the same control (e.g., creating both `go.mod` and `pyproject.toml`).
+- **`languages` context key**: Add a `languages: list[str]` field to the auto-detection context alongside the existing `primary_language: str`. Detection scans for all manifest files rather than stopping at the first match.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this change extends existing capabilities rather than introducing new top-level ones)_
+
+### Modified Capabilities
+
+- `handler-pipeline`: `HandlerInvocation` gains an optional `when` field; the orchestrator/executor must evaluate it before dispatching. Remediation pipeline gains a `strategy` field controlling handler selection semantics.
+- `conditional-controls`: The `when` evaluation logic is extended to support list-valued context (`value in list` semantics). This applies both to control-level `when` and handler-level `when`.
+- `context-collection`: The auto-detection subsystem gains a `languages: list[str]` context key that collects all detected languages, not just the primary one. The context flattening and storage layers must support this new key.
+
+## Impact
+
+- **`packages/darnit/src/darnit/config/framework_schema.py`**: Add `when` to `HandlerInvocation`, add `strategy` to `RemediationConfig`
+- **`packages/darnit/src/darnit/remediation/executor.py`**: Evaluate `when` on each handler before dispatching; respect `strategy` for early-exit
+- **`packages/darnit/src/darnit/sieve/orchestrator.py`**: Evaluate `when` on sieve pass handlers (same logic as remediation)
+- **`packages/darnit/src/darnit/context/auto_detect.py`**: `detect_primary_language()` → also populate `languages` list; add `detect_languages()` function
+- **`packages/darnit/src/darnit/config/schema.py`**: Add `languages: list[str]` field to context schema
+- **`packages/darnit/src/darnit/config/context_storage.py`**: Support `languages` key in flattening and storage
+- **TOML configs**: No breaking changes — `when` on handlers and `strategy` on remediation are both optional with backward-compatible defaults
+- **Tests**: New tests for handler-level `when` evaluation, list membership matching, `first_match` strategy, and multi-language detection

--- a/openspec/changes/handler-when-clause/specs/conditional-controls/spec.md
+++ b/openspec/changes/handler-when-clause/specs/conditional-controls/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: When clause supports boolean, string equality, and list membership
+The `when` clause SHALL support: boolean context values (`when = { key = true }`), string equality (`when = { key = "value" }`), list membership for string context values (`when = { key = ["val1", "val2"] }` meaning key must be one of the listed values), containment for list context values (`when = { key = "value" }` meaning value must be in the context list), and subset checking for list-to-list comparisons (`when = { key = ["val1", "val2"] }` meaning all listed values must be in the context list).
+
+#### Scenario: Boolean condition
+- **WHEN** a `when` clause declares `{ is_library = true }`
+- **AND** project context has `is_library = true`
+- **THEN** the condition SHALL evaluate to true
+
+#### Scenario: String equality condition
+- **WHEN** a `when` clause declares `{ ci_provider = "github" }`
+- **AND** project context has `ci_provider = "github"`
+- **THEN** the condition SHALL evaluate to true
+
+#### Scenario: List membership condition (string context, list when)
+- **WHEN** a `when` clause declares `{ ci_provider = ["github", "gitlab"] }`
+- **AND** project context has `ci_provider = "gitlab"`
+- **THEN** the condition SHALL evaluate to true
+
+#### Scenario: Containment condition (list context, string when)
+- **WHEN** a `when` clause declares `{ languages = "go" }`
+- **AND** project context has `languages = ["go", "typescript"]`
+- **THEN** the condition SHALL evaluate to true
+
+#### Scenario: Containment fails when value not in list
+- **WHEN** a `when` clause declares `{ languages = "rust" }`
+- **AND** project context has `languages = ["go", "typescript"]`
+- **THEN** the condition SHALL evaluate to false
+
+#### Scenario: Subset condition (list context, list when)
+- **WHEN** a `when` clause declares `{ languages = ["go", "typescript"] }`
+- **AND** project context has `languages = ["go", "typescript", "python"]`
+- **THEN** the condition SHALL evaluate to true
+
+#### Scenario: Subset fails when not all values present
+- **WHEN** a `when` clause declares `{ languages = ["go", "rust"] }`
+- **AND** project context has `languages = ["go", "typescript"]`
+- **THEN** the condition SHALL evaluate to false
+
+#### Scenario: Multiple conditions are AND-ed
+- **WHEN** a `when` clause declares `{ has_releases = true, is_library = true }`
+- **AND** project context has `has_releases = true` and `is_library = false`
+- **THEN** the condition SHALL evaluate to false
+
+#### Scenario: Empty list context matches nothing
+- **WHEN** a `when` clause declares `{ languages = "go" }`
+- **AND** project context has `languages = []`
+- **THEN** the condition SHALL evaluate to false

--- a/openspec/changes/handler-when-clause/specs/context-collection/spec.md
+++ b/openspec/changes/handler-when-clause/specs/context-collection/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Auto-detect all project languages
+The auto-detection subsystem SHALL detect all programming languages present in the repository and expose them as a `languages` context key containing a list of strings. This is in addition to the existing `primary_language` key which continues to return a single string.
+
+#### Scenario: Single-language repository
+- **WHEN** auto-detection runs on a repository containing only `go.mod`
+- **THEN** the context SHALL include `languages = ["go"]`
+- **AND** SHALL include `primary_language = "go"`
+
+#### Scenario: Multi-language repository
+- **WHEN** auto-detection runs on a repository containing `go.mod` and `package.json`
+- **THEN** the context SHALL include `languages = ["go", "javascript"]`
+- **AND** SHALL include `primary_language = "go"` (first match by detection order)
+
+#### Scenario: TypeScript refinement in languages list
+- **WHEN** auto-detection runs on a repository containing `package.json` and `tsconfig.json`
+- **THEN** the `languages` list SHALL include `"typescript"` rather than `"javascript"`
+
+#### Scenario: Multi-language with TypeScript
+- **WHEN** auto-detection runs on a repository containing `go.mod`, `package.json`, and `tsconfig.json`
+- **THEN** the context SHALL include `languages = ["go", "typescript"]`
+- **AND** SHALL include `primary_language = "go"`
+
+#### Scenario: No manifest files found
+- **WHEN** auto-detection runs on a repository with no recognized manifest files
+- **THEN** the context SHALL include `languages = []`
+- **AND** SHALL include `primary_language = null`
+
+#### Scenario: languages detection scans same manifest set as primary_language
+- **WHEN** auto-detection runs
+- **THEN** the `languages` detection SHALL use the same manifest-to-language mapping as `primary_language` detection: `go.mod` → go, `Cargo.toml` → rust, `pyproject.toml`/`setup.py`/`setup.cfg` → python, `pom.xml`/`build.gradle`/`build.gradle.kts` → java, `package.json` → javascript (refined to typescript if `tsconfig.json` exists)
+
+### Requirement: languages context key is available in when clauses and templates
+The `languages` context key SHALL be available for use in `when` clause evaluation and in template variable substitution, following the same patterns as other auto-detected context values.
+
+#### Scenario: languages available in when clause
+- **WHEN** a handler invocation declares `when = { languages = "go" }`
+- **AND** the auto-detected `languages` list contains `"go"`
+- **THEN** the `when` condition SHALL evaluate to true
+
+#### Scenario: languages available in template substitution
+- **WHEN** a remediation template references `${context.languages}`
+- **AND** the auto-detected `languages` list is `["go", "typescript"]`
+- **THEN** the template SHALL substitute `"go typescript"` (space-separated list)
+
+### Requirement: languages context key is stored and flattened
+The context storage layer SHALL support the `languages` key in both storage (`.project/project.yaml` or `.baseline.toml`) and flattening (for `when` clause evaluation).
+
+#### Scenario: languages persisted in context storage
+- **WHEN** `languages` is auto-detected as `["go", "typescript"]`
+- **THEN** the value SHALL be storable in `.project/project.yaml` under the platform context
+- **AND** SHALL be retrievable via `load_context()`
+
+#### Scenario: languages included in flattened context
+- **WHEN** `flatten_user_context()` is called
+- **AND** the context includes `languages = ["go", "typescript"]`
+- **THEN** the flattened dict SHALL include `"languages": ["go", "typescript"]`
+- **AND** the list value SHALL be preserved (not converted to string)

--- a/openspec/changes/handler-when-clause/specs/handler-pipeline/spec.md
+++ b/openspec/changes/handler-when-clause/specs/handler-pipeline/spec.md
@@ -1,0 +1,96 @@
+## MODIFIED Requirements
+
+### Requirement: HandlerInvocation schema uses extra="allow" for pass-through
+The `HandlerInvocation` model SHALL have `handler: str` (required), `shared: str | None` (optional reference to shared handler), `when: dict[str, Any] | None` (optional applicability condition), and SHALL allow extra fields via `extra="allow"`. Handler-specific configuration passes through without framework-level validation. The `when` field SHALL NOT be passed to handlers as configuration — it is consumed by the orchestrator/executor before dispatch.
+
+#### Scenario: Unknown fields pass through
+- **WHEN** a handler invocation includes `{ handler = "custom_check", custom_param = "value" }`
+- **THEN** the framework SHALL accept the TOML without validation errors
+- **AND** SHALL pass `custom_param = "value"` to the handler at execution time
+
+#### Scenario: when field is not passed to handler
+- **WHEN** a handler invocation includes `{ handler = "exec", command = ["ls"], when = { primary_language = "go" } }`
+- **THEN** the framework SHALL evaluate the `when` clause before dispatch
+- **AND** SHALL NOT include `when` in the handler's configuration dictionary
+- **AND** SHALL pass only `command` to the handler
+
+## ADDED Requirements
+
+### Requirement: Handler invocations support conditional dispatch via when clause
+A handler invocation MAY declare a `when` clause that specifies project context conditions under which the handler is applicable. When the condition evaluates to false, the handler SHALL be skipped without execution.
+
+#### Scenario: Handler skipped when language does not match
+- **WHEN** a handler invocation declares `when = { primary_language = "go" }`
+- **AND** the project context has `primary_language = "python"`
+- **THEN** the handler SHALL be skipped
+- **AND** the orchestrator/executor SHALL continue to the next handler in the list
+
+#### Scenario: Handler runs when language matches
+- **WHEN** a handler invocation declares `when = { primary_language = "go" }`
+- **AND** the project context has `primary_language = "go"`
+- **THEN** the handler SHALL be dispatched normally
+
+#### Scenario: Handler with no when clause always runs
+- **WHEN** a handler invocation does NOT declare a `when` clause
+- **THEN** the handler SHALL be dispatched unconditionally
+- **AND** behavior SHALL be identical to the pre-change behavior
+
+#### Scenario: Handler skipped when context key is missing
+- **WHEN** a handler invocation declares `when = { primary_language = "go" }`
+- **AND** the project context does NOT contain `primary_language`
+- **THEN** the handler SHALL be skipped
+- **AND** a debug-level log message SHALL note the missing context key
+
+#### Scenario: Multiple when conditions are AND-ed
+- **WHEN** a handler invocation declares `when = { primary_language = "go", platform = "github" }`
+- **AND** the project context has `primary_language = "go"` and `platform = "gitlab"`
+- **THEN** the handler SHALL be skipped
+
+#### Scenario: Sieve pass handler with when clause
+- **WHEN** a sieve pass handler invocation declares `when = { ci_provider = "github" }`
+- **AND** the project context has `ci_provider = "gitlab"`
+- **THEN** the sieve orchestrator SHALL skip that handler
+- **AND** SHALL continue to the next handler in the phase
+
+#### Scenario: Remediation handler with when clause
+- **WHEN** a remediation handler invocation declares `when = { primary_language = "python" }`
+- **AND** the project context has `primary_language = "python"`
+- **THEN** the remediation executor SHALL dispatch the handler normally
+
+### Requirement: Remediation config supports handler selection strategy
+The `RemediationConfig` model SHALL support a `strategy` field with values `"all"` (default) and `"first_match"`. The strategy controls how the executor iterates remediation handlers.
+
+#### Scenario: Default strategy runs all matching handlers
+- **WHEN** a remediation config has no `strategy` field (or `strategy = "all"`)
+- **AND** the handler list contains three handlers, two of which have matching `when` clauses
+- **THEN** the executor SHALL dispatch both matching handlers in order
+- **AND** behavior SHALL be identical to the pre-change behavior for handlers without `when` clauses
+
+#### Scenario: first_match strategy stops after first matching handler
+- **WHEN** a remediation config has `strategy = "first_match"`
+- **AND** the handler list contains `[{ handler = "file_create", when = { primary_language = "go" }, path = "go.mod" }, { handler = "file_create", when = { primary_language = "python" }, path = "pyproject.toml" }]`
+- **AND** the project context has `primary_language = "go"`
+- **THEN** the executor SHALL dispatch the first handler (go.mod)
+- **AND** SHALL NOT dispatch the second handler (pyproject.toml)
+
+#### Scenario: first_match with no when clause acts as catch-all
+- **WHEN** a remediation config has `strategy = "first_match"`
+- **AND** the handler list ends with `{ handler = "manual", steps = ["Create dependency manifest"] }`
+- **AND** no preceding handler's `when` clause matched
+- **THEN** the executor SHALL dispatch the manual handler as a fallback
+
+#### Scenario: first_match with no matching handlers
+- **WHEN** a remediation config has `strategy = "first_match"`
+- **AND** no handler's `when` clause matches the project context
+- **AND** no handler lacks a `when` clause
+- **THEN** the executor SHALL return a result indicating no applicable remediation
+- **AND** the result message SHALL list the unmatched conditions
+
+### Requirement: when evaluation uses a shared evaluate_when function
+The framework SHALL provide a single `evaluate_when(when_clause, context)` function that is used by both the sieve orchestrator and the remediation executor. This function SHALL live in the `config` package to avoid cross-layer imports between `sieve` and `remediation`.
+
+#### Scenario: Sieve and remediation use same evaluation logic
+- **WHEN** a sieve pass handler declares `when = { platform = "github" }`
+- **AND** a remediation handler declares `when = { platform = "github" }`
+- **THEN** both SHALL be evaluated by the same `evaluate_when` function
+- **AND** SHALL produce identical results for the same context

--- a/openspec/changes/handler-when-clause/tasks.md
+++ b/openspec/changes/handler-when-clause/tasks.md
@@ -1,0 +1,47 @@
+## 1. Schema Changes
+
+- [x] 1.1 Add `when: dict[str, Any] | None = None` field to `HandlerInvocation` in `framework_schema.py`
+- [x] 1.2 Add `strategy: Literal["all", "first_match"] = "all"` field to `RemediationConfig` in `framework_schema.py`
+- [x] 1.3 Add `languages: list[str] | None = None` field to the context schema in `schema.py`
+
+## 2. When Evaluator
+
+- [x] 2.1 Create `packages/darnit/src/darnit/config/when_evaluator.py` with `evaluate_when(when_clause, context) -> bool`
+- [x] 2.2 Implement match rules: str==str, str-in-list, bool==bool, scalar-in-list-context, subset check, missing key returns False
+- [x] 2.3 Implement AND semantics for multiple keys in a single `when` clause
+- [x] 2.4 Add debug logging for missing context keys and evaluation results
+
+## 3. Language Detection
+
+- [x] 3.1 Add `detect_languages(local_path) -> list[str]` to `auto_detect.py` that collects all manifest matches without early break
+- [x] 3.2 Apply TypeScript refinement (package.json + tsconfig.json → typescript instead of javascript) in `detect_languages()`
+- [x] 3.3 Call `detect_languages()` from `collect_auto_context()` and include result as `languages` key
+- [x] 3.4 Add `languages` to context storage flattening in `context_storage.py` (preserve list value, don't convert to string)
+
+## 4. Sieve Orchestrator Integration
+
+- [x] 4.1 Import `evaluate_when` in `orchestrator.py`
+- [x] 4.2 Add `when` evaluation before handler dispatch in `_dispatch_handler_invocations()` — skip handler if `invocation.when` is set and evaluates to false
+- [x] 4.3 Assemble flat context dict from `HandlerContext.project_context` for `when` evaluation
+
+## 5. Remediation Executor Integration
+
+- [x] 5.1 Import `evaluate_when` in `executor.py`
+- [x] 5.2 Add `when` evaluation before handler dispatch in `_execute_handler_invocations()` — skip handler if `invocation.when` is set and evaluates to false
+- [x] 5.3 Implement `first_match` strategy: break after first dispatched handler when `config.strategy == "first_match"`
+- [x] 5.4 Handle `first_match` with no matching handlers: return result with "no applicable remediation" message listing unmatched conditions
+- [x] 5.5 Assemble flat context dict from `self._project_values` and `self._context_values` for `when` evaluation
+
+## 6. Tests
+
+- [x] 6.1 Unit tests for `evaluate_when()`: str equality, bool equality, str-in-list, scalar-in-list-context, subset check, missing key, empty list, AND semantics
+- [x] 6.2 Unit tests for `detect_languages()`: single language, multi-language, TypeScript refinement, no manifests, deduplication (multiple python manifests)
+- [x] 6.3 Integration test: sieve orchestrator skips handler when `when` condition is false, runs when true, runs unconditionally when no `when`
+- [x] 6.4 Integration test: remediation executor with `strategy = "all"` runs all matching handlers
+- [x] 6.5 Integration test: remediation executor with `strategy = "first_match"` stops after first match, falls through to manual, handles no-match case
+- [x] 6.6 Test that `when` field does NOT appear in handler config dict (Pydantic explicit field vs model_extra)
+
+## 7. Spec Sync and Docs
+
+- [x] 7.1 Run `validate_sync.py` and fix any spec-implementation drift
+- [x] 7.2 Run `generate_docs.py` and commit any changes to `docs/generated/`

--- a/packages/darnit/src/darnit/config/context_storage.py
+++ b/packages/darnit/src/darnit/config/context_storage.py
@@ -101,6 +101,8 @@ def load_context(local_path: str) -> ContextByCategory:
             platform_context["platform"] = ContextValue.user_confirmed(ctx.platform)
         if ctx.primary_language is not None:
             platform_context["primary_language"] = ContextValue.user_confirmed(ctx.primary_language)
+        if ctx.languages is not None:
+            platform_context["languages"] = ContextValue.user_confirmed(ctx.languages)
         if platform_context:
             context_by_category["platform"] = platform_context
 

--- a/packages/darnit/src/darnit/config/framework_schema.py
+++ b/packages/darnit/src/darnit/config/framework_schema.py
@@ -127,7 +127,7 @@ Example:
 """
 
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -257,6 +257,11 @@ class HandlerInvocation(BaseModel):
 
     # Convenience: populate files from locator.discover at load time
     use_locator: bool = False
+
+    # Conditional dispatch — handler is skipped when condition evaluates to false
+    # Keys are context keys, values are expected values (same semantics as control-level when)
+    # Consumed by orchestrator/executor before dispatch; NOT passed to the handler
+    when: dict[str, Any] | None = None
 
     # All other fields pass through to the handler
     model_config = ConfigDict(extra="allow")
@@ -457,6 +462,11 @@ class RemediationConfig(BaseModel):
     """
     # Flat ordered list of remediation handler invocations
     handlers: list[HandlerInvocation] = Field(default_factory=list)
+
+    # Handler selection strategy:
+    # - "all" (default): run all handlers whose `when` matches (existing behavior)
+    # - "first_match": stop after the first handler whose `when` matches
+    strategy: Literal["all", "first_match"] = "all"
 
     # Post-remediation .project/ update (applied via on_pass, not a handler)
     project_update: Optional["ProjectUpdateRemediationConfig"] = None

--- a/packages/darnit/src/darnit/config/schema.py
+++ b/packages/darnit/src/darnit/config/schema.py
@@ -308,6 +308,9 @@ class ProjectContext(BaseModel):
     primary_language: str | None = None
     """Primary programming language - python, go, rust, javascript, etc."""
 
+    languages: list[str] | None = None
+    """All detected programming languages in the repository."""
+
     # New context keys for governance and security
     maintainers: list[str] | str | None = None
     """Project maintainers - list of GitHub usernames or path to MAINTAINERS file."""

--- a/packages/darnit/src/darnit/config/when_evaluator.py
+++ b/packages/darnit/src/darnit/config/when_evaluator.py
@@ -1,0 +1,79 @@
+"""Evaluate ``when`` clauses against project context.
+
+Provides a single ``evaluate_when()`` function used by both the sieve
+orchestrator (for pass handler dispatch) and the remediation executor
+(for remediation handler dispatch).
+
+Evaluation rules:
+- str context + str when  → exact equality
+- str context + list when → context value in the list
+- bool context + bool when → exact equality
+- list context + str when  → scalar is contained in the list
+- list context + list when → all when-values are in the context list (subset)
+- missing key             → condition not met (returns False)
+
+Multiple keys in a single ``when`` clause are AND-ed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from darnit.core.logging import get_logger
+
+logger = get_logger("config.when_evaluator")
+
+
+def evaluate_when(when_clause: dict[str, Any] | None, context: dict[str, Any]) -> bool:
+    """Evaluate a ``when`` clause against a flat context dict.
+
+    Args:
+        when_clause: Mapping of context keys to expected values.
+            ``None`` or empty dict means "always matches".
+        context: Flat dict of context key → value (auto-detected +
+            user-confirmed, merged by the caller).
+
+    Returns:
+        ``True`` if all conditions match (or no conditions), ``False`` otherwise.
+    """
+    if not when_clause:
+        return True
+
+    for key, expected in when_clause.items():
+        if key not in context:
+            logger.debug(
+                "when clause key '%s' not found in context — condition not met",
+                key,
+            )
+            return False
+
+        actual = context[key]
+
+        if not _match_value(key, actual, expected):
+            logger.debug(
+                "when clause '%s': actual=%r does not match expected=%r",
+                key,
+                actual,
+                expected,
+            )
+            return False
+
+    return True
+
+
+def _match_value(key: str, actual: Any, expected: Any) -> bool:
+    """Check if a single context value matches the when-clause expectation."""
+    # list context + str expected → containment
+    if isinstance(actual, list) and isinstance(expected, str):
+        return expected in actual
+
+    # list context + list expected → subset check
+    if isinstance(actual, list) and isinstance(expected, list):
+        return all(v in actual for v in expected)
+
+    # str context + list expected → membership
+    if isinstance(actual, str) and isinstance(expected, list):
+        return actual in expected
+
+    # scalar equality (str==str, bool==bool, int==int, etc.)
+    return actual == expected

--- a/packages/darnit/src/darnit/context/auto_detect.py
+++ b/packages/darnit/src/darnit/context/auto_detect.py
@@ -118,6 +118,48 @@ def detect_primary_language(local_path: str) -> str | None:
     return detected
 
 
+# Shared manifest-to-language mapping used by both detection functions
+_MANIFEST_CHECKS: list[tuple[str, str]] = [
+    ("go.mod", "go"),
+    ("Cargo.toml", "rust"),
+    ("pyproject.toml", "python"),
+    ("setup.py", "python"),
+    ("setup.cfg", "python"),
+    ("pom.xml", "java"),
+    ("build.gradle", "java"),
+    ("build.gradle.kts", "java"),
+    ("package.json", "javascript"),  # May be refined to typescript
+]
+
+
+def detect_languages(local_path: str) -> list[str]:
+    """Detect all programming languages present in the repository.
+
+    Unlike ``detect_primary_language()`` which stops at the first match,
+    this scans all manifest files and returns every detected language.
+    Deduplicates results (e.g., pyproject.toml and setup.py both → "python").
+
+    Returns:
+        List of language strings, e.g. ``["go", "typescript"]``. Empty if none found.
+    """
+    seen: set[str] = set()
+    languages: list[str] = []
+
+    for filename, language in _MANIFEST_CHECKS:
+        if os.path.isfile(os.path.join(local_path, filename)):
+            # TypeScript refinement
+            if language == "javascript" and os.path.isfile(
+                os.path.join(local_path, "tsconfig.json")
+            ):
+                language = "typescript"
+
+            if language not in seen:
+                seen.add(language)
+                languages.append(language)
+
+    return languages
+
+
 def collect_auto_context(local_path: str) -> dict[str, Any]:
     """Collect all auto-detectable context. Returns flat dict with bare keys.
 
@@ -137,6 +179,10 @@ def collect_auto_context(local_path: str) -> dict[str, Any]:
     primary_language = detect_primary_language(local_path)
     if primary_language:
         context["primary_language"] = primary_language
+
+    languages = detect_languages(local_path)
+    # Always include languages (even empty list) so when clauses can evaluate
+    context["languages"] = languages
 
     if context:
         logger.debug("Auto-detected context: %s", context)

--- a/packages/darnit/src/darnit/remediation/executor.py
+++ b/packages/darnit/src/darnit/remediation/executor.py
@@ -31,6 +31,7 @@ from darnit.config.framework_schema import (
     RemediationConfig,
     TemplateConfig,
 )
+from darnit.config.when_evaluator import evaluate_when
 from darnit.core.logging import get_logger
 from darnit.remediation.helpers import (
     detect_repo_from_git,
@@ -345,7 +346,8 @@ class RemediationExecutor:
         """Execute handler-based remediation invocations.
 
         Iterates config.handlers (flat list) and dispatches each through
-        the sieve handler registry.
+        the sieve handler registry. Respects ``when`` clauses on individual
+        handlers and the ``strategy`` field on RemediationConfig.
         """
         from darnit.sieve.handler_registry import (
             HandlerContext,
@@ -363,10 +365,29 @@ class RemediationExecutor:
             project_context=dict(self._project_values),
         )
 
+        # Assemble flat context for when-clause evaluation
+        when_context: dict[str, Any] = dict(self._project_values)
+        when_context.update(self._context_values)
+
         results: list[dict[str, Any]] = []
         all_success = True
+        first_match = config.strategy == "first_match"
+        matched_any = False
 
         for invocation in config.handlers:
+            # Evaluate when clause — skip handler if condition not met
+            if invocation.when and not evaluate_when(
+                invocation.when, when_context
+            ):
+                logger.debug(
+                    "Control %s: remediation handler '%s' skipped "
+                    "(when clause not met: %s)",
+                    control_id,
+                    invocation.handler,
+                    invocation.when,
+                )
+                continue
+
             handler_config = dict(invocation.model_extra or {})
             handler_config["handler"] = invocation.handler
 
@@ -385,6 +406,9 @@ class RemediationExecutor:
                     "message": f"Would execute handler: {invocation.handler}",
                     "config": handler_config,
                 })
+                matched_any = True
+                if first_match:
+                    break
                 continue
 
             handler_info = registry.get(invocation.handler)
@@ -395,6 +419,9 @@ class RemediationExecutor:
                     "message": f"Handler '{invocation.handler}' not found",
                 })
                 all_success = False
+                matched_any = True
+                if first_match:
+                    break
                 continue
 
             try:
@@ -413,6 +440,31 @@ class RemediationExecutor:
                     "message": str(e),
                 })
                 all_success = False
+
+            matched_any = True
+            if first_match:
+                break
+
+        # Handle first_match with no matching handlers
+        if first_match and not matched_any:
+            unmatched = [
+                str(inv.when)
+                for inv in config.handlers
+                if inv.when
+            ]
+            return RemediationResult(
+                success=False,
+                message=(
+                    "No applicable remediation handler matched the project context. "
+                    f"Unmatched conditions: {', '.join(unmatched)}"
+                    if unmatched
+                    else "No remediation handlers configured"
+                ),
+                control_id=control_id,
+                remediation_type="handler_pipeline",
+                dry_run=dry_run,
+                details={"handlers": results, "strategy": "first_match"},
+            )
 
         return RemediationResult(
             success=all_success,

--- a/packages/darnit/src/darnit/sieve/orchestrator.py
+++ b/packages/darnit/src/darnit/sieve/orchestrator.py
@@ -3,6 +3,7 @@
 import time
 from typing import Any
 
+from darnit.config.when_evaluator import evaluate_when
 from darnit.core.logging import get_logger
 
 from .handler_registry import (
@@ -232,7 +233,21 @@ class SieveOrchestrator:
             },
         )
 
+        # Assemble flat context for when-clause evaluation
+        when_context = dict(handler_ctx.project_context)
+
         for invocation in handler_invocations:
+            # Evaluate when clause — skip handler if condition not met
+            if invocation.when and not evaluate_when(
+                invocation.when, when_context
+            ):
+                logger.debug(
+                    "Control %s: handler '%s' skipped (when clause not met)",
+                    control_spec.control_id,
+                    invocation.handler,
+                )
+                continue
+
             handler_info = registry.get(invocation.handler)
             if not handler_info:
                 logger.warning(

--- a/tests/darnit/config/test_when_evaluator.py
+++ b/tests/darnit/config/test_when_evaluator.py
@@ -1,0 +1,123 @@
+"""Tests for darnit.config.when_evaluator module."""
+
+from darnit.config.when_evaluator import evaluate_when
+
+
+class TestEvaluateWhenBasic:
+    """Basic matching rules."""
+
+    def test_none_when_returns_true(self):
+        assert evaluate_when(None, {"a": 1}) is True
+
+    def test_empty_when_returns_true(self):
+        assert evaluate_when({}, {"a": 1}) is True
+
+    def test_str_equality_match(self):
+        assert evaluate_when(
+            {"primary_language": "go"},
+            {"primary_language": "go"},
+        ) is True
+
+    def test_str_equality_mismatch(self):
+        assert evaluate_when(
+            {"primary_language": "go"},
+            {"primary_language": "python"},
+        ) is False
+
+    def test_bool_equality_match(self):
+        assert evaluate_when(
+            {"is_library": True},
+            {"is_library": True},
+        ) is True
+
+    def test_bool_equality_mismatch(self):
+        assert evaluate_when(
+            {"is_library": True},
+            {"is_library": False},
+        ) is False
+
+    def test_missing_key_returns_false(self):
+        """Handler-level: missing context key → skip handler (conservative)."""
+        assert evaluate_when(
+            {"primary_language": "go"},
+            {},
+        ) is False
+
+    def test_missing_key_among_others(self):
+        """If any key is missing, the whole clause fails."""
+        assert evaluate_when(
+            {"primary_language": "go", "platform": "github"},
+            {"platform": "github"},
+        ) is False
+
+
+class TestEvaluateWhenListContext:
+    """List-valued context (e.g., languages)."""
+
+    def test_scalar_in_list_context(self):
+        assert evaluate_when(
+            {"languages": "go"},
+            {"languages": ["go", "typescript"]},
+        ) is True
+
+    def test_scalar_not_in_list_context(self):
+        assert evaluate_when(
+            {"languages": "rust"},
+            {"languages": ["go", "typescript"]},
+        ) is False
+
+    def test_empty_list_context_matches_nothing(self):
+        assert evaluate_when(
+            {"languages": "go"},
+            {"languages": []},
+        ) is False
+
+    def test_subset_check_passes(self):
+        assert evaluate_when(
+            {"languages": ["go", "typescript"]},
+            {"languages": ["go", "typescript", "python"]},
+        ) is True
+
+    def test_subset_check_fails(self):
+        assert evaluate_when(
+            {"languages": ["go", "rust"]},
+            {"languages": ["go", "typescript"]},
+        ) is False
+
+
+class TestEvaluateWhenListWhen:
+    """List-valued when clause (e.g., ci_provider = ["github", "gitlab"])."""
+
+    def test_str_context_in_list_when(self):
+        assert evaluate_when(
+            {"ci_provider": ["github", "gitlab"]},
+            {"ci_provider": "gitlab"},
+        ) is True
+
+    def test_str_context_not_in_list_when(self):
+        assert evaluate_when(
+            {"ci_provider": ["github", "gitlab"]},
+            {"ci_provider": "circleci"},
+        ) is False
+
+
+class TestEvaluateWhenANDSemantics:
+    """Multiple keys are AND-ed."""
+
+    def test_all_match(self):
+        assert evaluate_when(
+            {"primary_language": "go", "platform": "github"},
+            {"primary_language": "go", "platform": "github"},
+        ) is True
+
+    def test_one_mismatch(self):
+        assert evaluate_when(
+            {"primary_language": "go", "platform": "github"},
+            {"primary_language": "go", "platform": "gitlab"},
+        ) is False
+
+    def test_mixed_types(self):
+        assert evaluate_when(
+            {"is_library": True, "languages": "go"},
+            {"is_library": True, "languages": ["go", "python"]},
+        ) is True

--- a/tests/darnit/context/test_auto_detect.py
+++ b/tests/darnit/context/test_auto_detect.py
@@ -6,6 +6,7 @@ from darnit.context.auto_detect import (
     _extract_hostname,
     collect_auto_context,
     detect_ci_provider,
+    detect_languages,
     detect_platform,
     detect_primary_language,
 )
@@ -127,6 +128,43 @@ class TestDetectPrimaryLanguage:
         assert detect_primary_language(str(tmp_path)) is None
 
 
+class TestDetectLanguages:
+    def test_single_language(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com")
+        assert detect_languages(str(tmp_path)) == ["go"]
+
+    def test_multi_language(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com")
+        (tmp_path / "package.json").write_text("{}")
+        assert detect_languages(str(tmp_path)) == ["go", "javascript"]
+
+    def test_typescript_refinement(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "tsconfig.json").write_text("{}")
+        assert detect_languages(str(tmp_path)) == ["typescript"]
+
+    def test_multi_language_with_typescript(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com")
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "tsconfig.json").write_text("{}")
+        assert detect_languages(str(tmp_path)) == ["go", "typescript"]
+
+    def test_no_manifests(self, tmp_path):
+        assert detect_languages(str(tmp_path)) == []
+
+    def test_deduplication_python(self, tmp_path):
+        """Multiple Python manifests should produce a single 'python' entry."""
+        (tmp_path / "pyproject.toml").write_text("[project]")
+        (tmp_path / "setup.py").write_text("from setuptools import setup")
+        assert detect_languages(str(tmp_path)) == ["python"]
+
+    def test_deduplication_java(self, tmp_path):
+        """Multiple Java manifests should produce a single 'java' entry."""
+        (tmp_path / "pom.xml").write_text("<project/>")
+        (tmp_path / "build.gradle").write_text("plugins {}")
+        assert detect_languages(str(tmp_path)) == ["java"]
+
+
 class TestCollectAutoContext:
     def test_collects_all(self, tmp_path):
         # Set up git + GitHub remote + Python + GitHub Actions
@@ -142,10 +180,12 @@ class TestCollectAutoContext:
         assert result["platform"] == "github"
         assert result["ci_provider"] == "github"
         assert result["primary_language"] == "python"
+        assert result["languages"] == ["python"]
 
-    def test_empty_for_bare_dir(self, tmp_path):
+    def test_languages_always_included(self, tmp_path):
+        """languages key is always present, even as empty list."""
         result = collect_auto_context(str(tmp_path))
-        assert result == {}
+        assert result["languages"] == []
 
     def test_omits_undetectable(self, tmp_path):
         """Keys with None detection are omitted from the result."""
@@ -154,6 +194,7 @@ class TestCollectAutoContext:
         # No language files, no CI files
 
         result = collect_auto_context(str(tmp_path))
-        assert result == {"platform": "github"}
+        assert result["platform"] == "github"
+        assert result["languages"] == []
         assert "ci_provider" not in result
         assert "primary_language" not in result

--- a/tests/darnit/remediation/test_executor.py
+++ b/tests/darnit/remediation/test_executor.py
@@ -313,5 +313,232 @@ class TestHandlerInconclusiveHandling:
             assert handlers[0]["status"] == "inconclusive"
 
 
+class TestExecutorWhenClause:
+    """Test when clause filtering in remediation executor."""
+
+    def test_strategy_all_runs_all_matching(self):
+        """strategy='all' runs all handlers whose when clause matches."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            executor = RemediationExecutor(
+                local_path=tmpdir,
+                owner="testorg",
+                repo="testrepo",
+                context_values={"primary_language": "python"},
+            )
+
+            config = RemediationConfig(
+                strategy="all",
+                handlers=[
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="A.md",
+                        content="# A",
+                        when={"primary_language": "python"},
+                    ),
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="B.md",
+                        content="# B",
+                        when={"primary_language": "python"},
+                    ),
+                ],
+            )
+
+            result = executor.execute("TEST-01", config, dry_run=True)
+            assert result.success
+            assert len(result.details["handlers"]) == 2
+
+    def test_strategy_all_skips_unmatched(self):
+        """strategy='all' skips handlers whose when clause does not match."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            executor = RemediationExecutor(
+                local_path=tmpdir,
+                owner="testorg",
+                repo="testrepo",
+                context_values={"primary_language": "python"},
+            )
+
+            config = RemediationConfig(
+                strategy="all",
+                handlers=[
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="A.md",
+                        content="# A",
+                        when={"primary_language": "python"},
+                    ),
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="B.md",
+                        content="# B",
+                        when={"primary_language": "go"},
+                    ),
+                ],
+            )
+
+            result = executor.execute("TEST-01", config, dry_run=True)
+            assert result.success
+            # Only the python handler matches
+            assert len(result.details["handlers"]) == 1
+
+    def test_strategy_first_match_stops_after_first(self):
+        """strategy='first_match' stops after the first matching handler."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            executor = RemediationExecutor(
+                local_path=tmpdir,
+                owner="testorg",
+                repo="testrepo",
+                context_values={"primary_language": "go"},
+            )
+
+            config = RemediationConfig(
+                strategy="first_match",
+                handlers=[
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="A.md",
+                        content="# A",
+                        when={"primary_language": "go"},
+                    ),
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="B.md",
+                        content="# B",
+                        when={"primary_language": "go"},
+                    ),
+                ],
+            )
+
+            result = executor.execute("TEST-01", config, dry_run=True)
+            assert result.success
+            # Only first matching handler executes
+            assert len(result.details["handlers"]) == 1
+            assert result.details["handlers"][0]["handler"] == "file_create"
+
+    def test_strategy_first_match_skips_to_matching(self):
+        """strategy='first_match' skips non-matching handlers, runs first match."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            executor = RemediationExecutor(
+                local_path=tmpdir,
+                owner="testorg",
+                repo="testrepo",
+                context_values={"primary_language": "python"},
+            )
+
+            config = RemediationConfig(
+                strategy="first_match",
+                handlers=[
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="go.md",
+                        content="# Go",
+                        when={"primary_language": "go"},
+                    ),
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="python.md",
+                        content="# Python",
+                        when={"primary_language": "python"},
+                    ),
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="fallback.md",
+                        content="# Fallback",
+                    ),
+                ],
+            )
+
+            result = executor.execute("TEST-01", config, dry_run=True)
+            assert result.success
+            assert len(result.details["handlers"]) == 1
+
+    def test_strategy_first_match_no_match_returns_error(self):
+        """strategy='first_match' with no matching handler returns failure."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            executor = RemediationExecutor(
+                local_path=tmpdir,
+                owner="testorg",
+                repo="testrepo",
+                context_values={"primary_language": "rust"},
+            )
+
+            config = RemediationConfig(
+                strategy="first_match",
+                handlers=[
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="go.md",
+                        content="# Go",
+                        when={"primary_language": "go"},
+                    ),
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="python.md",
+                        content="# Python",
+                        when={"primary_language": "python"},
+                    ),
+                ],
+            )
+
+            result = executor.execute("TEST-01", config, dry_run=True)
+            assert not result.success
+            assert "No applicable remediation" in result.message
+
+    def test_when_with_languages_list_context(self):
+        """when clause matches list-valued context (e.g., languages)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            executor = RemediationExecutor(
+                local_path=tmpdir,
+                owner="testorg",
+                repo="testrepo",
+                context_values={"languages": ["go", "typescript"]},
+            )
+
+            config = RemediationConfig(
+                strategy="first_match",
+                handlers=[
+                    HandlerInvocation(
+                        handler="file_create",
+                        path="go.md",
+                        content="# Go",
+                        when={"languages": "go"},
+                    ),
+                ],
+            )
+
+            result = executor.execute("TEST-01", config, dry_run=True)
+            assert result.success
+
+
+class TestWhenFieldNotInHandlerConfig:
+    """Test that 'when' is a Pydantic explicit field, not model_extra."""
+
+    def test_when_not_in_model_extra(self):
+        """when field should not leak into handler config dict (model_extra)."""
+        inv = HandlerInvocation(
+            handler="file_create",
+            when={"primary_language": "go"},
+            path="test.md",
+            content="# Test",
+        )
+        config = dict(inv.model_extra or {})
+        assert "when" not in config
+        # when should be accessible as a field
+        assert inv.when == {"primary_language": "go"}
+        # model_extra should contain the handler-specific config
+        assert config.get("path") == "test.md"
+        assert config.get("content") == "# Test"
+
+    def test_strategy_not_in_model_extra(self):
+        """strategy field should not leak into model_extra."""
+        config = RemediationConfig(
+            strategy="first_match",
+            handlers=[
+                HandlerInvocation(handler="manual", steps=["Check"]),
+            ],
+        )
+        assert config.strategy == "first_match"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/darnit/sieve/test_orchestrator.py
+++ b/tests/darnit/sieve/test_orchestrator.py
@@ -10,13 +10,17 @@ from darnit.sieve.models import (
 from darnit.sieve.orchestrator import SieveOrchestrator
 
 
-def _make_context() -> CheckContext:
+def _make_context(
+    local_path: str = "/tmp/test",
+    project_context: dict | None = None,
+) -> CheckContext:
     return CheckContext(
         owner="test-org",
         repo="test-repo",
-        local_path="/tmp/test",
+        local_path=local_path,
         default_branch="main",
         control_id="TEST-01",
+        project_context=project_context or {},
     )
 
 
@@ -184,3 +188,157 @@ class TestVerifyWithLlmResponse:
 
         result = orchestrator.verify_with_llm_response(spec, _make_context(), response)
         assert result.status == "FAIL"
+
+
+class TestHandlerWhenClause:
+    """Test handler-level when clause in dispatch_handler_invocations."""
+
+    def test_handler_skipped_when_condition_false(self, tmp_path):
+        """Handler with when={primary_language: 'go'} is skipped when context is 'python'."""
+        (tmp_path / "README.md").write_text("# Test")
+        orchestrator = SieveOrchestrator(stop_on_llm=True)
+
+        spec = ControlSpec(
+            control_id="TEST-01",
+            level=1,
+            domain="TEST",
+            name="TestControl",
+            description="Test",
+            metadata={
+                "handler_invocations": [
+                    HandlerInvocation(
+                        handler="file_exists",
+                        files=["README.md"],
+                        when={"primary_language": "go"},
+                    ),
+                ],
+            },
+        )
+
+        ctx = _make_context(
+            local_path=str(tmp_path),
+            project_context={"primary_language": "python"},
+        )
+        result = orchestrator.verify(spec, ctx)
+        # Handler skipped → no conclusive result → WARN
+        assert result.status == "WARN"
+
+    def test_handler_runs_when_condition_true(self, tmp_path):
+        """Handler with when={primary_language: 'go'} runs when context matches."""
+        (tmp_path / "README.md").write_text("# Test")
+        orchestrator = SieveOrchestrator(stop_on_llm=True)
+
+        spec = ControlSpec(
+            control_id="TEST-01",
+            level=1,
+            domain="TEST",
+            name="TestControl",
+            description="Test",
+            metadata={
+                "handler_invocations": [
+                    HandlerInvocation(
+                        handler="file_exists",
+                        files=["README.md"],
+                        when={"primary_language": "go"},
+                    ),
+                ],
+            },
+        )
+
+        ctx = _make_context(
+            local_path=str(tmp_path),
+            project_context={"primary_language": "go"},
+        )
+        result = orchestrator.verify(spec, ctx)
+        assert result.status == "PASS"
+
+    def test_handler_runs_unconditionally_when_no_when(self, tmp_path):
+        """Handler without when clause runs regardless of context."""
+        (tmp_path / "README.md").write_text("# Test")
+        orchestrator = SieveOrchestrator(stop_on_llm=True)
+
+        spec = ControlSpec(
+            control_id="TEST-01",
+            level=1,
+            domain="TEST",
+            name="TestControl",
+            description="Test",
+            metadata={
+                "handler_invocations": [
+                    HandlerInvocation(
+                        handler="file_exists",
+                        files=["README.md"],
+                    ),
+                ],
+            },
+        )
+
+        ctx = _make_context(
+            local_path=str(tmp_path),
+            project_context={"primary_language": "python"},
+        )
+        result = orchestrator.verify(spec, ctx)
+        assert result.status == "PASS"
+
+    def test_handler_when_with_list_context(self, tmp_path):
+        """Handler with when={languages: 'go'} matches list context containing 'go'."""
+        (tmp_path / "README.md").write_text("# Test")
+        orchestrator = SieveOrchestrator(stop_on_llm=True)
+
+        spec = ControlSpec(
+            control_id="TEST-01",
+            level=1,
+            domain="TEST",
+            name="TestControl",
+            description="Test",
+            metadata={
+                "handler_invocations": [
+                    HandlerInvocation(
+                        handler="file_exists",
+                        files=["README.md"],
+                        when={"languages": "go"},
+                    ),
+                ],
+            },
+        )
+
+        ctx = _make_context(
+            local_path=str(tmp_path),
+            project_context={"languages": ["go", "typescript"]},
+        )
+        result = orchestrator.verify(spec, ctx)
+        assert result.status == "PASS"
+
+    def test_first_handler_skipped_second_runs(self, tmp_path):
+        """First handler skipped by when, second runs unconditionally."""
+        (tmp_path / "README.md").write_text("# Test")
+        orchestrator = SieveOrchestrator(stop_on_llm=True)
+
+        spec = ControlSpec(
+            control_id="TEST-01",
+            level=1,
+            domain="TEST",
+            name="TestControl",
+            description="Test",
+            metadata={
+                "handler_invocations": [
+                    HandlerInvocation(
+                        handler="file_exists",
+                        files=["NONEXISTENT.md"],
+                        when={"primary_language": "go"},
+                    ),
+                    HandlerInvocation(
+                        handler="file_exists",
+                        files=["README.md"],
+                    ),
+                ],
+            },
+        )
+
+        ctx = _make_context(
+            local_path=str(tmp_path),
+            project_context={"primary_language": "python"},
+        )
+        result = orchestrator.verify(spec, ctx)
+        # First handler skipped (go != python), second runs and finds README.md
+        assert result.status == "PASS"


### PR DESCRIPTION
## Summary

- Add `when` clause on `HandlerInvocation` for conditional handler dispatch based on project context (language, platform, CI provider, etc.)
- Add `strategy` field on `RemediationConfig` (`"all"` | `"first_match"`) to control whether all matching handlers run or only the first match
- Add shared `evaluate_when()` evaluator with list containment, subset matching, and AND semantics
- Add `detect_languages()` for multi-language detection (supports monorepo scenarios like Go + TypeScript)
- Wire when-clause evaluation into both sieve orchestrator and remediation executor pipelines

This enables language-aware remediation — e.g., a Go project gets Go-specific remediation while a Python project gets Python-specific remediation for the same control. The `first_match` strategy prevents conflicting remediations from running.

## Changes

### Schema (`framework_schema.py`)
- `HandlerInvocation.when: dict[str, Any] | None` — conditional dispatch field
- `RemediationConfig.strategy: Literal["all", "first_match"]` — handler selection strategy

### New module (`config/when_evaluator.py`)
- `evaluate_when(when_clause, context) -> bool` — shared evaluator for both orchestrator and executor
- Supports: str equality, bool equality, scalar-in-list, list subset, list-valued when (OR), AND semantics across keys
- Handler-level semantics: missing context key → `False` (skip handler, conservative)

### Language detection (`context/auto_detect.py`)
- `detect_languages(local_path) -> list[str]` — returns all detected languages
- TypeScript refinement: `package.json` + `tsconfig.json` → `"typescript"` instead of `"javascript"`
- `collect_auto_context()` now always includes `languages` key (even as empty list)

### Integration
- Orchestrator (`sieve/orchestrator.py`): evaluates `when` before handler dispatch, skips non-matching handlers
- Executor (`remediation/executor.py`): evaluates `when` with `first_match`/`all` strategy support, no-match error reporting

## Test plan

- [x] Unit tests for `evaluate_when()` — 18 tests covering all match rules and edge cases
- [x] Unit tests for `detect_languages()` — 7 tests including TypeScript refinement and deduplication
- [x] Integration tests for orchestrator when clause — 5 tests (skip, run, unconditional, list context, fallback)
- [x] Integration tests for executor strategy — 6 tests (all matching, skip unmatched, first_match stops, no-match error, list context)
- [x] Pydantic field exclusion tests — 2 tests (when/strategy not in model_extra)
- [x] Full test suite: 1027 passed, 1 skipped (pre-existing upstream spec hash drift)
- [x] Ruff lint: all checks passed
- [x] Spec sync validation: all validations passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)