### PR TITLE
fix: codebase hygiene — swallowed exceptions, stale docs, loose deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,23 +356,10 @@ else:
     result = []
 ```
 
-## Active Technologies
-- Python >=3.11 (project targets 3.11/3.12) + darnit (core framework), darnit-baseline (001-tiered-control-automation)
-- TOML config files, `.project/` YAML context, local filesystem (001-tiered-control-automation)
-- Markdown (GitHub-Flavored Markdown with Mermaid diagram support) + None (pure documentation) (005-getting-started-guide)
-- Filesystem (Markdown files in `docs/` directory) (005-getting-started-guide)
-- Python >=3.11 (project targets 3.11/3.12) + darnit (core framework), darnit-baseline (implementation package) — no new external dependencies (006-detailed-stride-threats)
-- N/A (generates reports from static analysis; no persistence) (006-detailed-stride-threats)
-- Python >=3.11 (project targets 3.11/3.12) + darnit (core framework — sieve handler registry), darnit-baseline (threat model engine) (007-threatmodel-remediation-handler)
-- N/A (writes a single file to the repository) (007-threatmodel-remediation-handler)
-- Python >=3.11 (project targets 3.11/3.12) + darnit (core framework), darnit-baseline (implementation), FastMCP, Pydantic >=2.0, PyYAML, cel-python (008-skills-orchestration)
-- `.project/project.yaml` (YAML), `.baseline.toml` (TOML), framework TOML configs (008-skills-orchestration)
-- Python 3.11+ + darnit (core framework), darnit-baseline (implementation), Pydantic >=2.0, PyYAML, FastMCP (009-context-aware-remediation)
-- Filesystem (`.project/project.yaml`, TOML configs, generated docs) (009-context-aware-remediation)
-- Python 3.11+ (project targets 3.11/3.12; uses modern type hints and `from __future__ import annotations`) + `tree-sitter>=0.25`, `tree-sitter-language-pack>=1.5` (bundles Python/JS/TS/Go/YAML grammars); existing deps: `darnit` (core framework) (010-threat-model-ast)
-- Filesystem only. Writes `THREAT_MODEL.md` (or configured path) via `HandlerContext.local_path`. No persistent state across runs (FR-031). (010-threat-model-ast)
-- Python 3.11+ (project targets 3.11/3.12) + ree-sitter, tree-sitter-language-pack, PyYAML (existing); hashlib (stdlib); no new external dependencies (011-threat-model-restructure)
-- Filesystem — Markdown, JSON, YAML files; no database (011-threat-model-restructure)
-
-## Recent Changes
-- 001-tiered-control-automation: Added Python >=3.11 (project targets 3.11/3.12) + darnit (core framework), darnit-baseline
+## Technology Stack
+- **Language**: Python 3.11+ (targets 3.11/3.12)
+- **Core deps**: FastMCP, Pydantic >=2.0, PyYAML, cel-python
+- **Threat model**: tree-sitter, tree-sitter-language-pack (Python/JS/Go/YAML grammars)
+- **Attestation**: sigstore, in-toto (optional)
+- **Config**: TOML framework configs, `.project/project.yaml` (YAML), `.baseline.toml` (user overrides)
+- **Storage**: Filesystem only (Markdown, JSON, YAML output files; no database)

--- a/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
+++ b/packages/darnit-baseline/src/darnit_baseline/remediation/orchestrator.py
@@ -466,8 +466,8 @@ def _apply_declarative_remediation(
         try:
             from darnit.context.auto_detect import collect_auto_context
             context_values = collect_auto_context(local_path)
-        except Exception:
-            pass  # Auto-detection is best-effort
+        except Exception as exc:
+            logger.warning(f"Auto-detection of context values failed: {exc}")
 
         # Confirmed context overrides auto-detected values
         try:
@@ -476,8 +476,8 @@ def _apply_declarative_remediation(
             for _category, values in all_context.items():
                 for key, ctx_val in values.items():
                     context_values[key] = ctx_val.value
-        except Exception:
-            pass  # Context loading is best-effort
+        except Exception as exc:
+            logger.warning(f"Context loading failed: {exc}")
 
         # Resolve framework TOML path for template file resolution
         fw_path: str | None = None
@@ -486,8 +486,8 @@ def _apply_declarative_remediation(
             p = get_framework_path()
             if p:
                 fw_path = str(p)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(f"Framework path resolution failed: {exc}")
 
         # Scan repository for context-aware template rendering
         scan_values: dict[str, Any] = {}
@@ -498,8 +498,8 @@ def _apply_declarative_remediation(
             )
             scan_ctx = scan_repository(local_path)
             scan_values = flatten_scan_context(scan_ctx)
-        except Exception:
-            pass  # Repo scanning is best-effort
+        except Exception as exc:
+            logger.warning(f"Repository scanning failed: {exc}")
 
         # Load .project/project.yaml for ${project.*} substitution
         project_values: dict[str, Any] = {}
@@ -520,8 +520,8 @@ def _apply_declarative_remediation(
                             out[key] = str(v) if not isinstance(v, list) else " ".join(str(i) for i in v)
                     return out
                 project_values = _flatten(raw)
-        except Exception:
-            pass  # Project YAML loading is best-effort
+        except Exception as exc:
+            logger.warning(f"Project YAML loading failed: {exc}")
 
         # Create executor with templates and context
         executor = RemediationExecutor(
@@ -911,7 +911,8 @@ def remediate_audit_findings(
     try:
         from darnit.core.audit_cache import read_audit_cache
         cache = read_audit_cache(local_path)
-    except Exception:
+    except Exception as exc:
+        logger.warning(f"Audit cache read failed: {exc}")
         cache = None
 
     if cache is not None:

--- a/packages/darnit/pyproject.toml
+++ b/packages/darnit/pyproject.toml
@@ -5,7 +5,7 @@ description = "Generic compliance audit framework with plugin architecture"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.23.0",  # CVE-2025-66416 DNS rebinding fix
+    "mcp>=1.23.0,<2",  # CVE-2025-66416 DNS rebinding fix; cap at next major
     "pydantic>=2.0.0",
     "pyyaml>=6.0.0",
     "pydantic[email]>=2.0.0",
@@ -27,8 +27,8 @@ darnit = "darnit.cli:main"
 attestation = [
     "sigstore>=3.0.0",
     "in-toto-attestation>=0.9.0",
-    "urllib3>=2.6.3",  # CVE-2025-66471, CVE-2026-21441, CVE-2025-66418 fixes
-    "cryptography>=46.0.6",  # CVE-2026-34073 DNS name constraint bypass
+    "urllib3>=2.6.3,<3",  # CVE-2025-66471, CVE-2026-21441, CVE-2025-66418 fixes
+    "cryptography>=46.0.6,<48",  # CVE-2026-34073 DNS name constraint bypass
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Three quick fixes from codebase health audit:

- **Swallowed exceptions** (#202): Replace 6 silent `except Exception: pass` blocks in `remediation/orchestrator.py` with `logger.warning` calls. Auto-detection, context loading, framework resolution, repo scanning, and cache read failures are now visible in logs.
- **Stale CLAUDE.md** (#203): Replace the machine-generated per-branch "Active Technologies" list with a clean technology stack summary.
- **Loose dependency bounds** (#204): Add upper bounds to `mcp` (<2), `urllib3` (<3), `cryptography` (<48) to prevent breaking changes on lock refresh.

Closes #202, closes #203, closes #204.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `tests/darnit_baseline/remediation/` — 89 tests pass
- [x] No behavioral change — exceptions are still caught, just logged now

🤖 Generated with [Claude Code](https://claude.com/claude-code)