### PR TITLE
fix(threat_model): add import corroboration for Go entry point detection (#151)

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/threat_model/ts_discovery.py
+++ b/packages/darnit-baseline/src/darnit_baseline/threat_model/ts_discovery.py
@@ -124,21 +124,27 @@ _GO_HTTP_HANDLER_METHODS: frozenset[str] = frozenset(
     }
 )
 
-#: Go import paths that signal an HTTP routing library is present.
+#: Go import path prefixes that signal an HTTP routing library is present.
 #: Used to corroborate ``obj.Get("/path", ...)`` calls so that non-HTTP
 #: callers (config readers, caches, etc.) do not produce false positives.
-_GO_HTTP_ROUTING_PACKAGES: frozenset[str] = frozenset(
-    {
-        "net/http",
-        "github.com/go-chi/chi",
-        "github.com/go-chi/chi/v5",
-        "github.com/gorilla/mux",
-        "github.com/gin-gonic/gin",
-        "github.com/labstack/echo",
-        "github.com/labstack/echo/v4",
-        "github.com/julienschmidt/httprouter",
-        "github.com/valyala/fasthttp",
-    }
+#:
+#: Prefix matching (``imp == prefix or imp.startswith(prefix + "/")``) handles
+#: Go module major-version suffixes (/v2, /v5, …) and sub-packages without
+#: requiring an explicit entry for every release.
+_GO_HTTP_ROUTING_PREFIXES: tuple[str, ...] = (
+    "net/http",
+    "github.com/go-chi/chi",
+    "github.com/gorilla/mux",
+    "github.com/gin-gonic/gin",
+    "github.com/labstack/echo",
+    "github.com/julienschmidt/httprouter",
+    "github.com/valyala/fasthttp",
+    "github.com/gofiber/fiber",
+    "github.com/beego/beego",
+    "github.com/kataras/iris",
+    "github.com/gobuffalo/buffalo",
+    "github.com/goji/goji",
+    "github.com/emicklei/go-restful",
 )
 
 #: Go ``(pkg, method)`` pairs that open a SQL connection. The first string
@@ -1305,7 +1311,11 @@ def _extract_go_entry_points(
 ) -> list[DiscoveredEntryPoint]:
     entries: list[DiscoveredEntryPoint] = []
     go_imports = _collect_go_imports(source, tree)
-    has_http_routing = any(imp in _GO_HTTP_ROUTING_PACKAGES for imp in go_imports)
+    has_http_routing = any(
+        imp == prefix or imp.startswith(prefix + "/")
+        for imp in go_imports
+        for prefix in _GO_HTTP_ROUTING_PREFIXES
+    )
     query = go_queries.QUERY_REGISTRY["go.entry.selector_string_arg"].query
     for caps in run_query(query, tree.root_node):
         method = _text(caps["method"][0], source)

--- a/packages/darnit-baseline/src/darnit_baseline/threat_model/ts_discovery.py
+++ b/packages/darnit-baseline/src/darnit_baseline/threat_model/ts_discovery.py
@@ -124,6 +124,23 @@ _GO_HTTP_HANDLER_METHODS: frozenset[str] = frozenset(
     }
 )
 
+#: Go import paths that signal an HTTP routing library is present.
+#: Used to corroborate ``obj.Get("/path", ...)`` calls so that non-HTTP
+#: callers (config readers, caches, etc.) do not produce false positives.
+_GO_HTTP_ROUTING_PACKAGES: frozenset[str] = frozenset(
+    {
+        "net/http",
+        "github.com/go-chi/chi",
+        "github.com/go-chi/chi/v5",
+        "github.com/gorilla/mux",
+        "github.com/gin-gonic/gin",
+        "github.com/labstack/echo",
+        "github.com/labstack/echo/v4",
+        "github.com/julienschmidt/httprouter",
+        "github.com/valyala/fasthttp",
+    }
+)
+
 #: Go ``(pkg, method)`` pairs that open a SQL connection. The first string
 #: argument is the driver, which doubles as the technology identifier.
 _GO_DB_OPEN_PAIRS: frozenset[tuple[str, str]] = frozenset(
@@ -1287,12 +1304,20 @@ def _extract_go_entry_points(
     file: ScannedFile, source: bytes, tree: Any
 ) -> list[DiscoveredEntryPoint]:
     entries: list[DiscoveredEntryPoint] = []
+    go_imports = _collect_go_imports(source, tree)
+    has_http_routing = any(imp in _GO_HTTP_ROUTING_PACKAGES for imp in go_imports)
     query = go_queries.QUERY_REGISTRY["go.entry.selector_string_arg"].query
     for caps in run_query(query, tree.root_node):
         method = _text(caps["method"][0], source)
         if method not in _GO_HTTP_HANDLER_METHODS:
             continue
         obj = _text(caps["obj"][0], source)
+        # Require a recognised HTTP routing import unless the call object is
+        # "http" (stdlib net/http — self-evident without an explicit import).
+        # This prevents config readers, caches, and other non-HTTP callers
+        # from producing false-positive entry-point findings.
+        if obj != "http" and not has_http_routing:
+            continue
         path = _strip_quotes(_text(caps["path"][0], source))
         whole = caps["whole"][0]
         # Map method name → HTTP verb where possible.

--- a/tests/darnit_baseline/threat_model/fixtures/red_herrings/go_config_getter.go
+++ b/tests/darnit_baseline/threat_model/fixtures/red_herrings/go_config_getter.go
@@ -1,0 +1,40 @@
+// Red herring — a Go config reader that uses .Get() with path-like keys.
+//
+// Before the import-corroboration fix, the broad tree-sitter query
+// obj.Get(stringArg, ...) would flag calls like cfg.Get("/database/host", ...)
+// as HTTP entry points because "Get" is in _GO_HTTP_HANDLER_METHODS.
+//
+// The pipeline MUST NOT emit any entry points for this file: it imports no
+// HTTP routing library, so every obj.Get/obj.Post call here is a config
+// lookup, not a route registration.
+
+package config
+
+import "fmt"
+
+// Config is a hierarchical key-value store using path-style keys.
+type Config struct {
+	data map[string]string
+}
+
+func (c *Config) Get(key string, defaultVal string) string {
+	if v, ok := c.data[key]; ok {
+		return v
+	}
+	return defaultVal
+}
+
+func (c *Config) Set(key string, value string) {
+	c.data[key] = value
+}
+
+func LoadDatabaseConfig(cfg *Config) string {
+	host := cfg.Get("/database/host", "localhost")
+	port := cfg.Get("/database/port", "5432")
+	return fmt.Sprintf("%s:%s", host, port)
+}
+
+func LoadCacheConfig(cfg *Config) string {
+	addr := cfg.Get("/cache/redis/address", "127.0.0.1:6379")
+	return addr
+}

--- a/tests/darnit_baseline/threat_model/fixtures/red_herrings/url_validator.py
+++ b/tests/darnit_baseline/threat_model/fixtures/red_herrings/url_validator.py
@@ -1,0 +1,38 @@
+"""Red herring — URL validation logic with route-format string patterns.
+
+This file contains a URL/route validator that uses route-format patterns
+in string literals and function bodies. The pipeline MUST NOT flag any of
+these as HTTP entry points; the patterns are purely for validation, not
+route registration.  There are no decorated function definitions that match
+the @app.get(...) / @app.post(...) shape.
+"""
+
+import re
+
+ROUTE_PATTERN = re.compile(r"^/api/v[0-9]+/[a-z]+(?:/[a-z]+)*$")
+
+EXAMPLE_ROUTES = [
+    "/api/v1/users",
+    "/api/v2/posts",
+    "/api/v1/orders",
+]
+
+
+def is_valid_route(path: str) -> bool:
+    return bool(ROUTE_PATTERN.match(path))
+
+
+def describe_route_format() -> str:
+    """Return a description of valid routes.
+
+    Example valid routes::
+
+        GET /api/v1/users
+        POST /api/v2/posts
+        DELETE /api/v1/users/{id}
+    """
+    return "Routes must start with /api/vN/resource_name"
+
+
+def get_example_route(index: int) -> str:
+    return EXAMPLE_ROUTES[index % len(EXAMPLE_ROUTES)]

--- a/tests/darnit_baseline/threat_model/test_ts_discovery.py
+++ b/tests/darnit_baseline/threat_model/test_ts_discovery.py
@@ -371,6 +371,33 @@ class TestRedHerringsRegression:
         # is really a doc-assertion test that we didn't regress.
         assert result.findings == []
 
+    def test_python_url_validator_produces_no_entry_points(self, result) -> None:
+        """url_validator.py contains route-format strings and a docstring
+        with GET/POST/DELETE examples, but no decorated function definitions.
+        The tree-sitter query requires @app.method(...) decorator shape, so
+        string literals and docstring content are structurally ignored."""
+        ep_from_validator = [
+            ep for ep in result.entry_points
+            if "url_validator" in ep.location.file
+        ]
+        assert ep_from_validator == [], (
+            f"url_validator.py must produce zero entry points; got: "
+            f"{[(ep.route_path, ep.location.file) for ep in ep_from_validator]}"
+        )
+
+    def test_go_config_getter_produces_no_entry_points(self, result) -> None:
+        """go_config_getter.go uses cfg.Get('/database/host', ...) — a path-
+        like key in a config reader. Without an HTTP routing library import
+        the extractor must skip these calls and emit no entry points."""
+        ep_from_config = [
+            ep for ep in result.entry_points
+            if "go_config_getter" in ep.location.file
+        ]
+        assert ep_from_config == [], (
+            f"go_config_getter.go must produce zero entry points; got: "
+            f"{[(ep.route_path, ep.location.file) for ep in ep_from_config]}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Dogfood: run against darnit itself (SC-001)


### PR DESCRIPTION
## Summary

Closes #151.

The tree-sitter rewrite (#0a9b375) eliminated regex-based entry-point detection for Python, Go, and JavaScript. Python's query requires a `@app.method(...)` decorated function definition, so string literals and comments are structurally excluded. The Go query, however, matches any `obj.Method(stringArg, ...)` call — including config readers and caches that use path-like string keys but are not HTTP route registrations.

### What changed

- **`_GO_HTTP_ROUTING_PACKAGES`** — new constant listing `net/http` and popular third-party Go routers (chi, gorilla/mux, gin, echo, httprouter, fasthttp)
- **`_extract_go_entry_points`** — collects file-level Go imports via the existing `_collect_go_imports` helper; skips any match where the call object is not `"http"` (stdlib, self-evident) and the file contains no recognised HTTP routing import
- **`fixtures/red_herrings/go_config_getter.go`** — a config reader using `cfg.Get("/database/host", ...)` path-style keys with no HTTP routing import; must produce zero entry points
- **`fixtures/red_herrings/url_validator.py`** — a Python URL validator with route-format patterns in string literals and a docstring with `GET /api/v1/users` examples; already produced zero entry points (tree-sitter requires decorated function shape) — now has an explicit regression test
- Two new tests in `TestRedHerringsRegression` assert zero entry points for both fixtures

### Verification

```
uv run pytest tests/darnit_baseline/threat_model/ -v
# 248 passed, 0 failed
```

## Test plan

- [ ] `uv run pytest tests/darnit_baseline/threat_model/ -v` — all 248 pass
- [ ] `TestGoHttpHandlerFixture` still finds the one entry point in the `go_http_handler` fixture (it imports `net/http`)
- [ ] CI passes