### PR TITLE
chore: Migrate legacy TOML configs and docs to [[passes]] handler format

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -178,7 +178,7 @@ Darnit operates at three distinct layers. Each has built-in primitives and plugi
 │  Layer 2: Remediation (how to fix a failing control)    │
 │                                                         │
 │  Built-in: file_create, exec, api_call, project_update  │
-│  Plugin:   handler = "my_module:my_func"                │
+│  Plugin:   handler = "my_custom_fix"                    │
 │                                                         │
 │  TOML:  [controls."X".remediation.file_create]          │
 │         path = "SECURITY.md"                            │
@@ -186,11 +186,12 @@ Darnit operates at three distinct layers. Each has built-in primitives and plugi
 ├─────────────────────────────────────────────────────────┤
 │  Layer 1: Checking (how to verify a control)            │
 │                                                         │
-│  Built-in: file_must_exist, exec, pattern, manual       │
-│  Plugin:   handler = "my_module:my_func"                │
+│  Built-in: file_exists, exec, pattern, manual           │
+│  Plugin:   handler = "my_custom_check"                  │
 │                                                         │
-│  TOML:  [controls."X".passes.deterministic]             │
-│         file_must_exist = ["README.md"]                 │
+│  TOML:  [[controls."X".passes]]                         │
+│         handler = "file_exists"                         │
+│         files = ["README.md"]                           │
 └─────────────────────────────────────────────────────────┘
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,9 +260,11 @@ actively used. All new controls must be defined entirely in TOML.
 Controls can use CEL (Common Expression Language) for pass logic:
 
 ```toml
-[controls."OSPS-AC-01.01".passes.deterministic]
-exec = { command = "gh api /orgs/{org}/settings" }
-expr = 'response.two_factor_requirement_enabled == true'
+[[controls."OSPS-AC-01.01".passes]]
+handler = "exec"
+command = ["gh", "api", "/orgs/{org}/settings"]
+output_format = "json"
+expr = 'output.json.two_factor_requirement_enabled == true'
 ```
 
 Available context variables:

--- a/docs/IMPLEMENTATION_GUIDE.md
+++ b/docs/IMPLEMENTATION_GUIDE.md
@@ -67,7 +67,7 @@ plugin extensibility:
 │  Layer 2: Remediation (how to fix a failing control)    │
 │                                                         │
 │  Built-in: file_create, exec, api_call, project_update  │
-│  Plugin:   handler = "my_module:my_func"                │
+│  Plugin:   handler = "my_custom_fix"                    │
 │                                                         │
 │  TOML:  [controls."X".remediation.file_create]          │
 │         path = "SECURITY.md"                            │
@@ -75,11 +75,12 @@ plugin extensibility:
 ├─────────────────────────────────────────────────────────┤
 │  Layer 1: Checking (how to verify a control)            │
 │                                                         │
-│  Built-in: file_must_exist, exec, pattern, manual       │
-│  Plugin:   handler = "my_module:my_func"                │
+│  Built-in: file_exists, exec, pattern, manual           │
+│  Plugin:   handler = "my_custom_check"                  │
 │                                                         │
-│  TOML:  [controls."X".passes.deterministic]             │
-│         file_must_exist = ["README.md"]                 │
+│  TOML:  [[controls."X".passes]]                         │
+│         handler = "file_exists"                         │
+│         files = ["README.md"]                           │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -121,10 +122,12 @@ name = "HasReadme"
 description = "Project must have a README"
 tags = { level = 1, domain = "DOC" }
 
-[controls."MS-01".passes]
-deterministic = { file_must_exist = ["README.md", "README.rst"] }
+[[controls."MS-01".passes]]
+handler = "file_exists"
+files = ["README.md", "README.rst"]
 
-[controls."MS-01".passes.manual]
+[[controls."MS-01".passes]]
+handler = "manual"
 steps = ["Check for README in project root"]
 
 [controls."MS-01".remediation]
@@ -425,8 +428,9 @@ help_md = """Create a README.md file in the repository root.
 """
 
 # Deterministic pass: check if file exists
-[controls."MS-DOC-01".passes.deterministic]
-file_must_exist = [
+[[controls."MS-DOC-01".passes]]
+handler = "file_exists"
+files = [
     "README.md",
     "README.rst",
     "README.txt",
@@ -434,7 +438,8 @@ file_must_exist = [
 ]
 
 # Manual pass: fallback verification steps
-[controls."MS-DOC-01".passes.manual]
+[[controls."MS-DOC-01".passes]]
+handler = "manual"
 steps = [
     "Check repository root for README file",
     "Verify README contains project description",
@@ -498,8 +503,9 @@ entries, implemented in `packages/darnit/src/darnit/sieve/builtin_handlers.py`:
 The simplest check — pass if any listed file exists:
 
 ```toml
-[controls."MS-SEC-01".passes.deterministic]
-file_must_exist = [
+[[controls."MS-SEC-01".passes]]
+handler = "file_exists"
+files = [
     "SECURITY.md",
     ".github/SECURITY.md",
     "docs/SECURITY.md",
@@ -511,7 +517,8 @@ file_must_exist = [
 Run a CLI tool and evaluate the result with a CEL expression:
 
 ```toml
-[controls."MS-AC-01".passes.exec]
+[[controls."MS-AC-01".passes]]
+handler = "exec"
 command = ["gh", "api", "/orgs/$OWNER"]
 pass_exit_codes = [0]
 fail_exit_codes = [1]
@@ -528,7 +535,8 @@ Variable substitution in commands: `$PATH` (local repo path), `$OWNER`,
 Search file contents with regex:
 
 ```toml
-[controls."MS-DOC-02".passes.pattern]
+[[controls."MS-DOC-02".passes]]
+handler = "pattern"
 file_patterns = ["SECURITY.md", ".github/SECURITY.md"]
 content_patterns = { security_contact = '([\w.-]+@[\w.-]+\.\w+|security\s*contact)' }
 expr = 'output.any_match'
@@ -539,7 +547,8 @@ expr = 'output.any_match'
 Always returns INCONCLUSIVE with human-readable steps:
 
 ```toml
-[controls."MS-DOC-02".passes.manual]
+[[controls."MS-DOC-02".passes]]
+handler = "manual"
 steps = [
     "Open SECURITY.md",
     "Verify it contains a clear contact method",

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -22,7 +22,8 @@ Handler short names are registered by the implementation's `register_handlers()`
 
 ### Before (Multiple Fields)
 ```toml
-[controls."OSPS-XX-01.01".passes.exec]
+[[controls."OSPS-XX-01.01".passes]]
+handler = "exec"
 command = ["kusari", "scan"]
 output_format = "json"
 pass_if_json_path = "$.status"
@@ -31,7 +32,8 @@ pass_if_json_value = "pass"
 
 ### After (CEL Expression)
 ```toml
-[controls."OSPS-XX-01.01".passes.exec]
+[[controls."OSPS-XX-01.01".passes]]
+handler = "exec"
 command = ["kusari", "scan"]
 output_format = "json"
 expr = 'output.json.status == "pass"'

--- a/docs/SECURITY_GUIDE.md
+++ b/docs/SECURITY_GUIDE.md
@@ -410,15 +410,8 @@ def my_custom_check(context):
 The handler can then be referenced in TOML by short name:
 
 ```toml
-[controls."MY-01.01".passes.deterministic]
+[[controls."MY-01.01".passes]]
 handler = "my_custom_check"  # Short name from registry
-```
-
-Or by full module path (must match allowlist):
-
-```toml
-[controls."MY-01.01".passes.deterministic]
-handler = "darnit_baseline.controls.level1:_create_mfa_check"
 ```
 
 ### Security Recommendations

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -27,8 +27,9 @@ name = "ReadmeExists"
 description = "Project must have a README file"
 tags = { level = 1, domain = "DO", documentation = true }
 
-[controls."EXAMPLE-DO-01".passes]
-deterministic = { file_must_exist = ["README.md", "README.rst"] }
+[[controls."EXAMPLE-DO-01".passes]]
+handler = "file_exists"
+files = ["README.md", "README.rst"]
 
 [controls."EXAMPLE-DO-01".remediation.file_create]
 path = "README.md"

--- a/docs/examples/declarative-framework/example-framework.toml
+++ b/docs/examples/declarative-framework/example-framework.toml
@@ -6,9 +6,9 @@
 # No Python code is required for simple checks and remediations.
 #
 # Features demonstrated:
-# - Deterministic file existence checks
-# - Pattern matching in files
-# - External command execution (ExecPass)
+# - File existence checks (file_exists handler)
+# - Pattern matching in files (pattern handler)
+# - External command execution (exec handler)
 # - File creation remediation from templates
 # - API call remediation
 # - Variable substitution ($OWNER, $REPO, $BRANCH, etc.)
@@ -113,9 +113,10 @@ description = "Project must have a README file"
 tags = { level = 1, domain = "DO", documentation = true, onboarding = true }
 docs_url = "https://example.com/docs/readme"
 
-# Check: File must exist (deterministic)
-[controls."EXAMPLE-DO-01".passes]
-deterministic = { file_must_exist = ["README.md", "README", "README.rst", "README.txt"] }
+# Check: File must exist
+[[controls."EXAMPLE-DO-01".passes]]
+handler = "file_exists"
+files = ["README.md", "README", "README.rst", "README.txt"]
 
 # Remediation: Create README.md from template
 [controls."EXAMPLE-DO-01".remediation]
@@ -135,8 +136,9 @@ name = "ChangelogExists"
 description = "Project must have a CHANGELOG file"
 tags = { level = 1, domain = "DO", documentation = true, versioning = true }
 
-[controls."EXAMPLE-DO-02".passes]
-deterministic = { file_must_exist = ["CHANGELOG.md", "CHANGELOG", "HISTORY.md", "NEWS.md"] }
+[[controls."EXAMPLE-DO-02".passes]]
+handler = "file_exists"
+files = ["CHANGELOG.md", "CHANGELOG", "HISTORY.md", "NEWS.md"]
 
 [controls."EXAMPLE-DO-02".remediation]
 safe = true
@@ -155,8 +157,9 @@ name = "LicenseExists"
 description = "Project must have a LICENSE file"
 tags = { level = 1, domain = "LE", security_severity = 3.0, legal = true, compliance = true }
 
-[controls."EXAMPLE-LE-01".passes]
-deterministic = { file_must_exist = ["LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING"] }
+[[controls."EXAMPLE-LE-01".passes]]
+handler = "file_exists"
+files = ["LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING"]
 
 # Note: No remediation - license choice requires human decision
 
@@ -169,18 +172,21 @@ description = "Repository must not contain hardcoded secrets"
 tags = { level = 1, domain = "SE", security_severity = 9.0, security = true, secrets = true }
 
 # Check: These files should NOT exist
-[controls."EXAMPLE-SE-01".passes]
-deterministic = { file_must_not_exist = [
+[[controls."EXAMPLE-SE-01".passes]]
+handler = "file_exists"
+files = [
     ".env",
     ".env.local",
     "secrets.json",
     "credentials.json",
     "*.pem",
     "*.key",
-]}
+]
+expr = 'output.files_found == 0'
 
 # Pattern check: Look for common secret patterns (these should NOT match)
-[controls."EXAMPLE-SE-01".passes.pattern]
+[[controls."EXAMPLE-SE-01".passes]]
+handler = "pattern"
 files = ["**/*.py", "**/*.js", "**/*.ts", "**/*.go", "**/*.java"]
 fail_if_no_match = false  # We WANT no matches
 
@@ -197,8 +203,9 @@ name = "CICDConfigured"
 description = "Project must have CI/CD configuration"
 tags = { level = 2, domain = "QA", ci-cd = true, automation = true, quality = true }
 
-[controls."EXAMPLE-QA-01".passes]
-deterministic = { file_must_exist = [
+[[controls."EXAMPLE-QA-01".passes]]
+handler = "file_exists"
+files = [
     ".github/workflows/*.yml",
     ".github/workflows/*.yaml",
     ".gitlab-ci.yml",
@@ -206,7 +213,7 @@ deterministic = { file_must_exist = [
     ".circleci/config.yml",
     ".travis.yml",
     "azure-pipelines.yml",
-]}
+]
 
 # -----------------------------------------------------------------------------
 # Control: Tests exist
@@ -216,8 +223,9 @@ name = "TestsExist"
 description = "Project must have test files"
 tags = { level = 2, domain = "QA", testing = true, quality = true }
 
-[controls."EXAMPLE-QA-02".passes]
-deterministic = { file_must_exist = [
+[[controls."EXAMPLE-QA-02".passes]]
+handler = "file_exists"
+files = [
     "tests/**/*.py",
     "test/**/*.py",
     "**/*_test.py",
@@ -226,7 +234,7 @@ deterministic = { file_must_exist = [
     "**/*.test.ts",
     "**/*.spec.js",
     "**/*.spec.ts",
-]}
+]
 
 # -----------------------------------------------------------------------------
 # Control: Code owners defined
@@ -236,8 +244,9 @@ name = "CodeOwnersExists"
 description = "Project must define code owners"
 tags = { level = 2, domain = "GV", governance = true, ownership = true }
 
-[controls."EXAMPLE-GV-01".passes]
-deterministic = { file_must_exist = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"] }
+[[controls."EXAMPLE-GV-01".passes]]
+handler = "file_exists"
+files = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 
 [controls."EXAMPLE-GV-01".remediation]
 safe = true
@@ -257,14 +266,16 @@ description = "Primary branch must have protection rules"
 tags = { level = 2, domain = "AC", security_severity = 7.5, access-control = true, branch-protection = true }
 
 # Check: Use gh CLI to verify branch protection
-[controls."EXAMPLE-AC-01".passes.exec]
+[[controls."EXAMPLE-AC-01".passes]]
+handler = "exec"
 command = ["gh", "api", "/repos/$OWNER/$REPO/branches/$BRANCH/protection"]
 pass_exit_codes = [0]
 fail_exit_codes = [1]
 output_format = "json"
 timeout = 30
 
-[controls."EXAMPLE-AC-01".passes.manual]
+[[controls."EXAMPLE-AC-01".passes]]
+handler = "manual"
 steps = [
     "Navigate to Repository Settings → Branches",
     "Verify branch protection rule exists for the default branch",
@@ -296,14 +307,15 @@ name = "DependencyScanningEnabled"
 description = "Automated dependency scanning must be configured"
 tags = { level = 3, domain = "VM", security_severity = 6.0, security = true, dependencies = true, scanning = true }
 
-[controls."EXAMPLE-VM-01".passes]
-deterministic = { file_must_exist = [
+[[controls."EXAMPLE-VM-01".passes]]
+handler = "file_exists"
+files = [
     ".github/dependabot.yml",
     ".github/dependabot.yaml",
     "renovate.json",
     ".renovaterc",
     ".renovaterc.json",
-]}
+]
 
 # -----------------------------------------------------------------------------
 # Control: External tool check (using kusari as example)
@@ -314,14 +326,16 @@ description = "Project passes SBOM compliance checks"
 tags = { level = 3, domain = "VM", sbom = true, supply-chain = true, compliance = true }
 
 # Check: Run external tool (kusari) for SBOM validation
-[controls."EXAMPLE-VM-02".passes.exec]
+[[controls."EXAMPLE-VM-02".passes]]
+handler = "exec"
 command = ["kusari", "repo", "scan", "$PATH", "HEAD"]
 pass_exit_codes = [0]
 fail_exit_codes = [1, 2]
 output_format = "json"
 timeout = 120
 
-[controls."EXAMPLE-VM-02".passes.manual]
+[[controls."EXAMPLE-VM-02".passes]]
+handler = "manual"
 steps = [
     "Run: kusari repo scan . HEAD",
     "Verify all checks pass",

--- a/packages/darnit-testchecks/testchecks.toml
+++ b/packages/darnit-testchecks/testchecks.toml
@@ -37,13 +37,14 @@ domain = "DOC"
 description = "Repository must have a README file"
 tags = ["documentation", "basic"]
 
-[controls."TEST-DOC-01".passes]
-deterministic = { file_must_exist = [
+[[controls."TEST-DOC-01".passes]]
+handler = "file_exists"
+files = [
     "README.md",
     "README.rst",
     "README.txt",
     "README",
-]}
+]
 
 [controls."TEST-DOC-01".remediation]
 handler = "create_readme"
@@ -56,14 +57,15 @@ domain = "DOC"
 description = "Repository should have a CHANGELOG file"
 tags = ["documentation", "releases"]
 
-[controls."TEST-DOC-02".passes]
-deterministic = { file_must_exist = [
+[[controls."TEST-DOC-02".passes]]
+handler = "file_exists"
+files = [
     "CHANGELOG.md",
     "CHANGELOG.txt",
     "CHANGELOG",
     "HISTORY.md",
     "CHANGES.md",
-]}
+]
 
 [controls."TEST-LIC-01"]
 name = "HasLicense"
@@ -72,13 +74,14 @@ domain = "LIC"
 description = "Repository must have a LICENSE file"
 tags = ["legal", "license"]
 
-[controls."TEST-LIC-01".passes]
-deterministic = { file_must_exist = [
+[[controls."TEST-LIC-01".passes]]
+handler = "file_exists"
+files = [
     "LICENSE",
     "LICENSE.md",
     "LICENSE.txt",
     "COPYING",
-]}
+]
 
 [controls."TEST-IGN-01"]
 name = "HasGitignore"
@@ -87,8 +90,9 @@ domain = "CFG"
 description = "Repository should have a .gitignore file"
 tags = ["configuration", "git"]
 
-[controls."TEST-IGN-01".passes]
-deterministic = { file_must_exist = [".gitignore"] }
+[[controls."TEST-IGN-01".passes]]
+handler = "file_exists"
+files = [".gitignore"]
 
 [controls."TEST-IGN-01".remediation]
 handler = "create_gitignore"
@@ -105,7 +109,8 @@ domain = "QA"
 description = "Code should not contain TODO comments (for testing - intentionally strict)"
 tags = ["quality", "code-review"]
 
-[controls."TEST-QA-01".passes.pattern]
+[[controls."TEST-QA-01".passes]]
+handler = "pattern"
 files = ["**/*.py", "**/*.js", "**/*.ts"]
 pass_if_any = false
 
@@ -119,7 +124,8 @@ domain = "QA"
 description = "Python code should not contain print() statements (use logging)"
 tags = ["quality", "python"]
 
-[controls."TEST-QA-02".passes.pattern]
+[[controls."TEST-QA-02".passes]]
+handler = "pattern"
 files = ["**/*.py"]
 pass_if_any = false
 
@@ -133,8 +139,9 @@ domain = "CFG"
 description = "Repository should have an .editorconfig file"
 tags = ["configuration", "editor"]
 
-[controls."TEST-CFG-01".passes]
-deterministic = { file_must_exist = [".editorconfig"] }
+[[controls."TEST-CFG-01".passes]]
+handler = "file_exists"
+files = [".editorconfig"]
 
 [controls."TEST-CFG-02"]
 name = "HasPreCommitConfig"
@@ -143,11 +150,12 @@ domain = "CFG"
 description = "Repository should have pre-commit configuration"
 tags = ["configuration", "hooks"]
 
-[controls."TEST-CFG-02".passes]
-deterministic = { file_must_exist = [
+[[controls."TEST-CFG-02".passes]]
+handler = "file_exists"
+files = [
     ".pre-commit-config.yaml",
     ".pre-commit-config.yml",
-]}
+]
 
 # =============================================================================
 # Level 3 Controls - Advanced
@@ -160,7 +168,8 @@ domain = "SEC"
 description = "Code should not contain hardcoded passwords"
 tags = ["security", "secrets"]
 
-[controls."TEST-SEC-01".passes.pattern]
+[[controls."TEST-SEC-01".passes]]
+handler = "pattern"
 files = ["**/*.py", "**/*.js", "**/*.ts", "**/*.yaml", "**/*.yml", "**/*.json"]
 pass_if_any = false
 
@@ -176,7 +185,8 @@ domain = "SEC"
 description = ".gitignore should exclude common secret files"
 tags = ["security", "secrets", "git"]
 
-[controls."TEST-SEC-02".passes.pattern]
+[[controls."TEST-SEC-02".passes]]
+handler = "pattern"
 files = [".gitignore"]
 
 [controls."TEST-SEC-02".passes.pattern.patterns]
@@ -191,8 +201,9 @@ domain = "CI"
 description = "Repository should have CI/CD configuration"
 tags = ["ci-cd", "automation"]
 
-[controls."TEST-CI-01".passes]
-deterministic = { file_must_exist = [
+[[controls."TEST-CI-01".passes]]
+handler = "file_exists"
+files = [
     ".github/workflows/*.yml",
     ".github/workflows/*.yaml",
     ".gitlab-ci.yml",
@@ -200,7 +211,7 @@ deterministic = { file_must_exist = [
     "Jenkinsfile",
     ".travis.yml",
     "azure-pipelines.yml",
-]}
+]
 
 [controls."TEST-CI-02"]
 name = "CIRunsTests"
@@ -209,7 +220,8 @@ domain = "CI"
 description = "CI configuration should run tests"
 tags = ["ci-cd", "testing"]
 
-[controls."TEST-CI-02".passes.pattern]
+[[controls."TEST-CI-02".passes]]
+handler = "pattern"
 files = [".github/workflows/*.yml", ".github/workflows/*.yaml", ".gitlab-ci.yml"]
 
 [controls."TEST-CI-02".passes.pattern.patterns]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.8.0",
     "pre-commit>=4.0.0",
+    "vulture>=2.11",
 ]
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -472,6 +472,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "vulture" },
 ]
 
 [package.dev-dependencies]
@@ -491,6 +492,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.11" },
 ]
 provides-extras = ["attestation", "dev"]
 
@@ -1846,4 +1848,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/25/925f35db758a0f9199113aaf61d703de891676b082bd7cf73ea01d6000f7/vulture-2.14.tar.gz", hash = "sha256:cb8277902a1138deeab796ec5bef7076a6e0248ca3607a3f3dee0b6d9e9b8415", size = 58823, upload-time = "2024-12-08T17:39:43.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/56/0cc15b8ff2613c1d5c3dc1f3f576ede1c43868c1bc2e5ccaa2d4bcd7974d/vulture-2.14-py2.py3-none-any.whl", hash = "sha256:d9a90dba89607489548a49d557f8bac8112bd25d3cbc8aeef23e860811bd5ed9", size = 28915, upload-time = "2024-12-08T17:39:40.573Z" },
 ]

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -1,0 +1,10 @@
+# Vulture allowlist — false positives and intentional unused code
+#
+# These entries suppress vulture warnings for code that appears unused but is
+# intentionally kept. Vulture allowlists use attribute access to mark names used.
+
+# MCP tool parameters: part of the public MCP tool schema, exposed to AI
+# assistants even though the function body doesn't use them yet.
+# Removing them would change the tool's API contract.
+_ = auto_init_config  # noqa: F821  # audit_openssf_baseline parameter
+_ = attest  # noqa: F821  # audit_openssf_baseline parameter


### PR DESCRIPTION
## Summary

Cleanup round 4, follow-up to PR #87. Migrates remaining legacy phase-bucketed TOML syntax to the current `[[passes]]` flat handler list format.

- **Migrate `testchecks.toml`** (12 controls): `deterministic = { file_must_exist = [...] }` → `[[passes]]` + `handler = "file_exists"`, `[passes.pattern]` → `[[passes]]` + `handler = "pattern"`
- **Migrate `example-framework.toml`** (10 controls): same conversions for file_exists, exec, pattern, manual handlers
- **Update 6 doc files**: ARCHITECTURE.md, IMPLEMENTATION_GUIDE.md, SECURITY_GUIDE.md, MIGRATION_GUIDE.md, CLAUDE.md, docs/examples/README.md — all inline TOML examples now use `[[passes]]` format
- **Remove stale `module:function` handler reference** from SECURITY_GUIDE.md (`_resolve_check_function` was deleted in round 3)
- **Add `vulture>=2.11`** to dev dependencies with allowlist for 2 unused MCP API parameters (`auto_init_config`, `attest`)

## Test plan

- [x] `uv run ruff check .` — all passed
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — 1040/1041 passed (1 pre-existing upstream spec sync failure)
- [x] `cd packages/darnit-testchecks && uv run pytest tests/ -q` — 62/62 passed
- [x] `uv run python scripts/validate_sync.py --verbose` — all passed
- [x] `uv run python scripts/generate_docs.py` — no changes needed
- [x] Grep for `passes.(deterministic|pattern|manual|exec)]` in `*.toml` and `*.md` — 0 hits
- [x] Grep for `_resolve_check_function` or `_create_mfa_check` in docs — 0 hits
- [x] `uv run vulture packages/ vulture_allowlist.py --min-confidence 80` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)