### PR TITLE
Fix/198 remediation template tests

### DIFF
--- a/tests/darnit/remediation/test_template_file_resolution.py
+++ b/tests/darnit/remediation/test_template_file_resolution.py
@@ -1,5 +1,6 @@
 """Tests for template file resolution in RemediationExecutor."""
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -56,17 +57,17 @@ class TestTemplateFileResolution:
         with pytest.raises(ValueError, match="specifies absolute path"):
             executor._get_template_content("abs")
 
-    def test_path_traversal_dotdot_rejected(self, tmp_path):
+    def test_path_traversal_dotdot_rejected(self, tmp_path, executor_factory):
         """Parent directory escape attempts are rejected."""
-        executor = RemediationExecutor(
-            local_path=str(tmp_path),
+        executor = executor_factory(
+            local_path_str=str(tmp_path),
             templates={"escape": TemplateConfig(file="../outside.tmpl")},
-            framework_path=str(tmp_path / "pkg" / "framework.toml"),
+            framework_path_str=str(tmp_path / "pkg" / "framework.toml"),
         )
         with pytest.raises(ValueError, match="outside framework directory"):
             executor._get_template_content("escape")
 
-    def test_path_traversal_symlink_rejected(self, tmp_path):
+    def test_path_traversal_symlink_rejected(self, tmp_path, executor_factory):
         """Symlinks traversing outside the directory are rejected."""
         base_dir = tmp_path / "pkg"
         base_dir.mkdir()
@@ -77,10 +78,10 @@ class TestTemplateFileResolution:
         # Create a symlink pointing outside
         symlink_file.symlink_to(outside_file)
 
-        executor = RemediationExecutor(
-            local_path=str(tmp_path),
+        executor = executor_factory(
+            local_path_str=str(tmp_path),
             templates={"symlink": TemplateConfig(file="symlink.tmpl")},
-            framework_path=str(base_dir / "framework.toml"),
+            framework_path_str=str(base_dir / "framework.toml"),
         )
         with pytest.raises(ValueError, match="resolves to .* outside framework directory"):
             executor._get_template_content("symlink")
@@ -129,6 +130,7 @@ class TestTemplateFileResolution:
 
     def test_oserror_at_read_time_logs_warning(self, tmp_path, executor_factory, caplog):
         """Simulates race condition: file exists at init but is deleted before read."""
+        caplog.set_level(logging.WARNING, logger="darnit.remediation.executor")
         executor = executor_factory(
             local_path_str=str(tmp_path),
             templates={"race": TemplateConfig(file="templates/race_condition.tmpl")},

--- a/tests/darnit/remediation/test_template_file_resolution.py
+++ b/tests/darnit/remediation/test_template_file_resolution.py
@@ -1,13 +1,32 @@
 """Tests for template file resolution in RemediationExecutor."""
 
+from unittest.mock import patch
+
+import pytest
+
 from darnit.config.framework_schema import TemplateConfig
 from darnit.remediation.executor import RemediationExecutor
+
+
+@pytest.fixture
+def executor_factory(tmp_path):
+    """Fixture that builds RemediationExecutor with explicit framework_path and local_path."""
+    def _factory(templates, framework_path_str=None, local_path_str=None):
+        if local_path_str is None:
+            local_path_str = str(tmp_path)
+
+        return RemediationExecutor(
+            local_path=local_path_str,
+            templates=templates,
+            framework_path=framework_path_str
+        )
+    return _factory
 
 
 class TestTemplateFileResolution:
     """Verify _get_template_content resolves file paths correctly."""
 
-    def test_relative_file_resolved_to_framework_dir(self, tmp_path):
+    def test_relative_file_resolved_to_framework_dir(self, tmp_path, executor_factory):
         """file= relative path resolves against framework TOML directory."""
         # Set up: framework TOML at tmp_path/pkg/framework.toml
         pkg_dir = tmp_path / "pkg"
@@ -16,25 +35,24 @@ class TestTemplateFileResolution:
         tmpl_dir.mkdir()
         (tmpl_dir / "hello.tmpl").write_text("Hello $OWNER")
 
-        executor = RemediationExecutor(
-            local_path=str(tmp_path / "repo"),
+        executor = executor_factory(
+            local_path_str=str(tmp_path / "repo"),
             templates={"hello": TemplateConfig(file="templates/hello.tmpl")},
-            framework_path=str(pkg_dir / "framework.toml"),
+            framework_path_str=str(pkg_dir / "framework.toml"),
         )
         content = executor._get_template_content("hello")
         assert content == "Hello $OWNER"
 
-    def test_absolute_file_rejected(self, tmp_path):
+    def test_absolute_file_rejected(self, tmp_path, executor_factory):
         """Absolute file= path is rejected with ValueError."""
         tmpl_file = tmp_path / "abs_template.tmpl"
         tmpl_file.write_text("Absolute content")
 
-        executor = RemediationExecutor(
-            local_path=str(tmp_path),
+        executor = executor_factory(
+            local_path_str=str(tmp_path),
             templates={"abs": TemplateConfig(file=str(tmpl_file))},
-            framework_path="/some/other/path/framework.toml",
+            framework_path_str="/some/other/path/framework.toml",
         )
-        import pytest
         with pytest.raises(ValueError, match="specifies absolute path"):
             executor._get_template_content("abs")
 
@@ -45,7 +63,6 @@ class TestTemplateFileResolution:
             templates={"escape": TemplateConfig(file="../outside.tmpl")},
             framework_path=str(tmp_path / "pkg" / "framework.toml"),
         )
-        import pytest
         with pytest.raises(ValueError, match="outside framework directory"):
             executor._get_template_content("escape")
 
@@ -65,48 +82,62 @@ class TestTemplateFileResolution:
             templates={"symlink": TemplateConfig(file="symlink.tmpl")},
             framework_path=str(base_dir / "framework.toml"),
         )
-        import pytest
         with pytest.raises(ValueError, match="resolves to .* outside framework directory"):
             executor._get_template_content("symlink")
 
-    def test_missing_file_returns_none(self, tmp_path):
+    def test_missing_file_returns_none(self, tmp_path, executor_factory):
         """Missing template file returns None with a warning."""
-        executor = RemediationExecutor(
-            local_path=str(tmp_path),
+        executor = executor_factory(
+            local_path_str=str(tmp_path),
             templates={"missing": TemplateConfig(file="templates/nope.tmpl")},
-            framework_path=str(tmp_path / "framework.toml"),
+            framework_path_str=str(tmp_path / "framework.toml"),
         )
         content = executor._get_template_content("missing")
         assert content is None
 
-    def test_fallback_to_local_path_when_no_framework_path(self, tmp_path):
+    def test_fallback_to_local_path_when_no_framework_path(self, tmp_path, executor_factory):
         """When framework_path is None, file resolves relative to local_path."""
         tmpl_dir = tmp_path / "templates"
         tmpl_dir.mkdir()
         (tmpl_dir / "fallback.tmpl").write_text("Fallback content")
 
-        executor = RemediationExecutor(
-            local_path=str(tmp_path),
+        executor = executor_factory(
+            local_path_str=str(tmp_path),
             templates={"fb": TemplateConfig(file="templates/fallback.tmpl")},
             # framework_path defaults to None
         )
         content = executor._get_template_content("fb")
         assert content == "Fallback content"
 
-    def test_inline_content_still_works(self, tmp_path):
+    def test_inline_content_still_works(self, tmp_path, executor_factory):
         """Inline content= is unaffected by framework_path."""
-        executor = RemediationExecutor(
-            local_path=str(tmp_path),
+        executor = executor_factory(
+            local_path_str=str(tmp_path),
             templates={"inline": TemplateConfig(content="Inline text")},
-            framework_path="/does/not/matter/framework.toml",
+            framework_path_str="/does/not/matter/framework.toml",
         )
         content = executor._get_template_content("inline")
         assert content == "Inline text"
 
-    def test_unknown_template_returns_none(self, tmp_path):
+    def test_unknown_template_returns_none(self, tmp_path, executor_factory):
         """Requesting a non-existent template name returns None."""
-        executor = RemediationExecutor(
-            local_path=str(tmp_path),
+        executor = executor_factory(
+            local_path_str=str(tmp_path),
             templates={},
         )
         assert executor._get_template_content("nonexistent") is None
+
+    def test_oserror_at_read_time_logs_warning(self, tmp_path, executor_factory, caplog):
+        """Simulates race condition: file exists at init but is deleted before read."""
+        executor = executor_factory(
+            local_path_str=str(tmp_path),
+            templates={"race": TemplateConfig(file="templates/race_condition.tmpl")},
+            framework_path_str=str(tmp_path / "framework.toml"),
+        )
+
+        with patch("builtins.open", side_effect=OSError("Simulated race condition")):
+            content = executor._get_template_content("race")
+
+        assert content is None
+        assert "Failed to read template file" in caplog.text
+        assert "Simulated race condition" in caplog.text


### PR DESCRIPTION
## Summary

This PR addresses Issue #198 by implementing direct testing for the `RemediationExecutor._get_template_content()` resolution branches. The `test_template_file_resolution.py` file has been refactored to utilize a pytest fixture (`executor_factory`) that builds `RemediationExecutor` with explicit `framework_path` and `local_path` combinations.

Additionally, this PR adds a mocked test to verify that `_get_template_content` correctly logs a warning and returns `None` during read time `OSError`s.

*Included is a secondary "chore" commit that resolves unrelated failing tests on `main` concerning the `dot-project` upstream specification hashing and `mcp_server` tool count checking.*

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist

If this PR modifies the darnit framework (`packages/darnit/`):

- [ ] Updated framework spec (`openspec/specs/framework-design/spec.md`) if behavior changed
- [x] Ran `uv run python scripts/validate_sync.py --verbose` and it passes
- [ ] Ran `uv run python scripts/generate_docs.py` and committed any doc changes

## Control/TOML Changes Checklist

If this PR modifies controls or TOML configuration:

- [ ] Control metadata defined in TOML (not Python code)
- [ ] SARIF fields (description, severity, help_url) included where appropriate
- [ ] Ran validation to confirm TOML schema compliance

## Testing

- [x] Tests pass locally (`uv run pytest tests/ -v`)
- [x] Added tests for new functionality (if applicable)
- [x] Linting passes (`uv run ruff check .`)

## Additional Notes

- Added `test_oserror_at_read_time_logs_warning` leveraging `unittest.mock.patch` on `builtins.open` to mimic race conditions where the target template exists at load but is deleted before the remediation run.
- Tests branches:
  - Absolute paths
  - Relative paths (with `framework_path` and fallback default `local_path`)
  - Inline content
  - missing files and `OSError`