### PR TITLE
test: Add dynamic SARIF 2.1.0 output validation tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dev = [
     "mypy>=1.8.0",
     "ruff>=0.8.0",
     "skills-ref>=0.1.1",
+    "jsonschema>=4.26.0",
 ]
 
 [tool.mypy]

--- a/tests/darnit_baseline/formatters/test_sarif_formatter_validation.py
+++ b/tests/darnit_baseline/formatters/test_sarif_formatter_validation.py
@@ -1,5 +1,4 @@
 import json
-import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -15,28 +14,34 @@ except ImportError:
 from darnit.core.models import AuditResult
 from darnit_baseline.formatters.sarif import generate_sarif_audit
 
-SARIF_SCHEMA_URL = "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json"
+SARIF_SCHEMA_URL = (
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0"
+    "/errata01/os/schemas/sarif-schema-2.1.0.json"
+)
 CACHE_DIR = Path(".pytest_cache")
-SCHEMA_PATH = CACHE_DIR / "sarif-2.1.0-rtm.5.json"
+SCHEMA_PATH = CACHE_DIR / "sarif-schema-2.1.0.json"
 
 
 @pytest.fixture(scope="session")
 def sarif_schema():
-    """Download and cache the official SARIF schema for validation tests."""
+    """Download and cache the official SARIF schema for validation tests.
+
+    Skips only when ``jsonschema`` is not installed (e.g. minimal test
+    environment).  When ``jsonschema`` IS available (CI), a download
+    failure is a hard error — this prevents CI from silently skipping
+    schema validation when the URL is temporarily unreachable.
+    """
     if not HAS_JSONSCHEMA:
         pytest.skip("jsonschema is not installed, skipping strict validation")
 
     if not SCHEMA_PATH.exists():
         CACHE_DIR.mkdir(exist_ok=True, parents=True)
-        try:
-            with urllib.request.urlopen(SARIF_SCHEMA_URL, timeout=10) as response:
-                schema_data = json.loads(response.read().decode())
-                with open(SCHEMA_PATH, "w") as f:
-                    json.dump(schema_data, f)
-        except urllib.error.URLError as e:
-            print(f"Failed to download SARIF schema: {e}")
-            pytest.skip(f"Failed to download SARIF schema: {e}")
-            return None
+        # Hard failure when jsonschema IS installed — don't let CI
+        # silently skip validation because of a transient network issue.
+        with urllib.request.urlopen(SARIF_SCHEMA_URL, timeout=30) as response:
+            schema_data = json.loads(response.read().decode())
+            with open(SCHEMA_PATH, "w") as f:
+                json.dump(schema_data, f)
 
     with open(SCHEMA_PATH) as f:
         return json.load(f)

--- a/tests/darnit_baseline/formatters/test_sarif_formatter_validation.py
+++ b/tests/darnit_baseline/formatters/test_sarif_formatter_validation.py
@@ -1,0 +1,207 @@
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+try:
+    import jsonschema
+
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
+
+from darnit.core.models import AuditResult
+from darnit_baseline.formatters.sarif import generate_sarif_audit
+
+SARIF_SCHEMA_URL = "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json"
+CACHE_DIR = Path(".pytest_cache")
+SCHEMA_PATH = CACHE_DIR / "sarif-2.1.0-rtm.5.json"
+
+
+@pytest.fixture(scope="session")
+def sarif_schema():
+    """Download and cache the official SARIF schema for validation tests."""
+    if not HAS_JSONSCHEMA:
+        pytest.skip("jsonschema is not installed, skipping strict validation")
+
+    if not SCHEMA_PATH.exists():
+        CACHE_DIR.mkdir(exist_ok=True, parents=True)
+        try:
+            with urllib.request.urlopen(SARIF_SCHEMA_URL, timeout=10) as response:
+                schema_data = json.loads(response.read().decode())
+                with open(SCHEMA_PATH, "w") as f:
+                    json.dump(schema_data, f)
+        except urllib.error.URLError as e:
+            print(f"Failed to download SARIF schema: {e}")
+            pytest.skip(f"Failed to download SARIF schema: {e}")
+            return None
+
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def test_sarif_empty_results(sarif_schema):
+    """Test generating SARIF with no results."""
+    audit = AuditResult(
+        owner="test-owner", repo="test-repo", local_path="/tmp/test", level=1, default_branch="main", all_results=[]
+    )
+    result = generate_sarif_audit(audit)
+
+    assert result["version"] == "2.1.0"
+    assert "runs" in result
+    assert len(result["runs"]) == 1
+
+    if sarif_schema:
+        jsonschema.validate(instance=result, schema=sarif_schema)
+
+
+def test_sarif_all_pass(sarif_schema):
+    """Test generating SARIF with all passing results."""
+    audit = AuditResult(
+        owner="test-owner",
+        repo="test-repo",
+        local_path="/tmp/test",
+        level=1,
+        default_branch="main",
+        all_results=[
+            {
+                "id": "OSPS-AC-01.01",
+                "status": "PASS",
+                "details": "MFA is required",
+                "level": 1,
+            },
+            {
+                "id": "OSPS-RE-01.02",
+                "status": "PASS",
+                "details": "Signatures exist",
+                "level": 1,
+            },
+        ],
+    )
+    result = generate_sarif_audit(audit, include_passing=True)
+
+    assert len(result["runs"][0]["results"]) == 2
+    # Ensure all rules referenced in results are defined in the tool rules
+    rule_ids = {r["id"] for r in result["runs"][0]["tool"]["driver"]["rules"]}
+    for res in result["runs"][0]["results"]:
+        assert res["ruleId"] in rule_ids
+
+    if sarif_schema:
+        jsonschema.validate(instance=result, schema=sarif_schema)
+
+
+def test_sarif_all_fail(sarif_schema):
+    """Test generating SARIF with failing results."""
+    audit = AuditResult(
+        owner="test-owner",
+        repo="test-repo",
+        local_path="/tmp/test",
+        level=1,
+        default_branch="main",
+        all_results=[
+            {
+                "id": "OSPS-AC-01.01",
+                "status": "FAIL",
+                "details": "MFA is NOT required",
+                "level": 1,
+            }
+        ],
+    )
+    result = generate_sarif_audit(audit)
+
+    assert len(result["runs"][0]["results"]) == 1
+    res = result["runs"][0]["results"][0]
+    assert res["level"] == "error"
+    assert "MFA is NOT required" in res["message"]["text"]
+
+    if sarif_schema:
+        jsonschema.validate(instance=result, schema=sarif_schema)
+
+
+def test_sarif_mixed_levels(sarif_schema):
+    """Test generating SARIF with mixed result states."""
+    audit = AuditResult(
+        owner="test-owner",
+        repo="test-repo",
+        local_path="/tmp/test",
+        level=1,
+        default_branch="main",
+        all_results=[
+            {
+                "id": "OSPS-AC-01.01",
+                "status": "FAIL",
+                "details": "Failed AC",
+                "level": 1,
+            },
+            {
+                "id": "OSPS-RE-01.02",
+                "status": "WARN",
+                "details": "Warning on setup",
+                "level": 2,
+            },
+            {
+                "id": "OSPS-GD-01.01",
+                "status": "PASS",
+                "details": "Passing",
+                "level": 1,
+            },
+        ],
+    )
+    # Don't include passing
+    result = generate_sarif_audit(audit, include_passing=False)
+
+    results = result["runs"][0]["results"]
+    assert len(results) == 2  # WARN and FAIL only
+
+    levels = {r["level"] for r in results}
+    assert "error" in levels
+    assert "warning" in levels
+
+    if sarif_schema:
+        jsonschema.validate(instance=result, schema=sarif_schema)
+
+
+def test_sarif_structure_and_location():
+    """Test specific expected fields without schema check to ensure manual coverage."""
+    audit = AuditResult(
+        owner="test-owner",
+        repo="test-repo",
+        local_path="/tmp/test",
+        level=1,
+        default_branch="main",
+        all_results=[
+            {
+                "id": "OSPS-AC-01.01",
+                "status": "FAIL",
+                "details": "Test Fail",
+                "level": 1,
+            }
+        ],
+    )
+    result = generate_sarif_audit(audit)
+
+    run = result["runs"][0]
+
+    # Check Tool
+    tool = run["tool"]["driver"]
+    assert tool["name"] in ("openssf-baseline-audit", "OpenSSF Baseline Threat Model", "OpenSSF Baseline")
+    assert len(tool["rules"]) > 0
+    rule = tool["rules"][0]
+    assert "id" in rule
+    assert "shortDescription" in rule
+    assert "helpUri" in rule
+
+    # Check Result
+    res = run["results"][0]
+    assert res["ruleId"] == "OSPS-AC-01.01"
+
+    # Check locations
+    assert len(res["locations"]) > 0
+    phys_loc = res["locations"][0]["physicalLocation"]
+    assert "artifactLocation" in phys_loc
+    assert "uri" in phys_loc["artifactLocation"]
+
+    # Check expected message format
+    assert "Test Fail" in res["message"]["text"]

--- a/uv.lock
+++ b/uv.lock
@@ -528,6 +528,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "jsonschema" },
     { name = "mypy" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -551,6 +552,7 @@ provides-extras = ["attestation", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "mypy", specifier = ">=1.8.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.8.0" },


### PR DESCRIPTION
## Summary
Expanded test coverage by adding robust SARIF 2.1.0 validation tests. This ensures that the generated SARIF output strictly adheres to standard structural requirements, checking for required top level JSON keys, run object formulations, and valid tool driver objects inside the formatter's output.

*Note: Instead of committing the 3000+ line SARIF schema to the repository, this implementation downloads the official OASIS JSON schema dynamically during testing and caches it. This avoids repository bloat while providing strict structural assertions via the `jsonschema` package. If JSON is needed we can add that too.* 

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes) (Testing additions only)

## Framework Changes Checklist
If this PR modifies the darnit framework (`packages/darnit/`):
- [ ] Updated framework spec (`openspec/specs/framework-design/spec.md`) if behavior changed
- [ ] Ran `uv run python scripts/validate_sync.py --verbose` and it passes
- [ ] Ran `uv run python scripts/generate_docs.py` and committed any doc changes

## Control/TOML Changes Checklist
If this PR modifies controls or TOML configuration:
- [ ] Control metadata defined in TOML (not Python code)
- [ ] SARIF fields (description, severity, help_url) included where appropriate
- [ ] Ran validation to confirm TOML schema compliance

## Testing
- [x] Tests pass locally (`uv run pytest tests/ -v`)
- [x] Added tests for new functionality (if applicable)
- [x] Linting passes (`uv run ruff check .`)

## Additional Notes
Added a new testing suite in `tests/darnit_baseline/formatters/test_sarif_formatter_validation.py` to continuously validate structural integrity of the SARIF outputs against schema assertions. The new tests explicitly cover empty results, all passing results, all failing results, and mixed level outputs.