### PR TITLE
fix: stop leaking security@example.com in generated SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,8 +13,7 @@ We take security seriously. If you discover a security vulnerability, please rep
 ### How to Report
 
 1. **DO NOT** create a public GitHub issue for security vulnerabilities
-2. Email security concerns to: security@example.com
-3. Or use GitHub's private vulnerability reporting feature
+2. Use GitHub's private vulnerability reporting feature (Security tab → "Report a vulnerability")
 
 ### What to Include
 

--- a/packages/darnit-baseline/templates/security_policy_minimal.tmpl
+++ b/packages/darnit-baseline/templates/security_policy_minimal.tmpl
@@ -4,6 +4,8 @@
 
 Please report security vulnerabilities by:
 - Using GitHub's "Report a vulnerability" feature in the Security tab
-- Or emailing << context.security_contact | default('security@example.com') >>
+<% if context.security_contact %>
+- Or emailing << context.security_contact >>
+<% endif %>
 
 We will respond within 48 hours and work with you to resolve the issue.

--- a/packages/darnit-baseline/templates/security_policy_standard.tmpl
+++ b/packages/darnit-baseline/templates/security_policy_standard.tmpl
@@ -19,7 +19,9 @@ Instead, please report security vulnerabilities by:
 
 1. **GitHub Security Advisories**: Use the "Report a vulnerability" button in
    the Security tab of this repository (preferred)
-2. **Email**: Send details to << context.security_contact | default('security@example.com') >>
+<% if context.security_contact %>
+2. **Email**: Send details to << context.security_contact >>
+<% endif %>
 
 ### What to Include
 

--- a/tests/darnit_baseline/remediation/test_template_rendering.py
+++ b/tests/darnit_baseline/remediation/test_template_rendering.py
@@ -383,20 +383,64 @@ class TestLLMEnhancement:
 class TestTemplateFallbackDefaults:
     """Verify templates render sensible defaults when context is missing."""
 
-    def test_security_policy_fallback_contact(self, tmp_path):
-        """Security policy renders placeholder email when no contact set."""
+    def test_security_policy_omits_email_when_no_contact(self, tmp_path):
+        """Security policy omits the email option when no contact is confirmed.
+
+        Regression guard: previously the template used
+        ``default('security@example.com')`` which leaked a fake address into
+        real SECURITY.md outputs, violating the "Never Guess User-Specific
+        Values" rule.
+        """
         rendered = _render_template("security_policy_standard", tmp_path)
 
-        # Should have the fallback, not a raw variable or empty string
-        assert "security@example.com" in rendered
+        # No placeholder email leaks
+        assert "security@example.com" not in rendered
+        assert "example.com" not in rendered
+        # No raw template variables
         assert "${context.security_contact}" not in rendered
+        assert "<< context.security_contact" not in rendered
+        # GitHub Security Advisories path is still present
+        assert "GitHub Security Advisories" in rendered
 
-    def test_security_policy_minimal_fallback_contact(self, tmp_path):
-        """Minimal security policy renders placeholder email when no contact set."""
+    def test_security_policy_minimal_omits_email_when_no_contact(self, tmp_path):
+        """Minimal security policy omits the email bullet when no contact set."""
         rendered = _render_template("security_policy_minimal", tmp_path)
 
-        assert "security@example.com" in rendered
+        assert "security@example.com" not in rendered
+        assert "example.com" not in rendered
         assert "${context.security_contact}" not in rendered
+        assert "<< context.security_contact" not in rendered
+        # GitHub vulnerability reporting path is still present
+        assert "Report a vulnerability" in rendered
+
+    def test_security_policy_renders_contact_when_confirmed(self, tmp_path):
+        """When context.security_contact is set, the email line is rendered verbatim."""
+        scan_ctx = scan_repository(str(tmp_path))
+        scan_values = flatten_scan_context(scan_ctx)
+
+        fw_path = _get_framework_path()
+        templates = _load_template("security_policy_standard")
+
+        executor = RemediationExecutor(
+            local_path=str(tmp_path),
+            owner="test-org",
+            repo="test-repo",
+            templates=templates,
+            context_values={"security_contact": "security@example-project.test"},
+            scan_values=scan_values,
+            framework_path=fw_path,
+        )
+
+        content = executor._get_template_content("security_policy_standard")
+        assert content is not None
+        rendered = executor._substitute(content, "OSPS-TEST-01")
+
+        # The confirmed contact is rendered
+        assert "security@example-project.test" in rendered
+        # The email section appears
+        assert "Email" in rendered
+        # No fallback fake address
+        assert "security@example.com" not in rendered
 
     def test_codeowners_fallback(self, tmp_path):
         """CODEOWNERS renders a valid placeholder when no maintainers set."""


### PR DESCRIPTION
## Summary

- The two security policy templates used `default('security@example.com')` as a Jinja2 fallback for `context.security_contact`. Dogfooded without a confirmed contact, this silently wrote a fabricated email into the real `SECURITY.md` at the repo root — violating the project's **"Never Guess User-Specific Values"** rule.
- Fix: conditionally render the email option only when `context.security_contact` is set. When unset, GitHub Security Advisories remains the sole reporting path and no placeholder leaks.
- Also fixes the leaked line in this repo's own `SECURITY.md`, and inverts the two existing tests that codified the buggy behavior (they asserted `security@example.com` *should* appear). Adds a positive test for the confirmed-contact path.

## Files changed

- `SECURITY.md` — remove the leaked `Email security concerns to: security@example.com` line
- `packages/darnit-baseline/templates/security_policy_standard.tmpl` — conditional email block
- `packages/darnit-baseline/templates/security_policy_minimal.tmpl` — conditional email bullet
- `tests/darnit_baseline/remediation/test_template_rendering.py` — invert existing tests, add confirmed-contact test

## Follow-ups (not in this PR)

- `codeowners_template.tmpl` has the same anti-pattern with `default('@org/maintainers')`. Worse than the security case because CODEOWNERS is actively enforced (routes reviews, blocks PRs) — a bogus team name creates a review bottleneck. The handler should refuse to write CODEOWNERS without a confirmed `context.maintainers`.
- `maintainers_template.tmpl` has `default('- @username (Name, role)')` — less dangerous (obviously placeholder-looking, informational file) but still violates "Never Guess". Conditional render with a FIXME marker.
- Both are tracked alongside the other items in `project_remediation_quality.md` for a separate change.

## Test plan

- [x] `uv run pytest tests/darnit_baseline/remediation/test_template_rendering.py -v -k security_policy` — 4/4 pass
- [x] `uv run ruff check .` — clean
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — 1526 pass (1 pre-existing unrelated failure: upstream CNCF `.project` spec hash drift in `test_dot_project_upstream.py`, needs `--update-hash` in a separate change)
- [x] `uv run python scripts/validate_sync.py --verbose` — passes
- [x] `uv run python scripts/generate_docs.py` — no diffs
- [ ] Reviewer spot-check: render both templates with an empty context and confirm no `example.com` appears; render with `security_contact` set and confirm the email line appears verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)