### PR TITLE
fix: show actionable error when gh CLI is missing

### DIFF
--- a/packages/darnit/src/darnit/core/utils.py
+++ b/packages/darnit/src/darnit/core/utils.py
@@ -11,6 +11,11 @@ from darnit.core.logging import get_logger
 
 logger = get_logger("utils")
 
+_GH_CLI_MISSING_MESSAGE = (
+    "GitHub CLI (gh) not found. Install it from https://cli.github.com/ "
+    "and run 'gh auth login' to authenticate."
+)
+
 
 def gh_api(endpoint: str) -> dict[str, Any]:
     """Execute a GitHub API call using the gh CLI.
@@ -18,11 +23,15 @@ def gh_api(endpoint: str) -> dict[str, Any]:
     Raises:
         RuntimeError: If the API call fails or returns invalid JSON.
     """
-    result = subprocess.run(
-        ["gh", "api", endpoint],
-        capture_output=True,
-        text=True
-    )
+    try:
+        result = subprocess.run(
+            ["gh", "api", endpoint],
+            capture_output=True,
+            text=True
+        )
+    except FileNotFoundError:
+        raise RuntimeError(_GH_CLI_MISSING_MESSAGE) from None
+
     if result.returncode != 0:
         error_msg = result.stderr.strip() or "Unknown error"
         raise RuntimeError(f"gh api failed: {error_msg}")
@@ -278,7 +287,10 @@ def _gh_enrich(owner: str, repo: str, cwd: str) -> dict[str, Any]:
             "is_private": data.get("isPrivate", False),
             "default_branch": data.get("defaultBranchRef", {}).get("name", "main"),
         }
-    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError,
+    except FileNotFoundError:
+        logger.debug(_GH_CLI_MISSING_MESSAGE)
+        return {}
+    except (subprocess.TimeoutExpired, json.JSONDecodeError,
             OSError, subprocess.SubprocessError) as e:
         logger.debug(f"gh enrichment failed for {owner}/{repo}: {type(e).__name__}: {e}")
         return {}

--- a/tests/darnit/core/test_utils.py
+++ b/tests/darnit/core/test_utils.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -10,6 +11,8 @@ from darnit.core.utils import (
     file_exists,
     get_git_commit,
     get_git_ref,
+    gh_api,
+    gh_api_safe,
     make_result,
     read_file,
     validate_local_path,
@@ -228,3 +231,22 @@ class TestGitRef:
         """Test getting ref from non-git directory returns None."""
         ref = get_git_ref(str(temp_dir))
         assert ref is None
+
+
+class TestGithubCliErrors:
+    """Tests for GitHub CLI helper failures."""
+
+    @pytest.mark.unit
+    def test_gh_api_missing_cli_shows_helpful_message(self):
+        """Missing gh CLI should raise a user-facing RuntimeError."""
+        with (
+            patch("darnit.core.utils.subprocess.run", side_effect=FileNotFoundError),
+            pytest.raises(RuntimeError, match=r"GitHub CLI \(gh\) not found"),
+        ):
+            gh_api("repos/kusari-oss/darnit")
+
+    @pytest.mark.unit
+    def test_gh_api_safe_missing_cli_returns_none(self):
+        """Safe helper should swallow missing gh CLI errors."""
+        with patch("darnit.core.utils.subprocess.run", side_effect=FileNotFoundError):
+            assert gh_api_safe("repos/kusari-oss/darnit") is None


### PR DESCRIPTION
## Summary
- raise a helpful RuntimeError from `gh_api()` when the `gh` executable is missing
- reuse the same message for `_gh_enrich()` debug logging so the failure mode is clearer during repo detection
- add unit tests covering both the direct error path and the safe helper fallback

## Verification
- `uv run pytest tests/darnit/core/test_utils.py -v`
- `uv run ruff check packages/darnit/src/darnit/core/utils.py tests/darnit/core/test_utils.py`
- `git diff --check`

Closes #104