### PR TITLE
Fix #170: Elevate tree-sitter extractor exceptions to WARN

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/threat_model/remediation.py
+++ b/packages/darnit-baseline/src/darnit_baseline/threat_model/remediation.py
@@ -86,8 +86,9 @@ def _run_ts_pipeline(
         )
     except Exception as exc:  # noqa: BLE001 — never break the handler
         logger.warning(
-            "ts_discovery.discover_all raised (%s); falling back to template",
-            exc,
+            "ts_discovery.discover_all raised (%s) on %s; falling back to template",
+            type(exc).__name__,
+            local_path,
         )
         return _TsRunOutput(
             result=None,
@@ -426,7 +427,12 @@ def generate_threat_model_handler(
             },
         )
     except Exception as e:  # noqa: BLE001 — renderer bugs must not crash the handler
-        logger.warning("Renderer error during multi-file output: %s", e)
+        logger.warning(
+            "Renderer error during multi-file output for %s (error type: %s): %s",
+            path,
+            type(e).__name__,
+            e,
+        )
         return HandlerResult(
             status=HandlerResultStatus.ERROR,
             message=f"Renderer error generating threat model: {e}",

--- a/packages/darnit-baseline/src/darnit_baseline/threat_model/ts_discovery.py
+++ b/packages/darnit-baseline/src/darnit_baseline/threat_model/ts_discovery.py
@@ -1446,7 +1446,13 @@ def _normalize_opengrep_findings(
         try:
             candidate = _normalize_one_opengrep_finding(entry, scanned_files, file_cache)
         except Exception as exc:  # noqa: BLE001
-            logger.debug("skipping malformed opengrep finding: %s", exc)
+            path = entry.get("path", "unknown")
+            logger.warning(
+                "skipping malformed opengrep finding in file %s (error type: %s): %s",
+                path,
+                type(exc).__name__,
+                exc,
+            )
             continue
         if candidate is not None:
             candidates.append(candidate)
@@ -1505,7 +1511,13 @@ def _normalize_one_opengrep_finding(
         source_enum = FindingSource.OPENGREP_TAINT
         try:
             data_flow = _parse_dataflow_trace(dataflow_raw, relpath)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "malformed opengrep dataflow trace in file %s (error type: %s): %s",
+                relpath,
+                type(exc).__name__,
+                exc,
+            )
             # Malformed trace — downgrade to pattern match
             source_enum = FindingSource.OPENGREP_PATTERN
             data_flow = None
@@ -1936,7 +1948,12 @@ def _run_opengrep_enrichment(repo_root: Path) -> OpengrepResult:
         with as_file(rules_ref) as rules_path:
             return run_opengrep(target=repo_root, rules_dir=rules_path)
     except Exception as exc:  # noqa: BLE001 — never break discovery
-        logger.debug("opengrep enrichment failed: %s", exc)
+        logger.warning(
+            "opengrep enrichment failed on %s (error type: %s): %s",
+            repo_root,
+            type(exc).__name__,
+            exc,
+        )
         return OpengrepResult(
             available=False,
             degraded_reason=f"opengrep rules resolution failed: {exc}",
@@ -1952,7 +1969,12 @@ def _read_dependency_names(repo_root: Path) -> set[str]:
     try:
         names = deps_module.parse_dependency_manifests(str(repo_root))
     except Exception as e:  # noqa: BLE001 — best-effort
-        logger.debug("dependency manifest parse failed: %s", e)
+        logger.warning(
+            "dependency manifest parse failed for %s (error type: %s): %s",
+            repo_root,
+            type(e).__name__,
+            e,
+        )
         return set()
     if isinstance(names, dict):
         return set(names.keys())


### PR DESCRIPTION
## Summary

Resolves Issue #170.

This PR addresses the issue of tree-sitter pipeline failures silently breaking by replacing broad `logger.debug` exceptions with `logger.warning` in `ts_discovery.py` and `remediation.py`. 

The extractors now log both the file/repository path where the error occurred and the exact exception type (`type(exc).__name__`). This strictly adheres to the "Never Suppress Silently" project principle by surfacing critical pipeline/query crashes without halting execution.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist

If this PR modifies the darnit framework (`packages/darnit/`):

- [ ] Updated framework spec (`openspec/specs/framework-design/spec.md`) if behavior changed (N/A)
- [ ] Ran `uv run python scripts/validate_sync.py --verbose` and it passes (N/A)
- [ ] Ran `uv run python scripts/generate_docs.py` and committed any doc changes (N/A)

## Control/TOML Changes Checklist

If this PR modifies controls or TOML configuration:

- [ ] Control metadata defined in TOML (not Python code)
- [ ] SARIF fields (description, severity, help_url) included where appropriate
- [ ] Ran validation to confirm TOML schema compliance

## Testing

- [x] Tests pass locally (`uv run pytest tests/ -v`)
- [ ] Added tests for new functionality (if applicable)
- [x] Linting passes (`uv run ruff check .`)

## Additional Notes

- All modified `except Exception: # noqa: BLE001` blocks corresponding to malformed extraction checks now emit visible `WARN` level messages instead of debug messages.