### PR TITLE
fix: enforce AskUserQuestion usage for pending context collection

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -4023,13 +4023,13 @@ limit = 4
 append_directive = true
 description = """Batch context collection wizard. Returns up to 4 questions at a time.
 
-**IMPORTANT — You MUST follow this workflow:**
-1. Call this tool. It returns up to 4 questions in "ask_user_batch".
-2. Pass "ask_user_batch.questions" directly to AskUserQuestion — do NOT paraphrase, reorder, or modify.
+MANDATORY WORKFLOW — your next action after calling this tool MUST be calling AskUserQuestion:
+1. Call this tool. It returns "ask_user_batch" — an array of AskUserQuestion-compatible question objects.
+2. Call AskUserQuestion with questions=<ask_user_batch>. Pass the array VERBATIM. Do NOT render as text.
 3. After the user answers, use "answer_mapping" to call confirm_project_context() for EACH answer.
 4. Call this tool again for the next batch. Repeat until status is "complete".
 
-Do NOT pre-fill or suggest answers. Do NOT guess values from git history or repo metadata.
+Do NOT pre-fill or suggest answers. Do NOT summarize questions as text. ALWAYS use AskUserQuestion.
 """
 
 [mcp.tools.generate_threat_model]

--- a/packages/darnit-baseline/src/darnit_baseline/tools.py
+++ b/packages/darnit-baseline/src/darnit_baseline/tools.py
@@ -468,19 +468,20 @@ _CONTEXT_KEY_ORDER = [
     "ci_provider",
 ]
 
-_LLM_DIRECTIVE = """
+_LLM_DIRECTIVE_PREFIX = """⚠️ MANDATORY: Your next action MUST be calling the AskUserQuestion tool.
+
+Copy "ask_user_batch" below verbatim as the "questions" parameter to AskUserQuestion.
+Do NOT render these questions as text. Do NOT paraphrase. Do NOT summarize.
+You MUST call the AskUserQuestion tool now.
+
+After the user answers, use "answer_mapping" to call confirm_project_context() for EACH answer:
+- "Yes" / "No" for booleans → pass true / false (not strings)
+- Selected option label for enums → pass the label as a string
+- "Other" selections → pass the user's typed value
+Then call get_pending_context() again for the next batch (if any remain).
+
 ---
-IMPORTANT — YOU MUST FOLLOW THESE RULES:
-1. Use the AskUserQuestion tool with the EXACT contents of "ask_user_batch.questions".
-   Pass the array directly — do NOT paraphrase, reorder, or modify any question text or options.
-2. After the user answers, use "answer_mapping" to call confirm_project_context() for EACH answer.
-   Map user selections to confirm_project_context values:
-   - "Yes" / "No" for booleans → pass true / false (not strings)
-   - Selected option label for enums → pass the label as a string
-   - "Other" selections → pass the user's typed value
-3. Then call get_pending_context() again for the next batch (if any remain).
-4. Do NOT guess, suggest, or pre-fill answers from the repository owner, git history, or your own knowledge.
----"""
+"""
 
 
 def get_pending_context(
@@ -494,15 +495,13 @@ def get_pending_context(
 ) -> str:
     """Get context values that would improve audit accuracy.
 
-    Returns up to `limit` questions per call as a batch. You MUST follow this workflow:
+    Returns up to `limit` questions per call as a batch.
 
-    1. Call get_pending_context() — it returns up to 4 questions with an "ask_user_batch" field.
-    2. Pass "ask_user_batch.questions" directly to the AskUserQuestion tool.
-       Do NOT paraphrase, reorder, or modify any question text or options.
-    3. After the user answers, use "answer_mapping" to call confirm_project_context()
-       for EACH answer.
-    4. Call get_pending_context() again for the next batch.
-    5. Repeat until status is "complete".
+    MANDATORY WORKFLOW — your next action MUST be calling AskUserQuestion:
+    1. Call this tool. It returns "ask_user_batch" — an array ready for AskUserQuestion.
+    2. Call AskUserQuestion(questions=<ask_user_batch>). Pass VERBATIM. Do NOT render as text.
+    3. After the user answers, use "answer_mapping" to call confirm_project_context() per answer.
+    4. Call get_pending_context() again for the next batch. Repeat until status is "complete".
 
     Parameters:
     - `local_path`: Path to repository (default: ".")
@@ -513,7 +512,7 @@ def get_pending_context(
     - `limit`: Max questions to return per batch (default: 4). Use 0 for all.
 
     Returns:
-        JSON with structured question(s), ask_user_batch for AskUserQuestion,
+        JSON with ask_user_batch (pass directly to AskUserQuestion),
         answer_mapping for confirm_project_context, and a progress indicator.
     """
     from darnit.config.context_storage import get_pending_context as _get_pending
@@ -605,22 +604,23 @@ def get_pending_context(
                 "answered": answered,
                 "total": total,
             },
-            "instructions": (
-                "Pass ask_user_batch.questions directly to AskUserQuestion. "
-                "Then use answer_mapping to call confirm_project_context() for each answer. "
-                "Then call get_pending_context() again for the next batch."
-            ),
-            "questions": questions,
         }
 
         if batch_questions:
-            response["ask_user_batch"] = {"questions": batch_questions}
+            response["ask_user_batch"] = batch_questions
             response["answer_mapping"] = answer_mapping
 
-        result = json.dumps(response, indent=2)
+        # Include raw question details only when no ask_user_batch
+        # (i.e., free_text questions that can't use AskUserQuestion)
+        if not batch_questions:
+            response["questions"] = questions
 
-        if append_directive:
-            result += _LLM_DIRECTIVE
+        result_json = json.dumps(response, indent=2)
+
+        if append_directive and batch_questions:
+            result = _LLM_DIRECTIVE_PREFIX + result_json
+        else:
+            result = result_json
 
         return result
 
@@ -984,6 +984,25 @@ def remediate_audit_findings(
     detected_owner, detected_repo = detect_owner_repo(str(repo_path))
     owner = owner or detected_owner
     repo = repo or detected_repo
+
+    # Guard: check for unresolved context before remediating
+    try:
+        from darnit.config.context_storage import get_pending_context as _get_pending
+
+        pending = _get_pending(
+            local_path=str(repo_path), owner=owner, repo=repo,
+        )
+        if pending:
+            keys = [p.key for p in pending]
+            return (
+                "⚠️ Cannot remediate yet — there are unresolved context questions.\n\n"
+                f"**Pending context keys**: {', '.join(keys)}\n\n"
+                "Please call `get_pending_context()` first to collect the missing "
+                "project context, then confirm each answer with `confirm_project_context()`. "
+                "Once all context is resolved, call `remediate_audit_findings()` again."
+            )
+    except Exception:
+        pass  # If context check fails, proceed with remediation anyway
 
     try:
         result = apply_remediations(

--- a/tests/darnit_baseline/test_get_pending_context.py
+++ b/tests/darnit_baseline/test_get_pending_context.py
@@ -16,7 +16,7 @@ from darnit.config.context_schema import (
 )
 from darnit_baseline.tools import (
     _CONTEXT_KEY_ORDER,
-    _LLM_DIRECTIVE,
+    _LLM_DIRECTIVE_PREFIX,
     _build_context_question,
     get_pending_context,
 )
@@ -41,8 +41,14 @@ def _make_pending(count: int) -> list[ContextPromptRequest]:
 
 
 def _parse_json_from_result(result: str) -> dict:
-    """Strip directive footer and parse JSON from get_pending_context result."""
-    json_str = result.split("\n---")[0].rstrip()
+    """Strip directive prefix/footer and parse JSON from get_pending_context result."""
+    # The directive prefix ends with "---\n", JSON starts after that
+    if "---\n" in result:
+        # Find the JSON portion (starts with '{')
+        idx = result.index("{")
+        json_str = result[idx:]
+    else:
+        json_str = result
     return json.loads(json_str)
 
 
@@ -52,7 +58,7 @@ class TestGetPendingContextPagination:
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
     def test_default_limit_returns_four_questions(self, mock_get, mock_path) -> None:
-        """Default limit=4 returns up to four questions."""
+        """Default limit=4 returns up to four questions in ask_user_batch."""
         mock_path.return_value.resolve.return_value = "/tmp/repo"
         mock_get.return_value = _make_pending(5)
 
@@ -60,7 +66,7 @@ class TestGetPendingContextPagination:
         data = _parse_json_from_result(result)
 
         assert data["status"] == "pending"
-        assert len(data["questions"]) == 4
+        assert len(data["ask_user_batch"]) == 4
 
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
@@ -72,7 +78,7 @@ class TestGetPendingContextPagination:
         result = get_pending_context(local_path="/tmp/repo")
         data = _parse_json_from_result(result)
 
-        assert len(data["questions"]) == 2
+        assert len(data["ask_user_batch"]) == 2
 
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
@@ -85,7 +91,7 @@ class TestGetPendingContextPagination:
         data = _parse_json_from_result(result)
 
         assert data["status"] == "pending"
-        assert len(data["questions"]) == 5
+        assert len(data["ask_user_batch"]) == 5
 
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
@@ -97,7 +103,7 @@ class TestGetPendingContextPagination:
         result = get_pending_context(local_path="/tmp/repo", limit=3)
         data = _parse_json_from_result(result)
 
-        assert len(data["questions"]) == 3
+        assert len(data["ask_user_batch"]) == 3
 
 
 class TestGetPendingContextProgress:
@@ -123,27 +129,27 @@ class TestGetPendingContextDirective:
 
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
-    def test_directive_appended_when_pending(self, mock_get, mock_path) -> None:
-        """LLM directive footer is appended when questions are pending."""
+    def test_directive_prepended_when_pending(self, mock_get, mock_path) -> None:
+        """LLM directive prefix is prepended when questions are pending."""
         mock_path.return_value.resolve.return_value = "/tmp/repo"
         mock_get.return_value = _make_pending(3)
 
         result = get_pending_context(local_path="/tmp/repo")
 
-        assert result.endswith(_LLM_DIRECTIVE)
-        assert "IMPORTANT" in result
-        assert "ask_user_batch" in result
+        assert result.startswith(_LLM_DIRECTIVE_PREFIX)
+        assert "MANDATORY" in result
+        assert "AskUserQuestion" in result
 
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
     def test_no_directive_when_complete(self, mock_get, mock_path) -> None:
-        """No directive footer when no questions are pending."""
+        """No directive when no questions are pending."""
         mock_path.return_value.resolve.return_value = "/tmp/repo"
         mock_get.return_value = []
 
         result = get_pending_context(local_path="/tmp/repo")
 
-        assert _LLM_DIRECTIVE not in result
+        assert _LLM_DIRECTIVE_PREFIX not in result
         data = json.loads(result)
         assert data["status"] == "complete"
 
@@ -346,7 +352,7 @@ class TestAskUserBatch:
     @patch("darnit_baseline.tools.Path")
     @patch("darnit.config.context_storage.get_pending_context")
     def test_batch_contains_all_ask_user_questions(self, mock_get, mock_path) -> None:
-        """ask_user_batch.questions aggregates per-question ask_user params."""
+        """ask_user_batch is an array of AskUserQuestion-compatible question objects."""
         mock_path.return_value.resolve.return_value = "/tmp/repo"
         mock_get.return_value = _make_pending(3)
 
@@ -354,7 +360,8 @@ class TestAskUserBatch:
         data = _parse_json_from_result(result)
 
         assert "ask_user_batch" in data
-        batch = data["ask_user_batch"]["questions"]
+        batch = data["ask_user_batch"]
+        assert isinstance(batch, list)
         assert len(batch) == 3
         # Each batch question has the AskUserQuestion structure
         for q in batch:
@@ -483,7 +490,8 @@ class TestTomlDefinitionOrder:
         result = get_pending_context(local_path="/tmp/repo", limit=0)
         data = _parse_json_from_result(result)
 
-        keys = [q["key"] for q in data["questions"]]
+        # answer_mapping preserves the order of ask_user_batch
+        keys = [m["context_key"] for m in data["answer_mapping"]]
         # Should be in TOML order: maintainers, has_subprojects, ci_provider
         assert keys == ["maintainers", "has_subprojects", "ci_provider"]
 
@@ -511,7 +519,7 @@ class TestTomlDefinitionOrder:
         result = get_pending_context(local_path="/tmp/repo", limit=0)
         data = _parse_json_from_result(result)
 
-        keys = [q["key"] for q in data["questions"]]
+        keys = [m["context_key"] for m in data["answer_mapping"]]
         assert keys == ["maintainers", "custom_key"]
 
     def test_context_key_order_has_all_eight_keys(self) -> None:


### PR DESCRIPTION
## Summary

- **Directive prefix instead of suffix**: Claude now sees `"MANDATORY: Your next action MUST be calling AskUserQuestion"` before any JSON data, preventing it from summarizing questions as plain text
- **Flat `ask_user_batch` array**: Directly passable as the `questions` parameter to `AskUserQuestion` — no more navigating `ask_user_batch.questions`
- **Remove redundant `questions` when `ask_user_batch` exists**: Eliminates the rich data Claude was using to render text summaries instead of calling the tool
- **Guard in `remediate_audit_findings`**: Checks for unresolved context and bounces the caller back to `get_pending_context()` before proceeding

## Test plan

- [x] All 24 `test_get_pending_context.py` tests pass
- [x] Full test suite passes (316 passed, 1 pre-existing upstream hash failure)
- [x] Ruff lint clean
- [ ] Manual verification: run audit + remediation flow in a test repo and confirm AskUserQuestion is called with selection options

🤖 Generated with [Claude Code](https://claude.com/claude-code)