### PR TITLE
fix: recognize YAML/Markdown issue templates for OSPS-DO-02.01

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -1242,7 +1242,12 @@ help_md = """Create a guide for reporting bugs and defects.
 
 [controls."OSPS-DO-02.01".locator]
 project_path = "security.policy"
-discover = [".github/ISSUE_TEMPLATE/bug_report.md", ".github/ISSUE_TEMPLATE/bug_report.yml", ".github/ISSUE_TEMPLATE.md"]
+discover = [
+  ".github/ISSUE_TEMPLATE/*bug*.md",
+  ".github/ISSUE_TEMPLATE/*bug*.yml",
+  ".github/ISSUE_TEMPLATE/*bug*.yaml",
+  ".github/ISSUE_TEMPLATE.md",
+]
 kind = "file"
 
 [controls."OSPS-DO-02.01".locator.llm_hints]
@@ -1256,7 +1261,14 @@ use_locator = true
 
 [[controls."OSPS-DO-02.01".passes]]
 handler = "pattern"
-files = [".github/ISSUE_TEMPLATE/bug_report.md", ".github/ISSUE_TEMPLATE/bug_report.yml", ".github/ISSUE_TEMPLATE.md", "README.md", "CONTRIBUTING.md"]
+files = [
+  ".github/ISSUE_TEMPLATE/*bug*.md",
+  ".github/ISSUE_TEMPLATE/*bug*.yml",
+  ".github/ISSUE_TEMPLATE/*bug*.yaml",
+  ".github/ISSUE_TEMPLATE.md",
+  "README.md",
+  "CONTRIBUTING.md",
+]
 pass_if_any = true
 
 [controls."OSPS-DO-02.01".passes.pattern.patterns]

--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -1243,9 +1243,9 @@ help_md = """Create a guide for reporting bugs and defects.
 [controls."OSPS-DO-02.01".locator]
 project_path = "security.policy"
 discover = [
-  ".github/ISSUE_TEMPLATE/*bug*.md",
-  ".github/ISSUE_TEMPLATE/*bug*.yml",
-  ".github/ISSUE_TEMPLATE/*bug*.yaml",
+  ".github/ISSUE_TEMPLATE/bug*.md",
+  ".github/ISSUE_TEMPLATE/bug*.yml",
+  ".github/ISSUE_TEMPLATE/bug*.yaml",
   ".github/ISSUE_TEMPLATE.md",
 ]
 kind = "file"
@@ -1262,9 +1262,9 @@ use_locator = true
 [[controls."OSPS-DO-02.01".passes]]
 handler = "pattern"
 files = [
-  ".github/ISSUE_TEMPLATE/*bug*.md",
-  ".github/ISSUE_TEMPLATE/*bug*.yml",
-  ".github/ISSUE_TEMPLATE/*bug*.yaml",
+  ".github/ISSUE_TEMPLATE/bug*.md",
+  ".github/ISSUE_TEMPLATE/bug*.yml",
+  ".github/ISSUE_TEMPLATE/bug*.yaml",
   ".github/ISSUE_TEMPLATE.md",
   "README.md",
   "CONTRIBUTING.md",

--- a/tests/darnit_baseline/test_handler_dispatch_integration.py
+++ b/tests/darnit_baseline/test_handler_dispatch_integration.py
@@ -35,6 +35,7 @@ def clean_registry():
 
 def _make_handler(status, message="ok", evidence=None, confidence=1.0):
     """Create a simple handler function that returns a fixed result."""
+
     def handler(config, context):
         return HandlerResult(
             status=status,
@@ -42,6 +43,7 @@ def _make_handler(status, message="ok", evidence=None, confidence=1.0):
             confidence=confidence,
             evidence=evidence or {},
         )
+
     return handler
 
 
@@ -89,9 +91,7 @@ class TestHandlerAliases:
 
         assert regex_info is not None, "regex handler not registered"
         assert pattern_info is not None, "pattern alias not registered"
-        assert regex_info.fn is pattern_info.fn, (
-            "pattern alias should resolve to same handler function as regex"
-        )
+        assert regex_info.fn is pattern_info.fn, "pattern alias should resolve to same handler function as regex"
 
     @pytest.mark.unit
     def test_manual_alias_resolves_to_manual_steps_handler(self):
@@ -114,8 +114,8 @@ class TestHandlerAliases:
         toml_handler_names = [
             "exec",
             "file_exists",
-            "pattern",       # alias for regex
-            "manual",        # alias for manual_steps
+            "pattern",  # alias for regex
+            "manual",  # alias for manual_steps
             "file_create",
             "api_call",
             # Canonical names should also work
@@ -147,9 +147,7 @@ class TestTomlControlsLoadAsHandlerFormat:
         assert impl is not None, "openssf-baseline implementation not found"
 
         toml_path = impl.get_framework_config_path()
-        assert toml_path is not None and Path(toml_path).exists(), (
-            f"Framework TOML not found at {toml_path}"
-        )
+        assert toml_path is not None and Path(toml_path).exists(), f"Framework TOML not found at {toml_path}"
 
         controls = load_controls_from_toml(toml_path)
         assert len(controls) > 0, "No controls loaded from TOML"
@@ -162,24 +160,19 @@ class TestTomlControlsLoadAsHandlerFormat:
             if invocations:
                 controls_with_handlers += 1
                 for inv in invocations:
-                    assert hasattr(inv, "handler"), (
-                        f"Control {spec.control_id}: invocation missing 'handler' field"
-                    )
+                    assert hasattr(inv, "handler"), f"Control {spec.control_id}: invocation missing 'handler' field"
                     # Verify handler name is resolvable
                     registry = get_sieve_handler_registry()
                     handler_name = inv.handler
                     info = registry.get(handler_name)
                     assert info is not None, (
-                        f"Control {spec.control_id}: handler '{handler_name}' "
-                        f"not found in registry"
+                        f"Control {spec.control_id}: handler '{handler_name}' not found in registry"
                     )
             else:
                 controls_without_handlers += 1
 
         # Most controls should have handler invocations
-        assert controls_with_handlers > 50, (
-            f"Expected >50 controls with handlers, got {controls_with_handlers}"
-        )
+        assert controls_with_handlers > 50, f"Expected >50 controls with handlers, got {controls_with_handlers}"
 
 
 # =============================================================================
@@ -436,9 +429,18 @@ class TestUseLocatorEffectivePath:
 
         # Known controls that use use_locator=true
         use_locator_controls = {
-            "OSPS-BR-07.01", "OSPS-DO-01.01", "OSPS-DO-02.01", "OSPS-GV-03.01",
-            "OSPS-LE-01.01", "OSPS-LE-03.01", "OSPS-QA-02.01", "OSPS-VM-02.01",
-            "OSPS-GV-01.01", "OSPS-VM-05.03", "OSPS-DO-03.01", "OSPS-SA-03.02",
+            "OSPS-BR-07.01",
+            "OSPS-DO-01.01",
+            "OSPS-DO-02.01",
+            "OSPS-GV-03.01",
+            "OSPS-LE-01.01",
+            "OSPS-LE-03.01",
+            "OSPS-QA-02.01",
+            "OSPS-VM-02.01",
+            "OSPS-GV-01.01",
+            "OSPS-VM-05.03",
+            "OSPS-DO-03.01",
+            "OSPS-SA-03.02",
         }
 
         for ctrl in controls:
@@ -458,3 +460,82 @@ class TestUseLocatorEffectivePath:
                         f"use_locator not resolved! Got: {inv_dict}"
                     )
                     break
+
+    @pytest.mark.unit
+    def test_osps_do_02_01_effective_config_uses_bug_globs(self):
+        """OSPS-DO-02.01 should resolve explicit bug-template glob patterns."""
+        from pathlib import Path
+
+        from darnit.config import load_controls_from_effective, load_effective_config_by_name
+
+        config = load_effective_config_by_name("openssf-baseline", Path("."))
+        controls = load_controls_from_effective(config)
+        control = next(ctrl for ctrl in controls if ctrl.control_id == "OSPS-DO-02.01")
+        invocations = control.metadata["handler_invocations"]
+
+        file_exists_inv = next((inv for inv in invocations if inv.handler == "file_exists"), None)
+        assert file_exists_inv is not None
+        assert file_exists_inv.files == [
+            ".github/ISSUE_TEMPLATE/*bug*.md",
+            ".github/ISSUE_TEMPLATE/*bug*.yml",
+            ".github/ISSUE_TEMPLATE/*bug*.yaml",
+            ".github/ISSUE_TEMPLATE.md",
+        ]
+
+        pattern_inv = next((inv for inv in invocations if inv.handler == "pattern"), None)
+        assert pattern_inv is not None
+        assert pattern_inv.files == [
+            ".github/ISSUE_TEMPLATE/*bug*.md",
+            ".github/ISSUE_TEMPLATE/*bug*.yml",
+            ".github/ISSUE_TEMPLATE/*bug*.yaml",
+            ".github/ISSUE_TEMPLATE.md",
+            "README.md",
+            "CONTRIBUTING.md",
+        ]
+
+
+class TestIssueTemplateGlobbingRegression:
+    """Regression coverage for OSPS-DO-02.01 issue template globbing."""
+
+    @pytest.mark.unit
+    def test_osps_do_02_01_passes_for_bug_yaml_issue_form(self, tmp_path):
+        """A GitHub issue form at bug.yaml should satisfy OSPS-DO-02.01."""
+        from pathlib import Path
+
+        from darnit.config import load_controls_from_effective, load_effective_config_by_name
+
+        issue_templates = tmp_path / ".github" / "ISSUE_TEMPLATE"
+        issue_templates.mkdir(parents=True)
+        (issue_templates / "bug.yaml").write_text(
+            """name: Bug Report
+description: File a bug report
+body:
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+  - type: textarea
+    attributes:
+      label: Expected behavior
+  - type: textarea
+    attributes:
+      label: Actual behavior
+""",
+        )
+
+        config = load_effective_config_by_name("openssf-baseline", Path("."))
+        controls = load_controls_from_effective(config)
+        control = next(ctrl for ctrl in controls if ctrl.control_id == "OSPS-DO-02.01")
+
+        orchestrator = SieveOrchestrator()
+        context = CheckContext(
+            owner="testorg",
+            repo="testrepo",
+            local_path=str(tmp_path),
+            default_branch="main",
+            control_id="OSPS-DO-02.01",
+            project_context={},
+        )
+        result = orchestrator.verify(control, context)
+
+        assert result.status == "PASS"
+        assert result.evidence.get("relative_path") == ".github/ISSUE_TEMPLATE/bug.yaml"

--- a/tests/darnit_baseline/test_handler_dispatch_integration.py
+++ b/tests/darnit_baseline/test_handler_dispatch_integration.py
@@ -498,15 +498,25 @@ class TestIssueTemplateGlobbingRegression:
     """Regression coverage for OSPS-DO-02.01 issue template globbing."""
 
     @pytest.mark.unit
-    def test_osps_do_02_01_passes_for_bug_yaml_issue_form(self, tmp_path):
-        """A GitHub issue form at bug.yaml should satisfy OSPS-DO-02.01."""
+    @pytest.mark.parametrize(
+        "template_filename",
+        [
+            "bug_report.md",
+            "bug_report.yml",
+            "bug.md",
+            "bug.yml",
+            "bug.yaml",
+        ],
+    )
+    def test_osps_do_02_01_passes_for_bug_template(self, tmp_path, template_filename):
+        """OSPS-DO-02.01 should pass for reasonable bug template filenames."""
         from pathlib import Path
 
         from darnit.config import load_controls_from_effective, load_effective_config_by_name
 
         issue_templates = tmp_path / ".github" / "ISSUE_TEMPLATE"
         issue_templates.mkdir(parents=True)
-        (issue_templates / "bug.yaml").write_text(
+        (issue_templates / template_filename).write_text(
             """name: Bug Report
 description: File a bug report
 body:
@@ -538,4 +548,43 @@ body:
         result = orchestrator.verify(control, context)
 
         assert result.status == "PASS"
-        assert result.evidence.get("relative_path") == ".github/ISSUE_TEMPLATE/bug.yaml"
+        assert result.evidence.get("relative_path") == f".github/ISSUE_TEMPLATE/{template_filename}"
+
+    @pytest.mark.unit
+    def test_osps_do_02_01_fails_for_feature_only_template(self, tmp_path):
+        """OSPS-DO-02.01 should fail when only a feature template exists."""
+        from pathlib import Path
+
+        from darnit.config import load_controls_from_effective, load_effective_config_by_name
+
+        issue_templates = tmp_path / ".github" / "ISSUE_TEMPLATE"
+        issue_templates.mkdir(parents=True)
+        (issue_templates / "feature.yaml").write_text(
+            """name: Feature Request
+description: Suggest a feature
+body:
+  - type: textarea
+    attributes:
+      label: Problem statement
+  - type: textarea
+    attributes:
+      label: Proposed solution
+""",
+        )
+
+        config = load_effective_config_by_name("openssf-baseline", Path("."))
+        controls = load_controls_from_effective(config)
+        control = next(ctrl for ctrl in controls if ctrl.control_id == "OSPS-DO-02.01")
+
+        orchestrator = SieveOrchestrator()
+        context = CheckContext(
+            owner="testorg",
+            repo="testrepo",
+            local_path=str(tmp_path),
+            default_branch="main",
+            control_id="OSPS-DO-02.01",
+            project_context={},
+        )
+        result = orchestrator.verify(control, context)
+
+        assert result.status == "FAIL"

--- a/tests/darnit_baseline/test_handler_dispatch_integration.py
+++ b/tests/darnit_baseline/test_handler_dispatch_integration.py
@@ -35,7 +35,6 @@ def clean_registry():
 
 def _make_handler(status, message="ok", evidence=None, confidence=1.0):
     """Create a simple handler function that returns a fixed result."""
-
     def handler(config, context):
         return HandlerResult(
             status=status,
@@ -43,7 +42,6 @@ def _make_handler(status, message="ok", evidence=None, confidence=1.0):
             confidence=confidence,
             evidence=evidence or {},
         )
-
     return handler
 
 
@@ -91,7 +89,9 @@ class TestHandlerAliases:
 
         assert regex_info is not None, "regex handler not registered"
         assert pattern_info is not None, "pattern alias not registered"
-        assert regex_info.fn is pattern_info.fn, "pattern alias should resolve to same handler function as regex"
+        assert regex_info.fn is pattern_info.fn, (
+            "pattern alias should resolve to same handler function as regex"
+        )
 
     @pytest.mark.unit
     def test_manual_alias_resolves_to_manual_steps_handler(self):
@@ -114,8 +114,8 @@ class TestHandlerAliases:
         toml_handler_names = [
             "exec",
             "file_exists",
-            "pattern",  # alias for regex
-            "manual",  # alias for manual_steps
+            "pattern",       # alias for regex
+            "manual",        # alias for manual_steps
             "file_create",
             "api_call",
             # Canonical names should also work
@@ -147,7 +147,9 @@ class TestTomlControlsLoadAsHandlerFormat:
         assert impl is not None, "openssf-baseline implementation not found"
 
         toml_path = impl.get_framework_config_path()
-        assert toml_path is not None and Path(toml_path).exists(), f"Framework TOML not found at {toml_path}"
+        assert toml_path is not None and Path(toml_path).exists(), (
+            f"Framework TOML not found at {toml_path}"
+        )
 
         controls = load_controls_from_toml(toml_path)
         assert len(controls) > 0, "No controls loaded from TOML"
@@ -160,19 +162,24 @@ class TestTomlControlsLoadAsHandlerFormat:
             if invocations:
                 controls_with_handlers += 1
                 for inv in invocations:
-                    assert hasattr(inv, "handler"), f"Control {spec.control_id}: invocation missing 'handler' field"
+                    assert hasattr(inv, "handler"), (
+                        f"Control {spec.control_id}: invocation missing 'handler' field"
+                    )
                     # Verify handler name is resolvable
                     registry = get_sieve_handler_registry()
                     handler_name = inv.handler
                     info = registry.get(handler_name)
                     assert info is not None, (
-                        f"Control {spec.control_id}: handler '{handler_name}' not found in registry"
+                        f"Control {spec.control_id}: handler '{handler_name}' "
+                        f"not found in registry"
                     )
             else:
                 controls_without_handlers += 1
 
         # Most controls should have handler invocations
-        assert controls_with_handlers > 50, f"Expected >50 controls with handlers, got {controls_with_handlers}"
+        assert controls_with_handlers > 50, (
+            f"Expected >50 controls with handlers, got {controls_with_handlers}"
+        )
 
 
 # =============================================================================
@@ -429,18 +436,9 @@ class TestUseLocatorEffectivePath:
 
         # Known controls that use use_locator=true
         use_locator_controls = {
-            "OSPS-BR-07.01",
-            "OSPS-DO-01.01",
-            "OSPS-DO-02.01",
-            "OSPS-GV-03.01",
-            "OSPS-LE-01.01",
-            "OSPS-LE-03.01",
-            "OSPS-QA-02.01",
-            "OSPS-VM-02.01",
-            "OSPS-GV-01.01",
-            "OSPS-VM-05.03",
-            "OSPS-DO-03.01",
-            "OSPS-SA-03.02",
+            "OSPS-BR-07.01", "OSPS-DO-01.01", "OSPS-DO-02.01", "OSPS-GV-03.01",
+            "OSPS-LE-01.01", "OSPS-LE-03.01", "OSPS-QA-02.01", "OSPS-VM-02.01",
+            "OSPS-GV-01.01", "OSPS-VM-05.03", "OSPS-DO-03.01", "OSPS-SA-03.02",
         }
 
         for ctrl in controls:
@@ -476,18 +474,18 @@ class TestUseLocatorEffectivePath:
         file_exists_inv = next((inv for inv in invocations if inv.handler == "file_exists"), None)
         assert file_exists_inv is not None
         assert file_exists_inv.files == [
-            ".github/ISSUE_TEMPLATE/*bug*.md",
-            ".github/ISSUE_TEMPLATE/*bug*.yml",
-            ".github/ISSUE_TEMPLATE/*bug*.yaml",
+            ".github/ISSUE_TEMPLATE/bug*.md",
+            ".github/ISSUE_TEMPLATE/bug*.yml",
+            ".github/ISSUE_TEMPLATE/bug*.yaml",
             ".github/ISSUE_TEMPLATE.md",
         ]
 
         pattern_inv = next((inv for inv in invocations if inv.handler == "pattern"), None)
         assert pattern_inv is not None
         assert pattern_inv.files == [
-            ".github/ISSUE_TEMPLATE/*bug*.md",
-            ".github/ISSUE_TEMPLATE/*bug*.yml",
-            ".github/ISSUE_TEMPLATE/*bug*.yaml",
+            ".github/ISSUE_TEMPLATE/bug*.md",
+            ".github/ISSUE_TEMPLATE/bug*.yml",
+            ".github/ISSUE_TEMPLATE/bug*.yaml",
             ".github/ISSUE_TEMPLATE.md",
             "README.md",
             "CONTRIBUTING.md",

--- a/uv.lock
+++ b/uv.lock
@@ -449,10 +449,10 @@ attestation = [
 [package.metadata]
 requires-dist = [
     { name = "cel-python", specifier = ">=0.5.0" },
-    { name = "cryptography", marker = "extra == 'attestation'", specifier = ">=46.0.6" },
+    { name = "cryptography", marker = "extra == 'attestation'", specifier = ">=46.0.6,<48" },
     { name = "in-toto-attestation", marker = "extra == 'attestation'", specifier = ">=0.9.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.23.0,<2" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -460,7 +460,7 @@ requires-dist = [
     { name = "sigstore", marker = "extra == 'attestation'", specifier = ">=3.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "tomllib-stubs", marker = "python_full_version < '3.11'", specifier = ">=0.1.0" },
-    { name = "urllib3", marker = "extra == 'attestation'", specifier = ">=2.6.3" },
+    { name = "urllib3", marker = "extra == 'attestation'", specifier = ">=2.6.3,<3" },
 ]
 provides-extras = ["attestation"]
 


### PR DESCRIPTION
## Summary

Fix `OSPS-DO-02.01` false negatives for repositories that use YAML/Markdown issue templates in `.github/ISSUE_TEMPLATE/` with names like `bug.yaml` instead of `bug_report.md`.

## FIX
#222 

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist

If this PR modifies the darnit framework (`packages/darnit/`):

- [ ] Updated framework spec (`openspec/specs/framework-design/spec.md`) if behavior changed
- [x] Ran `uv run python scripts/validate_sync.py --verbose` and it passes
- [x] Ran `uv run python scripts/generate_docs.py` and committed any doc changes

## Control/TOML Changes Checklist

If this PR modifies controls or TOML configuration:

- [x] Control metadata defined in TOML (not Python code)
- [ ] SARIF fields (description, severity, help_url) included where appropriate
- [x] Ran validation to confirm TOML schema compliance

## Testing

- [ ] Tests pass locally (`uv run pytest tests/ -v`)
- [x] Added tests for new functionality (if applicable)
- [x] Linting passes (`uv run ruff check .`)

## Additional Notes

Root cause: `OSPS-DO-02.01` only looked for `bug_report.md` / `bug_report.yml`, so repos using GitHub issue forms such as `.github/ISSUE_TEMPLATE/bug.yaml` were incorrectly marked as failing. This change broadens control detection with explicit Python-glob-compatible patterns and regression coverage.

Validation notes:
- `uv run pytest tests/darnit_baseline/test_handler_dispatch_integration.py -v` passed.
- `uv run pytest tests/darnit/sieve/test_builtin_handlers.py -v` passed.
- `uv run pytest tests/ -m integration -v --tb=short` passed.
- `uv run ruff check .` passed.
- `uv run ruff format --check --diff .` still reports many pre-existing formatting changes outside this PR.
- `uv run mypy packages/darnit/src/darnit/core/plugin.py --ignore-missing-imports` fails on a pre-existing missing return type annotation.
- `uv run mypy packages/darnit-baseline/src/darnit_baseline/tools.py --ignore-missing-imports --no-error-summary --show-error-codes` fails on pre-existing type issues.
- `uv run pytest tests/ -m unit ...` and the coverage run hang in the pre-existing attestation test `tests/darnit_baseline/attestation/test_generator.py::TestGenerateAttestationFromResults::test_signed_without_dependencies` inside Sigstore OIDC.
