### PR TITLE
fix: auto-detect ecosystem and license type without prompting

### DIFF
--- a/packages/darnit-baseline/README.md
+++ b/packages/darnit-baseline/README.md
@@ -80,7 +80,7 @@ Controls gated by `platform = "github"` require the GitHub CLI (`gh`). Additiona
 
 | Control | Lvl | What It Checks | How | Auto-Remediation |
 |---------|-----|----------------|-----|------------------|
-| LE-01.01 | 1 | Repository has a license file | `file` LICENSE | Creates LICENSE (MIT) |
+| LE-01.01 | 1 | Repository has a license file | `file` LICENSE | Creates LICENSE (MIT, Apache-2.0, or BSD-3-Clause via `license_type` context) |
 | LE-02.01 | 1 | License is OSI-approved | `exec` gh api | — |
 | LE-02.02 | 1 | Releases include license info | `exec` gh release view | — |
 | LE-03.01 | 1 | License file present in repository root | `file` LICENSE | — |
@@ -99,8 +99,8 @@ Controls gated by `platform = "github"` require the GitHub CLI (`gh`). Additiona
 | QA-04.02 | 3 | Subprojects enforce equal security *(if has_subprojects)* | `pattern` security files | Manual |
 | QA-05.01 | 1 | No generated executables in repo | `pattern` absence check | Manual |
 | QA-05.02 | 1 | No unreviewable binary artifacts | `pattern` absence check | Manual |
-| QA-06.01 | 2 | CI includes automated tests | `pattern` workflows | Creates ci.yml |
-| QA-06.02 | 3 | Testing instructions documented | `pattern` README, docs | Manual |
+| QA-06.01 | 2 | CI includes automated tests | `pattern` workflows | Creates ci.yml (ecosystem-aware: Python/Node/Rust/Go) |
+| QA-06.02 | 3 | Testing instructions documented | `pattern` README, docs | Creates docs/TESTING.md (ecosystem-aware: Python/Node/Rust/Go) |
 | QA-06.03 | 3 | Test requirements for contributions | `pattern` CONTRIBUTING.md | Manual |
 | QA-07.01 | 3 | PRs require approval before merge | `exec` gh api | API: require PR reviews |
 
@@ -111,7 +111,7 @@ Controls gated by `platform = "github"` require the GitHub CLI (`gh`). Additiona
 | SA-01.01 | 2 | Design docs show actions and actors | `pattern` architecture docs | Creates ARCHITECTURE.md |
 | SA-02.01 | 2 | API/interface documentation available | `pattern` API docs, README | — |
 | SA-03.01 | 2 | Security assessment before releases *(if has_releases)* | `manual` / `pattern` | Creates SECURITY-ASSESSMENT.md |
-| SA-03.02 | 3 | Threat model documentation available | `file` THREAT_MODEL.md / `pattern` | Creates THREAT_MODEL.md |
+| SA-03.02 | 3 | Threat model documentation available | `file` THREAT_MODEL.md / `pattern` | Creates THREAT_MODEL.md (`llm_enhance`) |
 
 ### OSPS-VM — Vulnerability Management (10 controls)
 
@@ -124,7 +124,7 @@ Controls gated by `platform = "github"` require the GitHub CLI (`gh`). Additiona
 | VM-04.02 | 3 | VEX policy documented | `pattern` SECURITY.md, docs | Creates docs/VEX-POLICY.md |
 | VM-05.01 | 3 | SCA remediation policy documented | `pattern` docs | Creates docs/SCA-POLICY.md |
 | VM-05.02 | 3 | Pre-release SCA workflow configured | `pattern` workflows | Creates sca.yml |
-| VM-05.03 | 3 | Automated dependency scanning configured | `file` dependabot.yml, renovate.json | Creates dependabot.yml |
+| VM-05.03 | 3 | Automated dependency scanning configured | `file` dependabot.yml, renovate.json | Creates dependabot.yml (ecosystem-aware: Python/Node/Rust/Go) |
 | VM-06.01 | 3 | SAST remediation policy documented | `pattern` docs | Creates docs/SAST-POLICY.md |
 | VM-06.02 | 3 | Automated SAST in CI pipeline | `pattern` workflows | Creates sast.yml |
 
@@ -144,6 +144,8 @@ Set context via the `confirm_project_context` MCP tool or by editing `.project/p
 | `is_library` | boolean | No | DO-04.01, BR-01.01 | Audit hints for accuracy |
 | `has_compiled_assets` | boolean | No | QA-02.02 | When-clause: control only runs if `true` |
 | `ci_provider` | enum | Yes | BR-01.01, BR-01.02, AC-04.01, AC-04.02 | When-clause: controls only run if `"github"` |
+
+**Auto-detected without prompting:** `detected_ecosystem` (from manifest files: pyproject.toml → python, package.json → node, Cargo.toml → rust, go.mod → go) and `license_type` (from LICENSE file content: Apache-2.0, MIT, BSD-3-Clause) are detected automatically by `collect_auto_context()` and injected into both audit and remediation paths. They never appear in `get_pending_context` questions.
 
 ## Remediation Capabilities
 
@@ -170,20 +172,20 @@ Five templates have `llm_enhance` prompts (marked with \*) that request LLM-base
 | GV-01.01 | `GOVERNANCE.md` | Scaffold\* | Roles, decision making. `llm_enhance`. **Needs: maintainers** |
 | GV-01.02 | `MAINTAINERS.md` | Scaffold | Responsibilities, criteria. **Needs: maintainers** |
 | GV-04.01 | `CODEOWNERS` | Scaffold | Single global ownership rule. **Needs: maintainers** |
-| LE-01.01 | `LICENSE` | Production | Full MIT license text. `project_update`. Hardcoded to MIT |
+| LE-01.01 | `LICENSE` | Production | MIT (default), Apache-2.0, BSD-3-Clause — selected via `license_type` context. `project_update` |
 | BR-07.01 | `.gitignore` | Production | Covers .env, \*.pem, \*.key, cloud creds (AWS/GCP/Azure) |
 | DO-03.01 | `SUPPORT.md` | Production | Getting help, scope table, EOL policy with 30-day notice |
 | DO-04.01 | `SUPPORT.md` | Production | Support scope variant (no-op if DO-03.01 ran first) |
 | DO-05.01 | `SUPPORT.md` | Production | End-of-support variant (no-op if DO-03.01 ran first) |
 | SA-01.01 | `ARCHITECTURE.md` | Scaffold\* | Components/actors/data flow — all example data. `llm_enhance` |
 | SA-02.01 | `API.md` | Scaffold\* | Interface tables, usage examples — all placeholder. `llm_enhance` |
-| SA-03.02 | `THREAT_MODEL.md` | Production | Full STRIDE: 5 assets, 9 threats with mitigations. `project_update` |
+| SA-03.02 | `THREAT_MODEL.md` | Production\* | Full STRIDE: 5 assets, 9 threats with mitigations. `llm_enhance`, `project_update` |
 
 #### CI Workflows (`.github/workflows/`)
 
 | Control | File | Quality | Notes |
 |---------|------|:-------:|-------|
-| QA-06.01 | `ci.yml` | Starter | Test step is `echo` placeholder. Needs language/framework adaptation |
+| QA-06.01 | `ci.yml` | Production | Ecosystem-aware: Python (pytest), Node (npm test), Rust (cargo test), Go (go test). Auto-detected via `detected_ecosystem` context |
 | VM-05.02 | `sca.yml` | Production | Pinned `dependency-review-action`, `fail-on-severity: high` |
 | VM-06.02 | `sast.yml` | Production | Pinned CodeQL init/autobuild/analyze, weekly schedule |
 | QA-02.02 | `sbom.yml` | Production | Pinned syft SPDX generation + release asset upload |
@@ -193,7 +195,7 @@ Five templates have `llm_enhance` prompts (marked with \*) that request LLM-base
 
 | Control | File | Quality | Notes |
 |---------|------|:-------:|-------|
-| VM-05.03 | `.github/dependabot.yml` | Scaffold | GitHub Actions ecosystem by default; others commented out |
+| VM-05.03 | `.github/dependabot.yml` | Production | Ecosystem-aware: includes github-actions + detected ecosystem (pip/npm/cargo/gomod). Auto-detected via `detected_ecosystem` context |
 | DO-02.01 | `.github/ISSUE_TEMPLATE/bug_report.md` | Production | Standard template: reproduce, expected, actual, environment |
 
 #### Policy Documentation (`docs/`)
@@ -207,7 +209,7 @@ Five templates have `llm_enhance` prompts (marked with \*) that request LLM-base
 | VM-04.02 | `docs/VEX-POLICY.md` | Scaffold | VEX purpose, publication methods, OpenVEX/CISA links |
 | VM-05.01 | `docs/SCA-POLICY.md` | Production | Scanning frequency, 4-severity thresholds, exception process |
 | VM-06.01 | `docs/SAST-POLICY.md` | Production | 3 scanning triggers, severity handling, exception process |
-| QA-06.02 | `docs/TESTING.md` | Starter | `make test` is TODO placeholder. Correct structure |
+| QA-06.02 | `docs/TESTING.md` | Production | Ecosystem-aware: Python (pytest/coverage), Node (npm test/jest), Rust (cargo test), Go (go test/race). Auto-detected via `detected_ecosystem` context |
 | QA-06.03 | `docs/TEST-REQUIREMENTS.md` | Scaffold | Contribution test requirements; `make test` placeholder |
 
 ### API Calls (7 actions)
@@ -261,25 +263,27 @@ Verification-only controls that check conditions which already exist or can't be
 
 | Rating | Count | Description |
 |--------|:-----:|-------------|
-| Production-ready | 15 | Substantive content following best practices — minimal customization needed |
-| Good scaffold | 14 | Correct structure — needs project-specific content added |
-| Starter | 2 | Minimal placeholder — must be customized before use |
+| Production-ready | 19 | Substantive content following best practices — minimal customization needed |
+| Good scaffold | 12 | Correct structure — needs project-specific content added |
+| Starter | 0 | Minimal placeholder — must be customized before use |
 
-**5 templates with `llm_enhance` prompts**: README.md, SECURITY.md, GOVERNANCE.md, ARCHITECTURE.md, API.md — these request LLM-based customization using project context.
+**6 templates with `llm_enhance` prompts**: README.md, SECURITY.md, GOVERNANCE.md, ARCHITECTURE.md, API.md, THREAT_MODEL.md — these request LLM-based customization using project context.
 
 ### Known Limitations
 
 - Templates use `$OWNER`, `$REPO`, `$BRANCH` variables resolved from git remote — may be wrong for forks or non-standard remote names
 - `security@$OWNER.github.io` in SECURITY.md is a placeholder email — almost always needs customization
-- LICENSE is hardcoded to MIT — no license type selection
-- GitHub Actions workflows (`ci.yml` especially) are generic starters — need language/framework adaptation
+- LICENSE template auto-detects existing license type; defaults to MIT if no LICENSE file is present
+- CI workflows, dependabot, and testing docs auto-detect ecosystem from manifest files — falls back to generic starter if ecosystem is unrecognized
 - `release-signing.yml` uses `subject-path: '.'` which should be customized to actual release artifacts
 - `llm_enhance` prompts are captured in templates but the LLM integration path isn't fully wired in the remediation executor
 - Three SUPPORT.md controls (DO-03.01, DO-04.01, DO-05.01) each create the same file with different templates — only the first to run takes effect due to `overwrite = false`
 - API call remediations require `gh` CLI authentication with appropriate scopes (`repo`, `admin:org` for MFA enforcement)
 - `zizmor --fix=all` applies all fixes including potentially unsafe ones — review changes before committing
 - Manual-only controls have varying depth of guidance (some have 2 steps, some have 6)
-- `dependabot.yml` only enables `github-actions` ecosystem by default — other ecosystems (npm, pip, etc.) need manual addition
+- `dependabot.yml` auto-detects project ecosystem — falls back to `github-actions` only if ecosystem is unrecognized
+- Ecosystem detection maps primary language to ecosystem (python→python, javascript/typescript→node, go→go, rust→rust, java→java, ruby→ruby); unrecognized languages get no ecosystem
+- **Monorepo limitation:** Language and ecosystem auto-detection only checks manifest files at the repository root (e.g., `pyproject.toml`, `go.mod`, `package.json`). Nested service directories are not scanned. In a monorepo with multiple languages, only the root-level manifest is detected — check order favors Go and Rust over Python and JavaScript. Use `confirm_project_context(detected_ecosystem="...")` to override if the wrong ecosystem is selected
 
 ## External Tool Dependencies
 

--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -232,6 +232,82 @@ updates:
   #     prefix: "deps"
 """
 
+[templates.dependabot_python]
+description = "Dependabot configuration for Python projects"
+content = """version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+"""
+
+[templates.dependabot_node]
+description = "Dependabot configuration for Node.js projects"
+content = """version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+"""
+
+[templates.dependabot_rust]
+description = "Dependabot configuration for Rust projects"
+content = """version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+"""
+
+[templates.dependabot_go]
+description = "Dependabot configuration for Go projects"
+content = """version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+"""
+
 [templates.readme_basic]
 description = "Basic README.md template with substantive default content"
 content = """# $REPO
@@ -292,6 +368,233 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+"""
+
+[templates.license_apache]
+description = "Apache License 2.0 template"
+content = """
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright $YEAR $OWNER
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+[templates.license_bsd3]
+description = "BSD 3-Clause License template"
+content = """BSD 3-Clause License
+
+Copyright (c) $YEAR, $OWNER
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 [templates.threat_model_basic]
@@ -609,6 +912,149 @@ jobs:
       # TODO: Replace with your project's test command
       - name: Run tests
         run: echo "Add your test command here"
+"""
+
+[templates.ci_python_workflow]
+description = "Python CI workflow with pytest"
+content = """name: CI Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/ -v
+"""
+
+[templates.ci_node_workflow]
+description = "Node.js CI workflow with npm test"
+content = """name: CI Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+"""
+
+[templates.ci_rust_workflow]
+description = "Rust CI workflow with cargo test"
+content = """name: CI Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1
+
+      - name: Run tests
+        run: cargo test --all-features
+
+      - name: Run clippy
+        run: cargo clippy --all-features -- -D warnings
+"""
+
+[templates.ci_go_workflow]
+description = "Go CI workflow with go test"
+content = """name: CI Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Run vet
+        run: go vet ./...
 """
 
 [templates.sbom_workflow]
@@ -1108,6 +1554,183 @@ make test
 - Aim for meaningful coverage of critical paths and edge cases
 """
 
+[templates.testing_python]
+description = "Testing instructions for Python projects"
+content = """# Testing
+
+## Prerequisites
+
+- Python 3.11 or later
+- Install development dependencies:
+
+```bash
+pip install -e ".[dev]"
+# or with uv:
+uv pip install -e ".[dev]"
+```
+
+## Running Tests
+
+```bash
+# Run the full test suite
+pytest tests/ -v
+
+# Run with coverage
+pytest tests/ --cov --cov-report=term-missing
+
+# Run a specific test file
+pytest tests/test_example.py -v
+
+# Run tests matching a pattern
+pytest tests/ -k "test_pattern" -v
+```
+
+## Test Requirements
+
+- All pull requests must include tests for new functionality
+- Bug fixes should include a regression test
+- Tests must pass in CI before a pull request can be merged
+
+## Writing Tests
+
+- Place tests in the `tests/` directory
+- Follow existing test patterns and naming conventions
+- Use pytest fixtures for shared test setup
+- Aim for meaningful coverage of critical paths and edge cases
+"""
+
+[templates.testing_node]
+description = "Testing instructions for Node.js projects"
+content = """# Testing
+
+## Prerequisites
+
+- Node.js 18 or later
+- Install dependencies:
+
+```bash
+npm ci
+```
+
+## Running Tests
+
+```bash
+# Run the full test suite
+npm test
+
+# Run with coverage
+npm run test:coverage
+
+# Run in watch mode during development
+npm run test:watch
+
+# Run a specific test file
+npx jest tests/example.test.js
+```
+
+## Test Requirements
+
+- All pull requests must include tests for new functionality
+- Bug fixes should include a regression test
+- Tests must pass in CI before a pull request can be merged
+
+## Writing Tests
+
+- Place tests alongside source files (`*.test.js` / `*.spec.js`) or in a `tests/` directory
+- Follow existing test patterns and naming conventions
+- Use describe/it blocks to organize test cases
+- Aim for meaningful coverage of critical paths and edge cases
+"""
+
+[templates.testing_rust]
+description = "Testing instructions for Rust projects"
+content = """# Testing
+
+## Prerequisites
+
+- Rust stable toolchain (install via [rustup](https://rustup.rs/))
+
+## Running Tests
+
+```bash
+# Run the full test suite
+cargo test
+
+# Run with all features enabled
+cargo test --all-features
+
+# Run a specific test
+cargo test test_name
+
+# Run tests with output shown
+cargo test -- --nocapture
+
+# Run only integration tests
+cargo test --test '*'
+
+# Run benchmarks (nightly)
+cargo bench
+```
+
+## Test Requirements
+
+- All pull requests must include tests for new functionality
+- Bug fixes should include a regression test
+- Tests must pass in CI before a pull request can be merged
+
+## Writing Tests
+
+- Place unit tests in the same file as the code using `#[cfg(test)]` modules
+- Place integration tests in the `tests/` directory
+- Use `#[test]` attribute for test functions
+- Aim for meaningful coverage of critical paths and edge cases
+"""
+
+[templates.testing_go]
+description = "Testing instructions for Go projects"
+content = """# Testing
+
+## Prerequisites
+
+- Go 1.21 or later
+
+## Running Tests
+
+```bash
+# Run the full test suite
+go test ./...
+
+# Run with verbose output
+go test -v ./...
+
+# Run with race detector
+go test -race ./...
+
+# Run with coverage
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out
+
+# Run a specific test
+go test -run TestName ./...
+
+# Run benchmarks
+go test -bench=. ./...
+```
+
+## Test Requirements
+
+- All pull requests must include tests for new functionality
+- Bug fixes should include a regression test
+- Tests must pass in CI before a pull request can be merged
+
+## Writing Tests
+
+- Place tests in `*_test.go` files alongside the source code
+- Follow Go testing conventions (`TestXxx`, `BenchmarkXxx`)
+- Use table-driven tests for parameterized testing
+- Aim for meaningful coverage of critical paths and edge cases
+"""
+
 [templates.test_requirements_contributing]
 description = "Test requirements section for CONTRIBUTING.md"
 content = """# Test Requirements for Contributions
@@ -1247,6 +1870,11 @@ detect = [
     { handler = "file_exists", files = ["azure-pipelines.yml"], value_if_pass = "azure" },
     { handler = "file_exists", files = [".travis.yml"], value_if_pass = "travis" },
 ]
+
+# NOTE: detected_ecosystem and license_type are auto-detected by
+# darnit.context.auto_detect (collect_auto_context) without prompting.
+# They do NOT need TOML [context.*] definitions because they never go
+# through get_pending_context / confirm_project_context.
 
 # =============================================================================
 # Shared Handlers (cached across controls within a single audit run)
@@ -2334,6 +2962,21 @@ steps = [
 [controls."OSPS-LE-01.01".remediation]
 safe = true
 dry_run_supported = true
+strategy = "first_match"
+
+[[controls."OSPS-LE-01.01".remediation.handlers]]
+handler = "file_create"
+path = "LICENSE"
+template = "license_apache"
+overwrite = false
+when = { license_type = "apache-2.0" }
+
+[[controls."OSPS-LE-01.01".remediation.handlers]]
+handler = "file_create"
+path = "LICENSE"
+template = "license_bsd3"
+overwrite = false
+when = { license_type = "bsd-3-clause" }
 
 [[controls."OSPS-LE-01.01".remediation.handlers]]
 handler = "file_create"
@@ -3175,24 +3818,47 @@ steps = [
 [controls."OSPS-QA-06.01".remediation]
 safe = true
 dry_run_supported = true
+strategy = "first_match"
 
+[[controls."OSPS-QA-06.01".remediation.handlers]]
+handler = "file_create"
+path = ".github/workflows/ci.yml"
+template = "ci_python_workflow"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "python" }
+
+[[controls."OSPS-QA-06.01".remediation.handlers]]
+handler = "file_create"
+path = ".github/workflows/ci.yml"
+template = "ci_node_workflow"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "node" }
+
+[[controls."OSPS-QA-06.01".remediation.handlers]]
+handler = "file_create"
+path = ".github/workflows/ci.yml"
+template = "ci_rust_workflow"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "rust" }
+
+[[controls."OSPS-QA-06.01".remediation.handlers]]
+handler = "file_create"
+path = ".github/workflows/ci.yml"
+template = "ci_go_workflow"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "go" }
+
+# Default fallback: generic CI workflow when ecosystem is unknown
 [[controls."OSPS-QA-06.01".remediation.handlers]]
 handler = "file_create"
 path = ".github/workflows/ci.yml"
 template = "ci_test_workflow"
 overwrite = false
 create_dirs = true
-
-[[controls."OSPS-QA-06.01".remediation.handlers]]
-handler = "manual"
-steps = [
-    "Create a CI workflow file at .github/workflows/test.yml",
-    "Add a test step appropriate for your language: 'npm test', 'pytest', 'go test ./...', 'cargo test', etc.",
-    "Configure triggers: 'on: [push, pull_request]' for the main branch",
-    "Verify the workflow passes by pushing a commit and checking the Actions tab",
-]
-docs_url = "https://docs.github.com/en/actions/automating-builds-and-tests"
-context_hints = ["ci.provider"]
 
 # =============================================================================
 # Level 2 Controls - Vulnerability Management (VM)
@@ -3720,21 +4386,47 @@ steps = [
 [controls."OSPS-QA-06.02".remediation]
 safe = true
 dry_run_supported = true
+strategy = "first_match"
 
+[[controls."OSPS-QA-06.02".remediation.handlers]]
+handler = "file_create"
+path = "docs/TESTING.md"
+template = "testing_python"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "python" }
+
+[[controls."OSPS-QA-06.02".remediation.handlers]]
+handler = "file_create"
+path = "docs/TESTING.md"
+template = "testing_node"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "node" }
+
+[[controls."OSPS-QA-06.02".remediation.handlers]]
+handler = "file_create"
+path = "docs/TESTING.md"
+template = "testing_rust"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "rust" }
+
+[[controls."OSPS-QA-06.02".remediation.handlers]]
+handler = "file_create"
+path = "docs/TESTING.md"
+template = "testing_go"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "go" }
+
+# Default fallback: generic testing instructions when ecosystem is unknown
 [[controls."OSPS-QA-06.02".remediation.handlers]]
 handler = "file_create"
 path = "docs/TESTING.md"
 template = "testing_instructions"
 overwrite = false
 create_dirs = true
-
-[[controls."OSPS-QA-06.02".remediation.handlers]]
-handler = "manual"
-steps = [
-    "Review the generated docs/TESTING.md and customize for your project",
-    "Replace placeholder test commands with your actual test commands",
-    "Document any environment setup required (databases, env vars, fixtures)",
-]
 
 [controls."OSPS-QA-06.03"]
 name = "TestRequirements"
@@ -3991,8 +4683,41 @@ steps = [
 [controls."OSPS-VM-05.03".remediation]
 safe = true
 dry_run_supported = true
+strategy = "first_match"
 
-# Declarative file creation remediation
+[[controls."OSPS-VM-05.03".remediation.handlers]]
+handler = "file_create"
+path = ".github/dependabot.yml"
+template = "dependabot_python"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "python" }
+
+[[controls."OSPS-VM-05.03".remediation.handlers]]
+handler = "file_create"
+path = ".github/dependabot.yml"
+template = "dependabot_node"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "node" }
+
+[[controls."OSPS-VM-05.03".remediation.handlers]]
+handler = "file_create"
+path = ".github/dependabot.yml"
+template = "dependabot_rust"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "rust" }
+
+[[controls."OSPS-VM-05.03".remediation.handlers]]
+handler = "file_create"
+path = ".github/dependabot.yml"
+template = "dependabot_go"
+overwrite = false
+create_dirs = true
+when = { detected_ecosystem = "go" }
+
+# Default fallback: github-actions only when ecosystem is unknown
 [[controls."OSPS-VM-05.03".remediation.handlers]]
 handler = "file_create"
 path = ".github/dependabot.yml"
@@ -4601,6 +5326,7 @@ handler = "file_create"
 path = "THREAT_MODEL.md"
 template = "threat_model_basic"
 overwrite = false
+llm_enhance = "Customize this threat model: run threat discovery to identify the project's actual entry points, data stores, authentication mechanisms, and sensitive data. Replace the generic STRIDE examples with threats specific to the discovered assets and architecture."
 
 [controls."OSPS-SA-03.02".remediation.project_update]
 set = { "security.threat_model.path" = "THREAT_MODEL.md" }

--- a/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
+++ b/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
@@ -451,8 +451,17 @@ def _apply_declarative_remediation(
         Dict with control_id, status, and result details
     """
     try:
-        # Load confirmed context values for ${context.*} substitution
+        # Start with auto-detected context (platform, ci_provider,
+        # detected_ecosystem, license_type) so that ``when`` clauses on
+        # remediation handlers can match without explicit user confirmation.
         context_values: dict[str, Any] = {}
+        try:
+            from darnit.context.auto_detect import collect_auto_context
+            context_values = collect_auto_context(local_path)
+        except Exception:
+            pass  # Auto-detection is best-effort
+
+        # Confirmed context overrides auto-detected values
         try:
             from darnit.config.context_storage import load_context
             all_context = load_context(local_path)

--- a/packages/darnit/src/darnit/config/context_storage.py
+++ b/packages/darnit/src/darnit/config/context_storage.py
@@ -607,7 +607,15 @@ def _run_detect_pipeline(
                 continue
 
             if result.status == HandlerResultStatus.PASS and result.evidence:
-                # Extract detected value from evidence
+                # First check handler config for value_if_pass
+                value_if_pass = handler_config.get("value_if_pass")
+                if value_if_pass is not None:
+                    return ContextValue.auto_detected(
+                        value=value_if_pass,
+                        method=f"detect_pipeline:{invocation.handler}",
+                        confidence=result.confidence,
+                    )
+                # Fallback: extract value from evidence
                 detected_value = result.evidence.get("value") or result.evidence.get(
                     key
                 )

--- a/packages/darnit/src/darnit/context/auto_detect.py
+++ b/packages/darnit/src/darnit/context/auto_detect.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+from pathlib import Path
 from typing import Any
 
 from darnit.core.logging import get_logger
@@ -85,7 +86,11 @@ def detect_ci_provider(local_path: str) -> str | None:
 
 
 def detect_primary_language(local_path: str) -> str | None:
-    """Detect primary language from manifest files.
+    """Detect primary language from manifest files at the repo root.
+
+    Only checks the root directory — nested manifests (e.g. in monorepo
+    service directories) are not scanned.  Check order favours more specific
+    indicators (go.mod, Cargo.toml) over common ones (package.json).
 
     Returns:
         "python", "go", "rust", "javascript", "typescript", "java", or None.
@@ -160,6 +165,56 @@ def detect_languages(local_path: str) -> list[str]:
     return languages
 
 
+def detect_license_type(local_path: str) -> str | None:
+    """Detect license type from LICENSE file content.
+
+    Reads the first 500 characters of the LICENSE file and pattern-matches
+    against known license headers.
+
+    Returns:
+        "apache-2.0", "mit", "bsd-3-clause", "gpl", or None if unknown.
+    """
+    license_path = Path(local_path) / "LICENSE"
+    if not license_path.is_file():
+        # Also check LICENSE.md, LICENSE.txt
+        for alt in ("LICENSE.md", "LICENSE.txt"):
+            alt_path = Path(local_path) / alt
+            if alt_path.is_file():
+                license_path = alt_path
+                break
+        else:
+            return None
+
+    try:
+        content = license_path.read_text(encoding="utf-8", errors="replace")[:500]
+    except OSError:
+        return None
+
+    content_lower = content.lower()
+    if "apache license" in content_lower:
+        return "apache-2.0"
+    if "mit license" in content_lower or "permission is hereby granted, free of charge" in content_lower:
+        return "mit"
+    if "bsd 3-clause" in content_lower or "bsd-3-clause" in content_lower:
+        return "bsd-3-clause"
+    if "gnu general public license" in content_lower:
+        return "gpl"
+
+    return None
+
+
+# Map primary_language to ecosystem names used in TOML when clauses
+_LANGUAGE_TO_ECOSYSTEM: dict[str, str] = {
+    "python": "python",
+    "javascript": "node",
+    "typescript": "node",
+    "go": "go",
+    "rust": "rust",
+    "java": "java",
+    "ruby": "ruby",
+}
+
+
 def collect_auto_context(local_path: str) -> dict[str, Any]:
     """Collect all auto-detectable context. Returns flat dict with bare keys.
 
@@ -179,10 +234,18 @@ def collect_auto_context(local_path: str) -> dict[str, Any]:
     primary_language = detect_primary_language(local_path)
     if primary_language:
         context["primary_language"] = primary_language
+        # Derive ecosystem from primary language
+        ecosystem = _LANGUAGE_TO_ECOSYSTEM.get(primary_language)
+        if ecosystem:
+            context["detected_ecosystem"] = ecosystem
 
     languages = detect_languages(local_path)
     # Always include languages (even empty list) so when clauses can evaluate
     context["languages"] = languages
+
+    license_type = detect_license_type(local_path)
+    if license_type:
+        context["license_type"] = license_type
 
     if context:
         logger.debug("Auto-detected context: %s", context)


### PR DESCRIPTION
## Summary

- **Ecosystem and license are now auto-detected** from project files instead of prompting via `get_pending_context`. Ecosystem is derived from manifest files (pyproject.toml → python, package.json → node, etc.) and license type is detected from LICENSE file content (Apache-2.0, MIT, BSD-3-Clause).
- **Wires `collect_auto_context()` into the remediation orchestrator** so `when` clauses on remediation handlers (e.g. `when = { detected_ecosystem = "python" }`) match at both audit and remediation time without requiring explicit user confirmation.
- **Fixes `value_if_pass` dead code** in `_run_detect_pipeline()` — the TOML detect pipelines used `value_if_pass` on handler entries but the pipeline never extracted it, causing ci_provider and has_releases auto-detection via TOML to silently fail.
- **Removes `[context.detected_ecosystem]` and `[context.license_type]` sections** from TOML so `get_pending_context` no longer asks about them.
- **Documents monorepo limitation** — language detection only checks root-level manifests.

## Test plan

- [x] `uv run ruff check .` — all checks pass
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — 956 passed (1 pre-existing unrelated failure)
- [x] `uv run python scripts/validate_sync.py --verbose` — all validations pass
- [x] Manual: `collect_auto_context('.')` returns `detected_ecosystem: "python"` and `license_type: "apache-2.0"` for this repo
- [x] Manual: `get_pending_context('.')` no longer includes `detected_ecosystem` or `license_type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)