### PR TITLE
feat: Batch context gathering via AskUserQuestion

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -4686,18 +4686,17 @@ confirm_project_context(
 
 [mcp.tools.get_pending_context]
 handler = "get_pending_context"
-limit = 1
+limit = 4
 append_directive = true
-description = """Sequential context collection wizard. Returns ONE question at a time.
+description = """Batch context collection wizard. Returns up to 4 questions at a time.
 
 **IMPORTANT — You MUST follow this workflow:**
-1. Call this tool. It returns a single question.
-2. Present the question to the user using the EXACT "question" text from the response. Do NOT paraphrase.
-3. Do NOT use markdown checkboxes, tables, or bullet formatting. Present plain text only.
-4. After the user answers, call confirm_project_context() with their answer.
-5. Call this tool again for the next question. Repeat until status is "complete".
+1. Call this tool. It returns up to 4 questions in "ask_user_batch".
+2. Pass "ask_user_batch.questions" directly to AskUserQuestion — do NOT paraphrase, reorder, or modify.
+3. After the user answers, use "answer_mapping" to call confirm_project_context() for EACH answer.
+4. Call this tool again for the next batch. Repeat until status is "complete".
 
-Do NOT batch multiple questions. Do NOT pre-fill or suggest answers.
+Do NOT pre-fill or suggest answers. Do NOT guess values from git history or repo metadata.
 """
 
 [mcp.tools.generate_threat_model]
@@ -4710,7 +4709,13 @@ description = "Generate an in-toto attestation for OpenSSF Baseline compliance"
 
 [mcp.tools.remediate_audit_findings]
 handler = "remediate_audit_findings"
-description = "Apply automated remediations for failed audit controls"
+description = """Apply automated remediations for failed audit controls.
+
+**IMPORTANT**: Before running remediation, ALWAYS call get_pending_context() first to gather any
+missing project context (maintainers, security contact, governance model, etc.). Some remediations
+require confirmed context to generate correct files (e.g., CODEOWNERS needs maintainers).
+Gather all context before remediating.
+"""
 
 [mcp.tools.create_remediation_branch]
 handler = "create_remediation_branch"

--- a/packages/darnit-baseline/src/darnit_baseline/tools.py
+++ b/packages/darnit-baseline/src/darnit_baseline/tools.py
@@ -445,20 +445,31 @@ def confirm_project_context(
     )
 
 
+# Fixed ordering matching TOML [context.*] definition order for stable UX.
+# This must match the order of sections in openssf-baseline.toml.
+_CONTEXT_KEY_ORDER = [
+    "maintainers",
+    "security_contact",
+    "governance_model",
+    "has_subprojects",
+    "has_releases",
+    "is_library",
+    "has_compiled_assets",
+    "ci_provider",
+]
+
 _LLM_DIRECTIVE = """
 ---
 IMPORTANT — YOU MUST FOLLOW THESE RULES:
-1. Use the AskUserQuestion tool to present this question interactively.
-   The "ask_user" object in each question maps directly to AskUserQuestion parameters:
-   pass "question", "header", "options", and "multiSelect" as-is.
-2. Do NOT batch multiple questions. Ask this ONE question, wait for the answer, then call get_pending_context again.
-3. Do NOT paraphrase or reword the question text.
-4. After the user answers, call confirm_project_context() with the value, then call get_pending_context() for the next question.
-5. Map user selections to confirm_project_context values:
+1. Use the AskUserQuestion tool with the EXACT contents of "ask_user_batch.questions".
+   Pass the array directly — do NOT paraphrase, reorder, or modify any question text or options.
+2. After the user answers, use "answer_mapping" to call confirm_project_context() for EACH answer.
+   Map user selections to confirm_project_context values:
    - "Yes" / "No" for booleans → pass true / false (not strings)
    - Selected option label for enums → pass the label as a string
    - "Other" selections → pass the user's typed value
-6. Do NOT guess, suggest, or pre-fill answers from the repository owner, git history, or your own knowledge.
+3. Then call get_pending_context() again for the next batch (if any remain).
+4. Do NOT guess, suggest, or pre-fill answers from the repository owner, git history, or your own knowledge.
 ---"""
 
 
@@ -468,19 +479,19 @@ def get_pending_context(
     level: int = 3,
     owner: str | None = None,
     repo: str | None = None,
-    limit: int = 1,
+    limit: int = 4,
     _tool_config: dict | None = None,
 ) -> str:
     """Get context values that would improve audit accuracy.
 
-    **IMPORTANT**: This is a sequential form processor. It returns ONE question at a time
-    by default. You MUST follow this workflow:
+    Returns up to `limit` questions per call as a batch. You MUST follow this workflow:
 
-    1. Call get_pending_context() — it returns a single question.
-    2. Present the question to the user using the EXACT "question" text from the response.
-       Do NOT paraphrase, batch, or use markdown formatting (no checkboxes, no tables).
-    3. After the user answers, call confirm_project_context() with the value.
-    4. Call get_pending_context() again for the next question.
+    1. Call get_pending_context() — it returns up to 4 questions with an "ask_user_batch" field.
+    2. Pass "ask_user_batch.questions" directly to the AskUserQuestion tool.
+       Do NOT paraphrase, reorder, or modify any question text or options.
+    3. After the user answers, use "answer_mapping" to call confirm_project_context()
+       for EACH answer.
+    4. Call get_pending_context() again for the next batch.
     5. Repeat until status is "complete".
 
     Parameters:
@@ -489,12 +500,11 @@ def get_pending_context(
     - `level`: Maximum maturity level (1, 2, or 3)
     - `owner`: GitHub owner (auto-detected if not provided)
     - `repo`: GitHub repo name (auto-detected if not provided)
-    - `limit`: Max questions to return (default: 1). Use 0 for all.
+    - `limit`: Max questions to return per batch (default: 4). Use 0 for all.
 
     Returns:
-        JSON with structured question(s) and a progress indicator. Each question
-        specifies its input_type (free_text, select, or confirm) and the exact
-        question to present. Follow the input_type exactly.
+        JSON with structured question(s), ask_user_batch for AskUserQuestion,
+        answer_mapping for confirm_project_context, and a progress indicator.
     """
     from darnit.config.context_storage import get_pending_context as _get_pending
 
@@ -539,28 +549,65 @@ def get_pending_context(
         for req in pending:
             questions.append(_build_context_question(req))
 
-        # Sort by priority (highest first)
-        questions.sort(key=lambda q: q["priority"], reverse=True)
+        # Sort by TOML definition order for stable UX across runs.
+        # Keys not in the fixed order list sort to the end.
+        def _toml_order(q: dict) -> int:
+            try:
+                return _CONTEXT_KEY_ORDER.index(q["key"])
+            except ValueError:
+                return len(_CONTEXT_KEY_ORDER)
+
+        questions.sort(key=_toml_order)
 
         # Apply pagination (limit=0 means return all)
         if effective_limit > 0:
             questions = questions[:effective_limit]
 
-        result = json.dumps({
+        # Build ask_user_batch: collect per-question ask_user params into
+        # a single array that maps directly to AskUserQuestion's questions param.
+        batch_questions = []
+        answer_mapping = []
+        for q in questions:
+            ask_user = q.get("ask_user")
+            if ask_user is not None:
+                batch_questions.append(ask_user)
+                mapping: dict = {
+                    "question_index": len(batch_questions) - 1,
+                    "context_key": q["key"],
+                }
+                # Build value_map for the LLM to translate selections
+                input_type = q.get("input_type")
+                if input_type == "select" and q.get("options") == ["true", "false"]:
+                    mapping["value_map"] = {"Yes": True, "No": False}
+                elif input_type == "confirm":
+                    mapping["value_map"] = {
+                        "Yes": q.get("detected_value"),
+                        "No": "ASK_USER_FOR_VALUE",
+                    }
+                answer_mapping.append(mapping)
+
+        # Determine answered count from total minus pending
+        answered = total - len(pending)
+
+        response: dict = {
             "status": "pending",
             "progress": {
-                "current": total - len(pending) + 1,
+                "answered": answered,
                 "total": total,
             },
             "instructions": (
-                "Present the question to the user using the EXACT 'question' text. "
-                "Do NOT paraphrase, batch, or use markdown formatting. "
-                "After the user answers, call confirm_project_context() with the value, "
-                "then call get_pending_context() again for the next question."
+                "Pass ask_user_batch.questions directly to AskUserQuestion. "
+                "Then use answer_mapping to call confirm_project_context() for each answer. "
+                "Then call get_pending_context() again for the next batch."
             ),
             "questions": questions,
-            "after_answer": "Call confirm_project_context() with the answer, then call get_pending_context() again.",
-        }, indent=2)
+        }
+
+        if batch_questions:
+            response["ask_user_batch"] = {"questions": batch_questions}
+            response["answer_mapping"] = answer_mapping
+
+        result = json.dumps(response, indent=2)
 
         if append_directive:
             result += _LLM_DIRECTIVE

--- a/tests/darnit_baseline/test_get_pending_context.py
+++ b/tests/darnit_baseline/test_get_pending_context.py
@@ -1,7 +1,8 @@
-"""Tests for get_pending_context deterministic context collection.
+"""Tests for get_pending_context batch context collection.
 
 Tests the pagination, LLM directive footer, progress indicator,
-and presentation hint features added to enforce sequential CLI wizard behavior.
+presentation hint, ask_user_batch, answer_mapping, and TOML ordering
+features for batched AskUserQuestion-based context gathering.
 """
 
 import json
@@ -11,8 +12,10 @@ from darnit.config.context_schema import (
     ContextDefinition,
     ContextPromptRequest,
     ContextType,
+    ContextValue,
 )
 from darnit_baseline.tools import (
+    _CONTEXT_KEY_ORDER,
     _LLM_DIRECTIVE,
     _build_context_question,
     get_pending_context,
@@ -37,23 +40,39 @@ def _make_pending(count: int) -> list[ContextPromptRequest]:
     return items
 
 
+def _parse_json_from_result(result: str) -> dict:
+    """Strip directive footer and parse JSON from get_pending_context result."""
+    json_str = result.split("\n---")[0].rstrip()
+    return json.loads(json_str)
+
+
 class TestGetPendingContextPagination:
-    """Tests for single-item pagination behavior."""
+    """Tests for batch pagination behavior."""
 
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
-    def test_default_limit_returns_one_question(self, mock_get, mock_path) -> None:
-        """Default limit=1 returns exactly one question."""
+    def test_default_limit_returns_four_questions(self, mock_get, mock_path) -> None:
+        """Default limit=4 returns up to four questions."""
         mock_path.return_value.resolve.return_value = "/tmp/repo"
         mock_get.return_value = _make_pending(5)
 
         result = get_pending_context(local_path="/tmp/repo")
-        # Strip directive footer to parse JSON
-        json_str = result.split("\n---")[0].rstrip()
-        data = json.loads(json_str)
+        data = _parse_json_from_result(result)
 
         assert data["status"] == "pending"
-        assert len(data["questions"]) == 1
+        assert len(data["questions"]) == 4
+
+    @patch("darnit_baseline.tools.Path")
+    @patch("darnit.config.context_storage.get_pending_context")
+    def test_default_limit_returns_all_if_fewer_than_four(self, mock_get, mock_path) -> None:
+        """Default limit=4 returns all questions when fewer than 4 pending."""
+        mock_path.return_value.resolve.return_value = "/tmp/repo"
+        mock_get.return_value = _make_pending(2)
+
+        result = get_pending_context(local_path="/tmp/repo")
+        data = _parse_json_from_result(result)
+
+        assert len(data["questions"]) == 2
 
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
@@ -63,8 +82,7 @@ class TestGetPendingContextPagination:
         mock_get.return_value = _make_pending(5)
 
         result = get_pending_context(local_path="/tmp/repo", limit=0)
-        json_str = result.split("\n---")[0].rstrip()
-        data = json.loads(json_str)
+        data = _parse_json_from_result(result)
 
         assert data["status"] == "pending"
         assert len(data["questions"]) == 5
@@ -77,8 +95,7 @@ class TestGetPendingContextPagination:
         mock_get.return_value = _make_pending(5)
 
         result = get_pending_context(local_path="/tmp/repo", limit=3)
-        json_str = result.split("\n---")[0].rstrip()
-        data = json.loads(json_str)
+        data = _parse_json_from_result(result)
 
         assert len(data["questions"]) == 3
 
@@ -89,17 +106,16 @@ class TestGetPendingContextProgress:
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
     def test_progress_included(self, mock_get, mock_path) -> None:
-        """Response includes progress object with current and total."""
+        """Response includes progress object with answered and total."""
         mock_path.return_value.resolve.return_value = "/tmp/repo"
         mock_get.return_value = _make_pending(8)
 
         result = get_pending_context(local_path="/tmp/repo")
-        json_str = result.split("\n---")[0].rstrip()
-        data = json.loads(json_str)
+        data = _parse_json_from_result(result)
 
         assert "progress" in data
         assert data["progress"]["total"] == 8
-        assert data["progress"]["current"] == 1
+        assert data["progress"]["answered"] == 0
 
 
 class TestGetPendingContextDirective:
@@ -116,7 +132,7 @@ class TestGetPendingContextDirective:
 
         assert result.endswith(_LLM_DIRECTIVE)
         assert "IMPORTANT" in result
-        assert "Do NOT batch" in result
+        assert "ask_user_batch" in result
 
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
@@ -244,8 +260,6 @@ class TestAskUserParams:
 
     def test_confirm_question_has_ask_user_accept_reject(self) -> None:
         """Auto-detected confirm question includes ask_user with Accept/Reject."""
-        from darnit.config.context_schema import ContextValue
-
         defn = ContextDefinition(
             type=ContextType.STRING,
             prompt="What CI provider?",
@@ -324,3 +338,184 @@ class TestAskUserParams:
 
         assert "ask_user" in question
         assert len(question["ask_user"]["header"]) <= 12
+
+
+class TestAskUserBatch:
+    """Tests for ask_user_batch and answer_mapping in response."""
+
+    @patch("darnit_baseline.tools.Path")
+    @patch("darnit.config.context_storage.get_pending_context")
+    def test_batch_contains_all_ask_user_questions(self, mock_get, mock_path) -> None:
+        """ask_user_batch.questions aggregates per-question ask_user params."""
+        mock_path.return_value.resolve.return_value = "/tmp/repo"
+        mock_get.return_value = _make_pending(3)
+
+        result = get_pending_context(local_path="/tmp/repo")
+        data = _parse_json_from_result(result)
+
+        assert "ask_user_batch" in data
+        batch = data["ask_user_batch"]["questions"]
+        assert len(batch) == 3
+        # Each batch question has the AskUserQuestion structure
+        for q in batch:
+            assert "question" in q
+            assert "header" in q
+            assert "options" in q
+            assert "multiSelect" in q
+
+    @patch("darnit_baseline.tools.Path")
+    @patch("darnit.config.context_storage.get_pending_context")
+    def test_answer_mapping_matches_batch_indices(self, mock_get, mock_path) -> None:
+        """answer_mapping has correct question_index and context_key for each question."""
+        mock_path.return_value.resolve.return_value = "/tmp/repo"
+        mock_get.return_value = _make_pending(3)
+
+        result = get_pending_context(local_path="/tmp/repo")
+        data = _parse_json_from_result(result)
+
+        assert "answer_mapping" in data
+        mappings = data["answer_mapping"]
+        assert len(mappings) == 3
+        for i, m in enumerate(mappings):
+            assert m["question_index"] == i
+            assert "context_key" in m
+
+    @patch("darnit_baseline.tools.Path")
+    @patch("darnit.config.context_storage.get_pending_context")
+    def test_boolean_answer_mapping_has_value_map(self, mock_get, mock_path) -> None:
+        """Boolean questions include value_map for Yes→true, No→false."""
+        mock_path.return_value.resolve.return_value = "/tmp/repo"
+        # Single boolean question
+        defn = ContextDefinition(
+            type=ContextType.BOOLEAN,
+            prompt="Has releases?",
+            affects=["CTRL-01"],
+        )
+        mock_get.return_value = [ContextPromptRequest(
+            key="has_releases",
+            definition=defn,
+            control_ids=["CTRL-01"],
+            priority=1,
+        )]
+
+        result = get_pending_context(local_path="/tmp/repo")
+        data = _parse_json_from_result(result)
+
+        mapping = data["answer_mapping"][0]
+        assert mapping["value_map"] == {"Yes": True, "No": False}
+
+    @patch("darnit_baseline.tools.Path")
+    @patch("darnit.config.context_storage.get_pending_context")
+    def test_confirm_answer_mapping_has_detected_value(self, mock_get, mock_path) -> None:
+        """Confirm questions include value_map with detected value for Yes."""
+        mock_path.return_value.resolve.return_value = "/tmp/repo"
+        defn = ContextDefinition(
+            type=ContextType.STRING,
+            prompt="CI provider?",
+            auto_detect=True,
+            affects=["CTRL-01"],
+        )
+        mock_get.return_value = [ContextPromptRequest(
+            key="ci_provider",
+            definition=defn,
+            control_ids=["CTRL-01"],
+            priority=1,
+            current_value=ContextValue.auto_detected(value="github", method="detected"),
+        )]
+
+        result = get_pending_context(local_path="/tmp/repo")
+        data = _parse_json_from_result(result)
+
+        mapping = data["answer_mapping"][0]
+        assert mapping["value_map"]["Yes"] == "github"
+        assert mapping["value_map"]["No"] == "ASK_USER_FOR_VALUE"
+
+    @patch("darnit_baseline.tools.Path")
+    @patch("darnit.config.context_storage.get_pending_context")
+    def test_no_batch_when_no_ask_user(self, mock_get, mock_path) -> None:
+        """No ask_user_batch field when questions lack ask_user params."""
+        mock_path.return_value.resolve.return_value = "/tmp/repo"
+        # Free text without examples → no ask_user
+        defn = ContextDefinition(
+            type=ContextType.STRING,
+            prompt="Project name?",
+            affects=["CTRL-01"],
+        )
+        mock_get.return_value = [ContextPromptRequest(
+            key="project_name",
+            definition=defn,
+            control_ids=["CTRL-01"],
+            priority=1,
+        )]
+
+        result = get_pending_context(local_path="/tmp/repo")
+        data = _parse_json_from_result(result)
+
+        assert "ask_user_batch" not in data
+        assert "answer_mapping" not in data
+
+
+class TestTomlDefinitionOrder:
+    """Tests for TOML definition order sorting."""
+
+    @patch("darnit_baseline.tools.Path")
+    @patch("darnit.config.context_storage.get_pending_context")
+    def test_questions_sorted_by_toml_order(self, mock_get, mock_path) -> None:
+        """Questions are sorted by TOML definition order, not priority."""
+        mock_path.return_value.resolve.return_value = "/tmp/repo"
+
+        # Create questions with keys in reverse TOML order but high priority
+        items = []
+        for key in reversed(["has_subprojects", "maintainers", "ci_provider"]):
+            defn = ContextDefinition(
+                type=ContextType.BOOLEAN,
+                prompt=f"{key}?",
+                affects=["CTRL-01"],
+            )
+            items.append(ContextPromptRequest(
+                key=key,
+                definition=defn,
+                control_ids=["CTRL-01"],
+                priority=10,  # all same priority
+            ))
+        mock_get.return_value = items
+
+        result = get_pending_context(local_path="/tmp/repo", limit=0)
+        data = _parse_json_from_result(result)
+
+        keys = [q["key"] for q in data["questions"]]
+        # Should be in TOML order: maintainers, has_subprojects, ci_provider
+        assert keys == ["maintainers", "has_subprojects", "ci_provider"]
+
+    @patch("darnit_baseline.tools.Path")
+    @patch("darnit.config.context_storage.get_pending_context")
+    def test_unknown_keys_sort_to_end(self, mock_get, mock_path) -> None:
+        """Keys not in TOML order list sort after known keys."""
+        mock_path.return_value.resolve.return_value = "/tmp/repo"
+
+        items = []
+        for key in ["custom_key", "maintainers"]:
+            defn = ContextDefinition(
+                type=ContextType.BOOLEAN,
+                prompt=f"{key}?",
+                affects=["CTRL-01"],
+            )
+            items.append(ContextPromptRequest(
+                key=key,
+                definition=defn,
+                control_ids=["CTRL-01"],
+                priority=1,
+            ))
+        mock_get.return_value = items
+
+        result = get_pending_context(local_path="/tmp/repo", limit=0)
+        data = _parse_json_from_result(result)
+
+        keys = [q["key"] for q in data["questions"]]
+        assert keys == ["maintainers", "custom_key"]
+
+    def test_context_key_order_has_all_eight_keys(self) -> None:
+        """_CONTEXT_KEY_ORDER contains all 8 expected context keys."""
+        assert len(_CONTEXT_KEY_ORDER) == 8
+        assert _CONTEXT_KEY_ORDER[0] == "maintainers"
+        assert _CONTEXT_KEY_ORDER[-1] == "ci_provider"


### PR DESCRIPTION
## Summary

- Context gathering previously asked 8 questions one-at-a-time (8 round-trips through `get_pending_context` → LLM → user → `confirm_project_context`). Now returns up to 4 questions per call with a structured `ask_user_batch` field that maps directly to `AskUserQuestion` parameters — 2 batches max instead of 8.
- Replaces priority-based question sorting with fixed TOML definition order for stable UX across runs
- Adds `context-first` instruction to `remediate_audit_findings` tool description so LLMs gather missing project context before attempting remediations that require it (e.g., CODEOWNERS needs maintainers)

### Key changes

**`get_pending_context` response now includes:**
- `ask_user_batch.questions` — array ready to pass directly to `AskUserQuestion`
- `answer_mapping` — per-question `context_key` + `value_map` for calling `confirm_project_context`
- `progress.answered` / `progress.total` instead of `current`/`total`

**TOML config (`openssf-baseline.toml`):**
- `limit = 1` → `limit = 4` in `[mcp.tools.get_pending_context]`
- Tool description rewritten for batch workflow
- `[mcp.tools.remediate_audit_findings]` now instructs LLM to gather context first

## Test plan

- [x] `uv run ruff check .` — linting passes
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — 956 passed (1 pre-existing upstream hash failure)
- [x] `uv run python scripts/validate_sync.py --verbose` — all validations pass
- [x] New tests: `TestAskUserBatch` (5 tests), `TestTomlDefinitionOrder` (3 tests)
- [ ] Manual test: verify `get_pending_context` returns batches of up to 4 questions
- [ ] Manual test: verify question order matches TOML definition order

🤖 Generated with [Claude Code](https://claude.com/claude-code)