### PR TITLE
Add timeout handling test for detect_forge

### DIFF
--- a/tests/darnit/context/test_detectors.py
+++ b/tests/darnit/context/test_detectors.py
@@ -5,6 +5,7 @@ and verify the detectors return the expected values.
 No real git repos or network calls needed.
 """
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -56,6 +57,16 @@ class TestDetectForge:
         """Returns 'unknown' gracefully when git remote fails."""
         with patch("subprocess.run", side_effect=OSError("git error")):
             result = detect_forge(str(tmp_path))
+        assert result == "unknown"
+
+    def test_git_command_times_out(self, tmp_path: Path) -> None:
+        """Returns 'unknown' when git remote lookup times out."""
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=10),
+        ):
+            result = detect_forge(str(tmp_path))
+
         assert result == "unknown"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -449,10 +449,10 @@ attestation = [
 [package.metadata]
 requires-dist = [
     { name = "cel-python", specifier = ">=0.5.0" },
-    { name = "cryptography", marker = "extra == 'attestation'", specifier = ">=46.0.6,<48" },
+    { name = "cryptography", marker = "extra == 'attestation'", specifier = ">=46.0.6" },
     { name = "in-toto-attestation", marker = "extra == 'attestation'", specifier = ">=0.9.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "mcp", specifier = ">=1.23.0,<2" },
+    { name = "mcp", specifier = ">=1.23.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -460,7 +460,7 @@ requires-dist = [
     { name = "sigstore", marker = "extra == 'attestation'", specifier = ">=3.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "tomllib-stubs", marker = "python_full_version < '3.11'", specifier = ">=0.1.0" },
-    { name = "urllib3", marker = "extra == 'attestation'", specifier = ">=2.6.3,<3" },
+    { name = "urllib3", marker = "extra == 'attestation'", specifier = ">=2.6.3" },
 ]
 provides-extras = ["attestation"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -449,10 +449,10 @@ attestation = [
 [package.metadata]
 requires-dist = [
     { name = "cel-python", specifier = ">=0.5.0" },
-    { name = "cryptography", marker = "extra == 'attestation'", specifier = ">=46.0.6" },
+    { name = "cryptography", marker = "extra == 'attestation'", specifier = ">=46.0.6,<48" },
     { name = "in-toto-attestation", marker = "extra == 'attestation'", specifier = ">=0.9.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.23.0,<2" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -460,7 +460,7 @@ requires-dist = [
     { name = "sigstore", marker = "extra == 'attestation'", specifier = ">=3.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "tomllib-stubs", marker = "python_full_version < '3.11'", specifier = ">=0.1.0" },
-    { name = "urllib3", marker = "extra == 'attestation'", specifier = ">=2.6.3" },
+    { name = "urllib3", marker = "extra == 'attestation'", specifier = ">=2.6.3,<3" },
 ]
 provides-extras = ["attestation"]
 


### PR DESCRIPTION
Adds a unit test for the `detect_forge` function to verify correct behavior when the git command times out.

The test mocks `subprocess.run` to raise a `TimeoutExpired` exception and ensures the function returns "unknown".

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Testing

- [x] Tests pass locally (`uv run pytest tests/ -v`)
- [x] Added tests for new functionality (if applicable)

## Additional Notes

This improves coverage for error handling in the detectors module.