### PR TITLE
fix: narrow broad except Exception blocks in context modules

### DIFF
--- a/packages/darnit/src/darnit/context/auto_detect.py
+++ b/packages/darnit/src/darnit/context/auto_detect.py
@@ -349,7 +349,7 @@ def collect_auto_context(local_path: str) -> dict[str, Any]:
         for category_values in stored.values():
             for key, ctx_val in category_values.items():
                 context[key] = ctx_val.value
-    except Exception:
+    except (OSError, KeyError, AttributeError):
         pass  # Graceful degradation if no .project/ config exists
 
     # Auto-detect (only for keys not already persisted)

--- a/packages/darnit/src/darnit/context/collection.py
+++ b/packages/darnit/src/darnit/context/collection.py
@@ -18,6 +18,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from darnit.core.logging import get_logger
 
 logger = get_logger("context.collection")
@@ -102,8 +104,6 @@ def parse_yaml_path(file_path: Path, path: str) -> Any:
         return None
 
     try:
-        import yaml
-
         content = file_path.read_text(encoding="utf-8")
         data = yaml.safe_load(content)
 
@@ -119,7 +119,7 @@ def parse_yaml_path(file_path: Path, path: str) -> Any:
                 return None
 
         return current
-    except Exception as e:
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as e:
         logger.debug(f"Could not parse YAML {file_path}: {e}")
         return None
 
@@ -171,7 +171,7 @@ def parse_json_path(file_path: Path, path: str) -> Any:
                 return None
 
         return current
-    except Exception as e:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as e:
         logger.debug(f"Could not parse JSON {file_path}: {e}")
         return None
 

--- a/packages/darnit/src/darnit/context/detectors.py
+++ b/packages/darnit/src/darnit/context/detectors.py
@@ -26,7 +26,7 @@ def detect_forge(local_path: str) -> str:
         else:
             return "unknown"
 
-    except Exception:
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return "unknown"
 
 

--- a/tests/darnit/context/test_detectors.py
+++ b/tests/darnit/context/test_detectors.py
@@ -54,7 +54,7 @@ class TestDetectForge:
 
     def test_git_command_fails(self, tmp_path: Path) -> None:
         """Returns 'unknown' gracefully when git remote fails."""
-        with patch("subprocess.run", side_effect=Exception("git error")):
+        with patch("subprocess.run", side_effect=OSError("git error")):
             result = detect_forge(str(tmp_path))
         assert result == "unknown"
 


### PR DESCRIPTION
Closes #7 (task: Narrow broad except-Exception blocks)

## Summary

Replaces catch-all `except Exception` handlers with specific exception types in three context modules. No behaviour changes — all real errors that were caught before are still caught; unrelated exceptions now propagate immediately instead of being swallowed.

### Changes

**`context/detectors.py`** — `detect_forge()`
- `except Exception` → `except (subprocess.TimeoutExpired, FileNotFoundError, OSError)`
- These are the only exceptions `subprocess.run()` raises

**`context/collection.py`** — `parse_yaml_path()` and `parse_json_path()`
- `parse_yaml_path`: `except Exception` → `except (OSError, UnicodeDecodeError, yaml.YAMLError)`
- `parse_json_path`: `except Exception` → `except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError)`
- Moves `import yaml` to module level (it's a declared dependency)

**`context/auto_detect.py`** — `collect_auto_context()`
- `except Exception` → `except (OSError, KeyError, AttributeError)`
- These are the exceptions `load_context()` and its attribute traversal can actually raise

**`tests/darnit/context/test_detectors.py`** — `test_git_command_fails`
- Updated to use `OSError` instead of bare `Exception`, matching the realistic failure mode

## Test plan
- [x] `uv run pytest tests/darnit/context/test_detectors.py tests/darnit/context/test_auto_detect.py tests/darnit/context/test_collection.py` — 109 passed
- [x] `uv run ruff check` — clean