### PR TITLE
infra: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a bug in darnit
+labels: bug
+---
+
+## Description
+
+<!-- A clear description of the bug -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened -->
+
+## Environment
+
+- darnit version:
+- Python version:
+- OS:
+
+## Additional Context
+
+<!-- Logs, screenshots, or anything else that helps reproduce the problem -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Description
+
+<!-- A clear description of the feature -->
+
+## Motivation
+
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Proposed Solution
+
+<!-- How should this work? -->
+
+## Alternatives Considered
+
+<!-- Any alternative approaches you considered -->
+
+## Additional Context
+
+<!-- Mockups, examples, related issues, or anything else useful -->


### PR DESCRIPTION
## Summary
- add a bug report issue template
- add a feature request issue template
- keep blank issues enabled with a simple issue template config

## Verification
- `git diff --check`

Closes #103