### PR TITLE
fix: remediation fails on repos without .baseline.toml

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -3977,10 +3977,17 @@ Supports filtering by:
 - level: Maximum maturity level (1, 2, or 3). Default: 3
 - tags: Filter by domain, tags, or custom attributes (e.g., "domain=AC", "security", "severity>=7.0")
 
+Output formats:
+- "markdown" (default): Human-readable report with remediation guidance
+- "json": Full JSON with all evidence and pass history (~164K for 62 controls)
+- "summary": Compact JSON with id/status/level/details only (~5-8K for 62 controls)
+- "sarif": SARIF format for tool integration
+
 Examples:
 - Level 1 only: level=1
 - AC domain controls: tags="domain=AC"
 - Security-tagged level 2: level=2, tags="security"
+- Compact output: output_format="summary"
 """
 
 [mcp.tools.list_available_checks]
@@ -4069,6 +4076,11 @@ description = """Apply automated remediations for failed audit controls.
 missing project context (maintainers, security contact, governance model, etc.). Some remediations
 require confirmed context to generate correct files (e.g., CODEOWNERS needs maintainers).
 Gather all context before remediating.
+
+Supports optional git workflow (ignored when dry_run=True):
+- branch_name: Create/switch to this branch before applying (e.g., "fix/compliance")
+- auto_commit: Commit changes after applying (requires dry_run=false)
+- create_pr: Create a pull request after committing (requires auto_commit=true)
 """
 
 [mcp.tools.create_remediation_branch]

--- a/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
+++ b/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
@@ -258,7 +258,10 @@ def _run_baseline_checks(
         return None, error
 
     # Run checks - returns (results_list, skipped_controls_dict)
-    all_results, skipped_controls = run_checks(owner, repo, resolved_path, default_branch, level)
+    all_results, skipped_controls = run_checks(
+        owner, repo, resolved_path, default_branch, level,
+        framework_name="openssf-baseline",
+    )
 
     # Calculate summary
     summary = summarize_results(all_results)
@@ -746,7 +749,8 @@ def remediate_audit_findings(
     owner: str | None = None,
     repo: str | None = None,
     categories: list[str] | None = None,
-    dry_run: bool = True
+    dry_run: bool = True,
+    profile: str | None = None,
 ) -> str:
     """Apply automated remediations for failed audit controls.
 
@@ -760,6 +764,7 @@ def remediate_audit_findings(
         repo: Repository name (auto-detected if not provided)
         categories: Optional filter — list of category names, or ["all"]
         dry_run: If True (default), show what would be changed without applying
+        profile: Optional audit profile name to filter to profile controls only
 
     Returns:
         Markdown-formatted summary of applied or planned remediations
@@ -782,6 +787,25 @@ def remediate_audit_findings(
     framework = _get_framework_config()
     if not framework:
         return "❌ Error: Could not load framework TOML config"
+
+    # Apply profile filtering if specified
+    profile_ids: set[str] | None = None
+    if profile:
+        try:
+            from darnit.config.control_loader import load_controls_from_framework
+            from darnit.config.profile_resolver import (
+                resolve_profile,
+                resolve_profile_control_ids,
+            )
+
+            all_controls = load_controls_from_framework(framework)
+            profile_impls: dict = {}
+            if framework.audit_profiles:
+                profile_impls["openssf-baseline"] = dict(framework.audit_profiles)
+            _, profile_config = resolve_profile(profile, profile_impls)
+            profile_ids = set(resolve_profile_control_ids(profile_config, all_controls))
+        except Exception as e:
+            return f"❌ Error resolving profile '{profile}': {e}"
 
     # ------------------------------------------------------------------
     # Determine which controls failed the audit.
@@ -812,6 +836,10 @@ def remediate_audit_findings(
                 r.get("id", "") for r in audit_result.all_results if r.get("status") == "FAIL"
             }
 
+    # Apply profile filter to failed_ids
+    if profile_ids is not None and failed_ids is not None:
+        failed_ids = failed_ids & profile_ids
+
     # ------------------------------------------------------------------
     # Build the list of controls to remediate
     # ------------------------------------------------------------------
@@ -819,7 +847,9 @@ def remediate_audit_findings(
         if error:
             return f"❌ Error running audit: {error}"
         if not failed_ids:
-            return "✅ No remediations needed - all controls with available auto-fixes are passing."
+            if failed_ids is None:
+                return "❌ Audit did not produce results. Try running an audit first."
+            return "✅ No remediations needed - all controls are passing."
 
         # All failed controls that have ANY remediation in TOML
         remediable_ids = []
@@ -858,7 +888,14 @@ def remediate_audit_findings(
             )
 
     if not remediable_ids:
-        return "✅ No remediations needed - all controls with available auto-fixes are passing."
+        if failed_ids:
+            no_handler_ids = sorted(failed_ids)
+            return (
+                f"⚠️ {len(failed_ids)} control(s) failed but none have auto-fix handlers.\n\n"
+                f"**Controls without auto-fix:** {', '.join(no_handler_ids)}\n\n"
+                "These require manual remediation."
+            )
+        return "✅ No remediations needed - all controls are passing."
 
     # ------------------------------------------------------------------
     # Pre-flight context check (prompt for ALL missing context upfront)

--- a/packages/darnit-baseline/src/darnit_baseline/tools.py
+++ b/packages/darnit-baseline/src/darnit_baseline/tools.py
@@ -64,7 +64,8 @@ def audit_openssf_baseline(
               - Different fields use AND logic: domain=AC AND level=1
               - Same field repeated uses OR logic: priority=low OR priority=high
               - Bare values match against control tags dict keys
-        output_format: Output format - "markdown", "json", or "sarif". Default: "markdown"
+        output_format: Output format - "markdown", "json", "summary", or "sarif". Default: "markdown".
+              Use "summary" for compact JSON (id/status/level/details only, no evidence).
         auto_init_config: Create .project.yaml if missing. Default: True
         attest: Generate in-toto attestation after audit. Default: False
         sign_attestation: Sign attestation with Sigstore. Default: True
@@ -159,7 +160,26 @@ def audit_openssf_baseline(
     )
 
     # Format output
-    if output_format == "json":
+    if output_format == "summary":
+        # Compact JSON: only id/status/level/details — no evidence or pass_history.
+        # ~5-8K vs ~164K for full JSON with 62 controls.
+        compact_results = [
+            {
+                "id": r.get("id"),
+                "status": r.get("status"),
+                "level": r.get("level"),
+                "details": r.get("details", ""),
+            }
+            for r in results
+        ]
+        return json.dumps({
+            "owner": owner,
+            "repo": repo,
+            "level": level,
+            "summary": summary,
+            "results": compact_results,
+        }, indent=2)
+    elif output_format == "json":
         return json.dumps({
             "owner": owner,
             "repo": repo,
@@ -1013,6 +1033,9 @@ def remediate_audit_findings(
     categories: list | None = None,
     dry_run: bool = True,
     profile: str | None = None,
+    branch_name: str | None = None,
+    auto_commit: bool = False,
+    create_pr: bool = False,
 ) -> str:
     """
     Apply automated remediations for failed audit controls.
@@ -1024,6 +1047,11 @@ def remediate_audit_findings(
     - access_control, build_release, documentation, governance, legal,
       quality, security_architecture, vulnerability_management
 
+    Supports optional git workflow (ignored when dry_run=True):
+    - branch_name: Create/switch to this branch before applying (e.g., "fix/compliance")
+    - auto_commit: Commit changes after applying (requires dry_run=false)
+    - create_pr: Create a pull request after committing (requires auto_commit=true)
+
     Args:
         local_path: ABSOLUTE path to repo
         owner: GitHub org/user (auto-detected if not provided)
@@ -1031,15 +1059,22 @@ def remediate_audit_findings(
         categories: Optional filter — list of category names, or ["all"]
         dry_run: If True (default), show what would be changed without applying
         profile: Optional audit profile name to filter remediation to profile controls only
+        branch_name: Create/checkout this branch before applying remediations
+        auto_commit: Automatically commit after applying remediations
+        create_pr: Create a pull request after committing
 
     Returns:
-        Summary of applied or planned remediations
+        Summary of applied or planned remediations (with git workflow status if applicable)
     """
     from darnit_baseline.remediation import remediate_audit_findings as apply_remediations
 
     repo_path = Path(local_path).resolve()
     if not repo_path.exists():
         return f"❌ Error: Repository path not found: {repo_path}"
+
+    # Validate git workflow param combinations
+    if create_pr and not auto_commit:
+        return "❌ Error: create_pr requires auto_commit=True"
 
     from darnit.core.utils import detect_owner_repo
 
@@ -1066,6 +1101,19 @@ def remediate_audit_findings(
     except Exception:
         pass  # If context check fails, proceed with remediation anyway
 
+    # Step 1: Create branch before applying (so changes land on the right branch)
+    git_report: list[str] = []
+    if branch_name and not dry_run:
+        from darnit.server.tools.git_operations import create_remediation_branch_impl
+
+        branch_result = create_remediation_branch_impl(
+            branch_name=branch_name, local_path=str(repo_path),
+        )
+        if "❌" in branch_result:
+            return f"❌ Branch creation failed, aborting remediation.\n\n{branch_result}"
+        git_report.append(branch_result)
+
+    # Step 2: Apply remediations
     try:
         result = apply_remediations(
             local_path=str(repo_path),
@@ -1073,10 +1121,34 @@ def remediate_audit_findings(
             repo=repo,
             categories=categories or ["all"],
             dry_run=dry_run,
+            profile=profile,
         )
-        return result
     except Exception as e:
         return f"❌ Error applying remediations: {e}"
+
+    # Step 3: Commit and optionally create PR (only on successful non-dry-run apply)
+    if not dry_run and "❌" not in result:
+        if auto_commit:
+            from darnit.server.tools.git_operations import commit_remediation_changes_impl
+
+            commit_result = commit_remediation_changes_impl(
+                local_path=str(repo_path),
+            )
+            git_report.append(commit_result)
+
+            if create_pr and "❌" not in commit_result:
+                from darnit.server.tools.git_operations import create_remediation_pr_impl
+
+                pr_result = create_remediation_pr_impl(
+                    local_path=str(repo_path),
+                )
+                git_report.append(pr_result)
+
+    # Append git workflow summary if any git steps ran
+    if git_report:
+        result += "\n\n---\n## Git Workflow\n\n" + "\n\n".join(git_report)
+
+    return result
 
 
 # =============================================================================

--- a/packages/darnit/src/darnit/server/tools/git_operations.py
+++ b/packages/darnit/src/darnit/server/tools/git_operations.py
@@ -49,7 +49,7 @@ def create_remediation_branch_impl(
             text=True
         )
         if result.returncode == 0:
-            # Branch exists, check it out
+            # Branch exists, check it out (stash dirty files if needed)
             result = subprocess.run(
                 ["git", "checkout", branch_name],
                 cwd=resolved_path,
@@ -57,7 +57,35 @@ def create_remediation_branch_impl(
                 text=True
             )
             if result.returncode != 0:
-                return f"❌ Error checking out existing branch: {result.stderr.strip()}"
+                if "local changes" in result.stderr or "would be overwritten" in result.stderr:
+                    stash_result = subprocess.run(
+                        ["git", "stash", "--include-untracked"],
+                        cwd=resolved_path, capture_output=True, text=True,
+                    )
+                    if stash_result.returncode != 0:
+                        return f"❌ Error stashing changes: {stash_result.stderr.strip()}"
+
+                    checkout_result = subprocess.run(
+                        ["git", "checkout", branch_name],
+                        cwd=resolved_path, capture_output=True, text=True,
+                    )
+                    if checkout_result.returncode != 0:
+                        subprocess.run(["git", "stash", "pop"], cwd=resolved_path,
+                                       capture_output=True, text=True)
+                        return f"❌ Error checking out branch: {checkout_result.stderr.strip()}"
+
+                    pop_result = subprocess.run(
+                        ["git", "stash", "pop"],
+                        cwd=resolved_path, capture_output=True, text=True,
+                    )
+                    if pop_result.returncode != 0:
+                        subprocess.run(["git", "checkout", "--theirs", ".project/"],
+                                       cwd=resolved_path, capture_output=True, text=True)
+                        subprocess.run(["git", "stash", "drop"],
+                                       cwd=resolved_path, capture_output=True, text=True)
+                else:
+                    return f"❌ Error checking out existing branch: {result.stderr.strip()}"
+
             return f"""✅ Switched to existing branch '{branch_name}'
 
 **Next steps:**
@@ -66,7 +94,7 @@ def create_remediation_branch_impl(
 3. Create PR: `create_remediation_pr(local_path="{resolved_path}")`
 """
 
-        # Create and checkout new branch
+        # Create and checkout new branch (preserves dirty working tree)
         result = subprocess.run(
             ["git", "checkout", "-b", branch_name],
             cwd=resolved_path,

--- a/packages/darnit/src/darnit/skills/darnit-audit/SKILL.md
+++ b/packages/darnit/src/darnit/skills/darnit-audit/SKILL.md
@@ -4,7 +4,7 @@ description: Run a compliance audit on the current repository using darnit. Use 
 compatibility: Requires darnit MCP server running (darnit serve)
 metadata:
   author: kusari-oss
-  version: "1.1"
+  version: "2.0"
 ---
 
 # Compliance Audit
@@ -21,6 +21,7 @@ Common audit tools:
 ## Workflow
 
 1. Identify the audit tool to use (see above). Call it with `local_path` set to the repository root and `output_format` set to `"markdown"`.
+   - Use `output_format: "summary"` if you only need pass/fail counts (compact JSON, ~5-8K vs ~164K for full JSON).
    - If the user mentions a profile (e.g., "just level 1", "access control only", "onboard"), pass it as the `profile` parameter.
    - If the user mentions a level, pass it as the `level` parameter.
 

--- a/packages/darnit/src/darnit/skills/darnit-comply/SKILL.md
+++ b/packages/darnit/src/darnit/skills/darnit-comply/SKILL.md
@@ -4,12 +4,12 @@ description: Run the full compliance pipeline — audit, collect context, remedi
 compatibility: Requires darnit MCP server running (darnit serve) and gh CLI for PR creation
 metadata:
   author: kusari-oss
-  version: "1.1"
+  version: "2.0"
 ---
 
 # Full Compliance Pipeline
 
-Orchestrate the complete audit-to-PR workflow. Run audit, collect missing context, re-audit, show remediation plan, apply fixes, and create a PR.
+Orchestrate the complete audit-to-PR workflow with minimal MCP round-trips. Let the tools handle the plumbing; add value by enhancing generated content.
 
 ## Discovering tools
 
@@ -19,7 +19,7 @@ Darnit registers tools per implementation module. Look for available tools match
 
 ### 1. Initial audit
 
-Call the appropriate `audit_*` tool with `output_format: "json"` and any profile the user mentioned. Present a brief summary: total controls, pass/fail/warn counts, compliance percentage. Resolve any PENDING_LLM controls using your own reasoning.
+Call the appropriate `audit_*` tool with `output_format: "summary"` and any profile the user mentioned. The "summary" format returns compact JSON (~5-8K vs ~164K for full JSON). Present a brief summary: total controls, pass/fail/warn counts, compliance percentage. Resolve any PENDING_LLM controls using your own reasoning.
 
 ### 2. Collect context (if needed)
 
@@ -28,33 +28,46 @@ If WARN controls exist due to missing context:
 - Follow the `/darnit-context` skill workflow: call `get_pending_context`, present questions, call `confirm_project_context` for answers
 - Continue until `status: "complete"` or the user says "skip remaining"
 
-### 3. Re-audit (if context was collected)
-
-Call the audit tool again. Show the improvement: "X controls improved from WARN to PASS."
-
-### 4. Remediation plan
+### 3. Remediation plan
 
 If there are FAIL controls with auto-fixes:
 - Call `remediate_audit_findings` with `dry_run: true`
 - Present the plan, distinguishing safe auto-fixes from unsafe/manual ones
 - Ask: "Apply the safe auto-fixes?"
 
-If no failures or no auto-fixes: report the status and list manual steps.
+If no failures or no auto-fixes: report the status and list manual steps. Skip to step 6.
 
-### 5. Apply fixes (if confirmed)
+### 4. Apply fixes (if confirmed)
 
-1. `create_remediation_branch` — branch name like "fix/compliance"
-2. `remediate_audit_findings` with `dry_run: false`
-3. `commit_remediation_changes`
-4. Ask if the user wants a PR → `create_remediation_pr`
+Call `remediate_audit_findings` with:
+- `dry_run: false`
+- `branch_name: "fix/compliance"` (or `"fix/compliance-{profile}"`)
+- `auto_commit: true`
 
-### 6. Final report
+This single call creates the branch, applies all remediations, and commits.
+Do NOT make separate calls to `create_remediation_branch` or `commit_remediation_changes`.
+
+### 5. Enhance generated files (value-add)
+
+Read the generated template files and improve them with project-specific content:
+- Fill in real project details (maintainer names, security contact, CI/CD specifics)
+- Improve language and formatting
+- Make templates feel like real documentation rather than boilerplate
+
+If files were enhanced, make a new commit with the improvements.
+
+### 6. Create PR and final report
+
+Ask if the user wants a PR. If yes, call `create_remediation_pr` and display the URL.
 
 Show before/after compliance comparison, list of changes made, and remaining manual items.
 
 ## Gotchas
 
 - Always show the remediation plan and get confirmation before applying changes. Never auto-apply.
+- Use `output_format: "summary"` for audits to keep token usage low.
+- Do NOT run a separate audit before calling `remediate_audit_findings` — it handles audit internally.
+- Do NOT call `create_remediation_branch` or `commit_remediation_changes` separately — use the built-in `branch_name` and `auto_commit` params.
 - Unsafe remediations (requiring API access or manual review) must be clearly excluded from automatic application.
 - If any step fails, report what was accomplished and suggest continuing manually.
 - Never leave the repository in a broken state — if remediation partially applied, report which files changed.

--- a/packages/darnit/src/darnit/skills/darnit-remediate/SKILL.md
+++ b/packages/darnit/src/darnit/skills/darnit-remediate/SKILL.md
@@ -1,60 +1,68 @@
 ---
 name: darnit-remediate
 description: Apply automated fixes for failing compliance controls. Shows a plan first, then creates a branch with fixes and optionally a PR. Use when the user wants to fix compliance failures, apply remediations, or create a compliance PR.
-compatibility: Requires darnit MCP server running (darnit serve) and gh CLI for PR creation
+compatibility: Requires darnit MCP server running (darnit serve)
 metadata:
   author: kusari-oss
-  version: "1.2"
+  version: "2.0"
 ---
 
 # Compliance Remediation
 
-Apply automated fixes for failing compliance controls on a new branch.
+Show a dry-run plan of fixes for failing controls, get confirmation, then apply changes on a new branch. After applying, enhance generated template files with project-specific content.
 
-## Quick vs reviewed mode
+## Workflow
 
-If the user signals they want speed (e.g., "quick", "just fix it", "skip the review", "apply everything"), use **quick mode**: skip the dry-run, create the branch, apply fixes, commit, and report what changed. Do not ask for confirmation.
+### 1. Show dry-run plan
 
-Otherwise, use **reviewed mode** (default): show a dry-run plan first, get confirmation, then apply.
-
-## Quick mode
-
-1. Call `create_remediation_branch`
-2. Call `remediate_audit_findings` with `dry_run: false`
-3. Call `commit_remediation_changes`
-4. Report: branch name, controls fixed, files changed
-5. Ask if the user wants a PR
-
-## Reviewed mode
-
-### 1. Get audit results
-
-Check conversation context for recent audit results. If none exist, call the appropriate `audit_*` MCP tool with `output_format: "json"`.
-
-### 2. Show dry-run plan
-
-Call `remediate_audit_findings` with `dry_run: true`.
+Call `remediate_audit_findings` with `dry_run: true` and any profile mentioned.
+The tool internally runs an audit (or uses cached results) — do NOT run a separate audit call.
 
 Present the plan:
 - **Safe auto-fixes**: what will be created or modified
 - **Unsafe / manual**: why these can't be auto-fixed, what to do instead
+- **No fix available**: controls without remediation handlers
 
 Ask: "Apply the safe auto-fixes? This will create a new branch."
 
-### 3. Apply fixes (if confirmed)
+### 2. Apply fixes (if confirmed)
 
-1. `create_remediation_branch`
-2. `remediate_audit_findings` with `dry_run: false`
-3. `commit_remediation_changes`
+Call `remediate_audit_findings` with:
+- `dry_run: false`
+- `branch_name: "fix/compliance"` (or `"fix/compliance-{profile}"` if a profile was specified)
+- `auto_commit: true`
+
+This single call creates the branch, applies all remediations, and commits. Do NOT make separate calls to `create_remediation_branch` or `commit_remediation_changes`.
+
+### 3. Enhance generated files (value-add)
+
+This is where the skill adds unique value beyond what the tool provides. Read the generated template files and improve them with project-specific content:
+
+- Read each generated file (e.g., SECURITY.md, CONTRIBUTING.md, docs/*.md)
+- Enhance with real project details: actual maintainer names, real security contact, specific CI/CD details
+- Improve language, formatting, and completeness
+- Make templates feel like real documentation rather than boilerplate
+
+If any files were enhanced, make a new commit with the improvements.
 
 ### 4. Offer PR creation
 
 Ask if the user wants a PR. If yes, call `create_remediation_pr` and display the URL.
 
+### 5. Summary
+
+Show: branch name, controls fixed, files changed, PR URL (if created), and remaining manual items.
+
 ## Gotchas
 
-- In reviewed mode, always show the plan before applying. In quick mode, skip straight to applying.
-- The tool only applies `safe: true` remediations. Unsafe ones are always skipped regardless of mode.
-- If there are unresolved context questions, the remediation tool will block. Suggest running `/darnit-context` first.
-- If `remediate_audit_findings` fails mid-way, report which files were already changed.
-- Tool names vary by implementation. Discover available tools from the darnit MCP server.
+- Always show the dry-run plan first. Never apply changes without confirmation.
+- Do NOT call `audit_openssf_baseline` separately — `remediate_audit_findings` handles audit internally.
+- Do NOT call `create_remediation_branch` or `commit_remediation_changes` separately — use the `branch_name` and `auto_commit` params instead.
+- If `remediate_audit_findings` fails mid-way, report which files were already changed so the user can review.
+- The tool respects the `safe` flag on remediations — only safe remediations are auto-applied. Unsafe ones are listed but excluded.
+- If there are unresolved context questions, the remediation tool will block and tell you. Suggest running `/darnit-context` first.
+
+## Error handling
+
+If the tool returns a context warning, suggest running `/darnit-context` first.
+If branch creation fails, report the error — the tool aborts before applying any changes.

--- a/packages/darnit/src/darnit/tools/audit.py
+++ b/packages/darnit/src/darnit/tools/audit.py
@@ -282,6 +282,7 @@ def run_checks(
     level: int = 3,
     stop_on_llm: bool = True,
     apply_user_config: bool = True,
+    framework_name: str | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
     """Run OSPS baseline checks at the specified level.
 
@@ -297,6 +298,8 @@ def run_checks(
         level: Maximum level to check (1, 2, or 3)
         stop_on_llm: Return PENDING_LLM for LLM consultation
         apply_user_config: Apply .baseline.toml user config overrides
+        framework_name: Explicit framework name (e.g., "openssf-baseline").
+            If None, resolved from .baseline.toml in the repo.
 
     Returns:
         Tuple of (check_results, skipped_controls)
@@ -308,6 +311,7 @@ def run_checks(
         owner, repo, local_path, default_branch, level,
         apply_user_config=apply_user_config,
         stop_on_llm=stop_on_llm,
+        framework_name=framework_name,
     )
 
     return results, skipped_controls


### PR DESCRIPTION
## Summary

- **Root cause fix**: `remediate_audit_findings` internal audit called `run_sieve_audit` without `framework_name`, so repos without `.baseline.toml` got 0 controls loaded → 0 results → "no remediations needed" even with 20+ real failures
- **Git workflow**: `remediate_audit_findings` now accepts `branch_name`/`auto_commit`/`create_pr` for single-call branch+apply+commit
- **Profile passthrough**: `profile` param was accepted by the MCP tool but silently dropped before reaching the orchestrator
- **Summary format**: New `output_format="summary"` for compact audit JSON (~5K vs ~164K)
- **Dirty file handling**: Branch checkout now handles dirty `.project/` files via stash-checkout-pop
- **Better errors**: Distinguishes "audit failed" vs "all passing" vs "no auto-fix handlers"
- **Skills v2.0**: Source skills synced to installed versions

## Test plan

- [x] `uv run ruff check` passes on all changed files
- [x] `uv run pytest tests/ --ignore=tests/integration/` — 1300 passed (1 pre-existing failure)
- [x] `remediate_audit_findings(dry_run=True)` finds 12 remediable controls (was returning "no remediations needed")
- [x] `run_checks(framework_name="openssf-baseline")` correctly loads 62 controls and finds failures
- [x] Profile resolution works (invalid profile returns clear error listing available profiles)
- [x] Branch creation with dirty `.project/` files succeeds via stash-checkout-pop
- [ ] Manual: Run `/darnit-remediate` on kusari-cli after `uv pip install -e` to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)