### PR TITLE
feat(packaging): wire PyPI publishing + Sigstore smoke (Phase 3, US1)

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -4,7 +4,7 @@ name: Release Smoke Tests
 # Triggered after .github/workflows/release.yml completes; channel jobs are
 # added phase-by-phase as their channels go live.
 #
-#   Phase 3 (US1) → pypi_smoke
+#   Phase 3 (US1) → pypi_smoke ✅
 #   Phase 4 (US2) → container_smoke
 #   Phase 5 (US3) → binary_smoke + homebrew_smoke
 #   Phase 6 (US4) → plugin_structural_smoke + plugin_behavioral_smoke
@@ -21,14 +21,203 @@ on:
 permissions:
   contents: read
 
-# Channel-specific smoke jobs are added in subsequent phases. This file is a
-# skeleton so the trigger contract (workflow_run on "Release") exists before
-# the first channel job is wired up.
 jobs:
-  noop:
-    name: Skeleton — no channels wired yet
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  # Parse the tag that triggered the Release workflow. workflow_run carries the
+  # triggering ref in github.event.workflow_run.head_branch (for tag triggers,
+  # this is the tag name).
+  parse-trigger:
+    name: Parse triggering tag
+    if: ${{ github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'v') && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+      is_prerelease: ${{ steps.parse.outputs.is_prerelease }}
+      index_url: ${{ steps.parse.outputs.index_url }}
     steps:
-      - run: echo "release-smoke.yml skeleton. Channel-specific smoke jobs will be added in Phases 3–6."
+      - name: Parse
+        id: parse
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          tag="$HEAD_BRANCH"
+          if [[ "$tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            version="${BASH_REMATCH[1]}"
+            is_prerelease="false"
+            index_url="https://pypi.org/simple/"
+          elif [[ "$tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+rc[0-9]+)$ ]]; then
+            version="${BASH_REMATCH[1]}"
+            is_prerelease="true"
+            index_url="https://test.pypi.org/simple/"
+          else
+            echo "::error::Trigger ref '$tag' is not a release tag — smoke skipped"
+            exit 1
+          fi
+          {
+            echo "version=$version"
+            echo "is_prerelease=$is_prerelease"
+            echo "index_url=$index_url"
+          } >> "$GITHUB_OUTPUT"
+          echo "Parsed: tag=$tag version=$version is_prerelease=$is_prerelease index=$index_url"
+
+  # T015: install each public package from the selected index in a clean venv,
+  # then run a per-package smoke check (CLI version for darnit-mcp, import for
+  # the others).
+  # T016: verify each package's Sigstore attestation against the release
+  # workflow's OIDC identity.
+  pypi_smoke:
+    name: pypi_smoke (${{ matrix.package }})
+    needs: parse-trigger
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [darnit, darnit-baseline, darnit-gittuf, darnit-mcp]
+    steps:
+      - name: Checkout (for public-packages.txt sanity check)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          persist-credentials: false
+
+      - name: Verify package is in the public set
+        env:
+          PKG: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          if ! grep -Fxq "$PKG" packaging/pypi/public-packages.txt; then
+            echo "::error::Matrix package '$PKG' is not in packaging/pypi/public-packages.txt"
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install sigstore CLI (T016)
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install 'sigstore>=3.0.0,<4'
+
+      - name: Install ${{ matrix.package }} from ${{ needs.parse-trigger.outputs.is_prerelease == 'true' && 'TestPyPI' || 'PyPI' }}
+        env:
+          PKG: ${{ matrix.package }}
+          VERSION: ${{ needs.parse-trigger.outputs.version }}
+          INDEX_URL: ${{ needs.parse-trigger.outputs.index_url }}
+        run: |
+          set -euo pipefail
+          python -m venv "/tmp/smoke-$PKG"
+          # --extra-index-url falls back to PyPI for transitive deps that
+          # only exist there (e.g., tree-sitter for darnit-baseline). The
+          # primary --index-url is the index we just published to.
+          "/tmp/smoke-$PKG/bin/pip" install --upgrade pip
+          "/tmp/smoke-$PKG/bin/pip" install \
+            --index-url "$INDEX_URL" \
+            --extra-index-url https://pypi.org/simple/ \
+            --pre \
+            "${PKG}==${VERSION}"
+
+      - name: Per-package smoke check (T015)
+        env:
+          PKG: ${{ matrix.package }}
+          VERSION: ${{ needs.parse-trigger.outputs.version }}
+        run: |
+          set -euo pipefail
+          venv="/tmp/smoke-$PKG"
+          case "$PKG" in
+            "darnit-mcp")
+              # darnit-mcp installs the `darnit` console script via its
+              # darnit dependency. Confirm the CLI is reachable and reports
+              # the expected version.
+              actual=$("$venv/bin/darnit" --version 2>&1 | tail -n1)
+              echo "darnit --version → $actual"
+              echo "$actual" | grep -F "$VERSION"
+              ;;
+            "darnit")
+              "$venv/bin/python" -c "import darnit; print('darnit imports OK')"
+              ;;
+            "darnit-baseline")
+              "$venv/bin/python" -c "import darnit_baseline; print('darnit_baseline imports OK')"
+              ;;
+            "darnit-gittuf")
+              "$venv/bin/python" -c "import darnit_gittuf; print('darnit_gittuf imports OK')"
+              ;;
+            *)
+              echo "::error::No smoke recipe defined for package '$PKG'"
+              exit 1
+              ;;
+          esac
+
+      - name: Verify Sigstore attestation (T016)
+        env:
+          PKG: ${{ matrix.package }}
+          VERSION: ${{ needs.parse-trigger.outputs.version }}
+          IS_PRERELEASE: ${{ needs.parse-trigger.outputs.is_prerelease }}
+          INDEX_URL: ${{ needs.parse-trigger.outputs.index_url }}
+        run: |
+          set -euo pipefail
+          # Download the wheel directly so we can verify the attestation
+          # against the actual artifact bytes.
+          mkdir -p /tmp/dl
+          "/tmp/smoke-$PKG/bin/pip" download \
+            --no-deps \
+            --dest /tmp/dl \
+            --index-url "$INDEX_URL" \
+            --extra-index-url https://pypi.org/simple/ \
+            --pre \
+            "${PKG}==${VERSION}"
+
+          # Find the .whl. PyPI normalizes hyphens to underscores in wheel
+          # filenames, so we match by version rather than exact package name.
+          wheel=$(find /tmp/dl -maxdepth 1 -type f -name "*-${VERSION}*.whl" | head -n1)
+          if [ -z "$wheel" ]; then
+            echo "::error::No wheel for $PKG $VERSION found in /tmp/dl"
+            exit 1
+          fi
+          echo "Verifying $wheel"
+
+          # PyPI exposes attestations via its provenance API. Fetch the
+          # provenance bundle and verify it. Same path on test.pypi.org.
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            pypi_host="test.pypi.org"
+          else
+            pypi_host="pypi.org"
+          fi
+          wheel_basename=$(basename "$wheel")
+          provenance_url="https://${pypi_host}/integrity/${PKG}/${VERSION}/${wheel_basename}/provenance"
+          echo "Fetching $provenance_url"
+          if ! curl -fsSLo /tmp/provenance.json "$provenance_url"; then
+            echo "::error::Could not fetch provenance for $PKG $VERSION at $provenance_url. PEP 740 attestation is required for FR-003."
+            exit 1
+          fi
+
+          # The provenance response contains attestation_bundles[].attestations[].
+          # Extract the first attestation as a sigstore-readable bundle file.
+          python <<'PY'
+          import json, sys
+          with open('/tmp/provenance.json') as f:
+              data = json.load(f)
+          bundles = data.get('attestation_bundles') or []
+          if not bundles:
+              print('::error::No attestation bundles in provenance response')
+              sys.exit(1)
+          attestations = bundles[0].get('attestations') or []
+          if not attestations:
+              print('::error::Attestation bundle is empty')
+              sys.exit(1)
+          with open('/tmp/attestation.sigstore.json', 'w') as out:
+              json.dump(attestations[0], out)
+          print('Extracted attestation to /tmp/attestation.sigstore.json')
+          PY
+
+          python -m sigstore verify identity \
+            --bundle /tmp/attestation.sigstore.json \
+            --cert-identity-regexp '^https://github\.com/kusari-oss/darnit/\.github/workflows/release\.yml@' \
+            --cert-oidc-issuer https://token.actions.githubusercontent.com \
+            "$wheel"
+          echo "✓ Sigstore identity verified for $PKG $VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,13 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v4
         with:
           version: ${{ env.UV_VERSION }}
-          enable-cache: true
+          # Caching is intentionally disabled in the release pipeline.
+          # The blast radius of cache poisoning is significantly elevated
+          # here because this workflow produces and publishes signed
+          # artifacts; a poisoned cache from a prior run could inject
+          # malicious content into the published wheels. Clean builds only.
+          # Flagged by Kusari Inspector on #235.
+          enable-cache: false
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -194,7 +200,13 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v4
         with:
           version: ${{ env.UV_VERSION }}
-          enable-cache: true
+          # Caching is intentionally disabled in the release pipeline.
+          # The blast radius of cache poisoning is significantly elevated
+          # here because this workflow produces and publishes signed
+          # artifacts; a poisoned cache from a prior run could inject
+          # malicious content into the published wheels. Clean builds only.
+          # Flagged by Kusari Inspector on #235.
+          enable-cache: false
 
       - name: Build each public package into its own dist directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,8 +168,161 @@ jobs:
             actionlint .github/workflows/release-smoke.yml
           fi
 
-  # Channel jobs are added in subsequent phases:
-  #   Phase 3 (US1) → pypi_publish
+  # T013: build all public packages once; per-package publish jobs consume the
+  # uploaded artifacts. Splitting build from publish keeps the build cache hot
+  # across the four publish jobs and isolates a build failure from any partial
+  # PyPI state.
+  build:
+    name: Build public packages
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v4
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Build each public package into its own dist directory
+        run: |
+          set -euo pipefail
+          while IFS= read -r pkg; do
+            [ -z "$pkg" ] && continue
+            echo "::group::Building $pkg"
+            uv build --package "$pkg" --out-dir "dist/$pkg"
+            ls -la "dist/$pkg"
+            echo "::endgroup::"
+          done < packaging/pypi/public-packages.txt
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  # T013 + T014: per-package publish. Sequenced via `needs:` because
+  # `darnit-baseline`, `darnit-gittuf`, and `darnit-mcp` declare
+  # `darnit>=...` runtime dependencies — publishing them before darnit
+  # is on the target index would briefly produce unresolvable wheels.
+  # `darnit-mcp` depends on all three other packages, so it publishes last.
+  publish-darnit:
+    name: Publish darnit to ${{ needs.preflight.outputs.is_prerelease == 'true' && 'TestPyPI' || 'PyPI' }}
+    needs: [preflight, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      id-token: write       # OIDC for Trusted Publishing + Sigstore signing
+      attestations: write   # PEP 740 attestations
+      contents: read
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish darnit
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist/darnit/
+          repository-url: ${{ needs.preflight.outputs.is_prerelease == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          attestations: true
+          # We refuse to overwrite published artifacts. If a re-attempt is
+          # needed, the failure path is per-channel recovery, not retry.
+          skip-existing: false
+
+  publish-darnit-baseline:
+    name: Publish darnit-baseline to ${{ needs.preflight.outputs.is_prerelease == 'true' && 'TestPyPI' || 'PyPI' }}
+    needs: [preflight, build, publish-darnit]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish darnit-baseline
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist/darnit-baseline/
+          repository-url: ${{ needs.preflight.outputs.is_prerelease == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          attestations: true
+          skip-existing: false
+
+  publish-darnit-gittuf:
+    name: Publish darnit-gittuf to ${{ needs.preflight.outputs.is_prerelease == 'true' && 'TestPyPI' || 'PyPI' }}
+    needs: [preflight, build, publish-darnit]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish darnit-gittuf
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist/darnit-gittuf/
+          repository-url: ${{ needs.preflight.outputs.is_prerelease == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          attestations: true
+          skip-existing: false
+
+  publish-darnit-mcp:
+    name: Publish darnit-mcp to ${{ needs.preflight.outputs.is_prerelease == 'true' && 'TestPyPI' || 'PyPI' }}
+    needs: [preflight, build, publish-darnit-baseline, publish-darnit-gittuf]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish darnit-mcp
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist/darnit-mcp/
+          repository-url: ${{ needs.preflight.outputs.is_prerelease == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          attestations: true
+          skip-existing: false
+
+  # Channel jobs added in later phases:
   #   Phase 4 (US2) → container_build_push
   #   Phase 5 (US3) → binary_matrix + homebrew_dispatch
   #   Phase 6 (US4) → plugin_package

--- a/docs/install/pypi.md
+++ b/docs/install/pypi.md
@@ -1,0 +1,115 @@
+# Install darnit from PyPI
+
+This is the recommended install path for users who have **Python 3.11 or 3.12** already installed. Examples assume version `0.1.0` — substitute the version you want.
+
+## Pick an install command
+
+```bash
+# pipx — isolated install, recommended for end users
+pipx install darnit-mcp==0.1.0
+
+# uv — fastest, modern
+uv tool install darnit-mcp==0.1.0
+
+# pip — works in any virtualenv
+pip install darnit-mcp==0.1.0
+```
+
+After install, `darnit --version` should print `0.1.0`.
+
+## Pre-releases (TestPyPI)
+
+Pre-releases (`rcN` suffix) are published to TestPyPI only. To install one:
+
+```bash
+pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  --pre \
+  darnit-mcp==0.1.0rc1
+```
+
+The `--extra-index-url` is required so dependencies of darnit that exist only on PyPI (e.g. `tree-sitter`, `mcp`, `pydantic`) can still be resolved.
+
+## Verify the Sigstore attestation
+
+Every release attaches a [PEP 740](https://peps.python.org/pep-0740/) Sigstore attestation. The signing identity is the GitHub Actions workflow that produced the wheel; you can verify the chain back to the canonical repository without trusting anything in between.
+
+### One-step verification with pip
+
+If your pip is 25.0 or newer, `--verify-attestations` does the whole thing automatically:
+
+```bash
+pip install --verify-attestations darnit-mcp==0.1.0
+```
+
+pip refuses to install if the attestation is missing or fails to verify against PyPI's public certs.
+
+### Manual verification with `sigstore`
+
+If you need to verify outside an install context (security scanning, attestation archives, etc.):
+
+```bash
+# Install the verifier
+pip install 'sigstore>=3.0.0'
+
+# Download the wheel
+pip download --no-deps darnit-mcp==0.1.0
+
+# Fetch the PEP 740 attestation bundle from PyPI's provenance API
+curl -fsSL \
+  "https://pypi.org/integrity/darnit-mcp/0.1.0/darnit_mcp-0.1.0-py3-none-any.whl/provenance" \
+  -o provenance.json
+
+# Extract the first attestation as a sigstore-readable bundle
+python -c "
+import json
+with open('provenance.json') as f:
+    data = json.load(f)
+with open('attestation.sigstore.json', 'w') as out:
+    json.dump(data['attestation_bundles'][0]['attestations'][0], out)
+"
+
+# Verify against the canonical kusari-oss/darnit identity
+python -m sigstore verify identity \
+  --bundle attestation.sigstore.json \
+  --cert-identity-regexp '^https://github\.com/kusari-oss/darnit/\.github/workflows/release\.yml@' \
+  --cert-oidc-issuer https://token.actions.githubusercontent.com \
+  darnit_mcp-0.1.0-py3-none-any.whl
+```
+
+A passing verification proves:
+
+- The wheel bytes match exactly what was signed.
+- The signer was the `release.yml` workflow in `kusari-oss/darnit`.
+- The OIDC issuer was GitHub Actions (not some other identity provider).
+
+For TestPyPI pre-releases, substitute `test.pypi.org` for `pypi.org` in the provenance URL.
+
+## Public package set
+
+Each release publishes four packages in lockstep:
+
+| Package | Purpose |
+|---|---|
+| `darnit` | Core framework (you'll usually install `darnit-mcp`, which pulls this in) |
+| `darnit-baseline` | OpenSSF Baseline compliance implementation |
+| `darnit-gittuf` | Gittuf policy plugin |
+| `darnit-mcp` | The MCP server entry point — installs the `darnit` CLI |
+
+For most users, `pip install darnit-mcp` is the right command. The other packages exist for users who want only the framework, only a specific implementation, or who are writing their own implementation plugin (see [`docs/packaging-plugins.md`](../packaging-plugins.md)).
+
+## Prerequisites
+
+- **Python 3.11 or 3.12** — older Python versions are not supported and will fail to install
+- **Network access to pypi.org** (or test.pypi.org for pre-releases)
+- Some darnit controls invoke `git` and the `gh` CLI at audit time. If you only `pip install`, you'll need to install those separately. The [container image](container.md) bundles them.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `ERROR: Package requires a different Python` | Host Python is older than 3.11. Install Python 3.11+ or use [pipx](https://pipx.pypa.io/) with an explicit `--python` flag. |
+| `Could not find a version that satisfies the requirement` (for a pre-release) | Missing `--pre` flag or wrong `--index-url`. |
+| Sigstore verification fails with "no attestation bundles" | The release was published before PEP 740 attestations existed, or the attestation hasn't propagated yet (rare; retry in a few minutes). |
+| Sigstore verification fails with "identity mismatch" | The wheel was not signed by `kusari-oss/darnit`'s release workflow. **Do not trust this artifact.** Report it via the project's security policy. |

--- a/packaging/RECOVERY.md
+++ b/packaging/RECOVERY.md
@@ -19,15 +19,57 @@ If recovery is impossible (e.g., a wheel uploaded under the wrong version), the 
 
 ## PyPI
 
-> _Filled by Phase 3 (User Story 1)._
+The four per-package publish jobs (`publish-darnit`, `publish-darnit-baseline`, `publish-darnit-gittuf`, `publish-darnit-mcp`) are sequenced via `needs:` and `darnit` always publishes first. A failure can leave some packages uploaded and others not.
 
-Failure modes:
+### Failure mode 1 — One or more packages uploaded; one failed mid-flight
 
-- Upload to PyPI succeeded for some packages and failed for others.
-- Sigstore attestation upload failed.
-- TestPyPI publish failed for a pre-release tag.
+**Symptom**: `release.yml` shows green for some `publish-*` jobs and red for others. PyPI/TestPyPI shows the green ones live.
 
-Repair procedure: _TBD in T018._
+**Important**: PyPI versions are **immutable**. You cannot re-upload version `X.Y.Z` after one byte of it is on the index, even via the `release.yml` re-run path (which preflight rejects anyway).
+
+**Procedure**:
+
+1. Determine which packages uploaded successfully. The `release.yml` job summary names each failed publish; PyPI's project page is the source of truth (`https://pypi.org/project/<package>/<version>/`).
+2. **For the failed packages**:
+   - If the failure was transient (network, OIDC token, rate limit) and re-running the publish step succeeds: download the dist artifact from the failed workflow run via `gh run download <run-id> --name dist`. Manually invoke the publish action against the package's `dist/<pkg>/` subdirectory, using the same OIDC environment. PyPI is **not** idempotent — if even one wheel for the version is up, the whole upload is rejected.
+   - If the failure was permanent (bad metadata, missing classifier, name collision): **roll forward to a fresh version**. PyPI version numbers cannot be reused; bump to a patch (`X.Y.Z+1`) and re-tag. The already-uploaded packages from the failed run remain on PyPI at the original version but will be unused — yank them via `https://pypi.org/manage/project/<pkg>/release/<version>/`.
+3. **For the succeeded packages**: leave them. Yanking is only necessary if the bad release was already advertised.
+
+### Failure mode 2 — Sigstore attestation upload failed
+
+**Symptom**: Wheel uploaded successfully to PyPI but `release.yml` reports a failure in the publish step's attestation sub-step, OR a smoke run reports "no attestation bundles in provenance response".
+
+**Important**: PEP 740 attestations are signed at publish time. You cannot retroactively add a Sigstore attestation to an existing PyPI release.
+
+**Procedure**:
+
+1. Confirm the wheel itself is on PyPI (`pip download <pkg>==<version>` works).
+2. Bump to `X.Y.Z+1` and re-tag — the new release will carry a fresh attestation.
+3. Yank `X.Y.Z` once `X.Y.Z+1` is up to prevent users from installing the un-attested version.
+
+### Failure mode 3 — TestPyPI failure on a pre-release tag
+
+**Symptom**: `v<X.Y.Z>rc<N>` tag was pushed; `release.yml` failed during the TestPyPI publish step.
+
+**Important**: TestPyPI has more relaxed policies (its index gets nuked periodically) and is less reliable than PyPI. A failure here is **not** a release-blocking event.
+
+**Procedure**:
+
+1. Verify the failure was on TestPyPI (the index URL in the publish action's log will show `test.pypi.org`).
+2. Optionally re-tag as `v<X.Y.Z>rc<N+1>`. TestPyPI rcN versions are cheap and don't affect stable users.
+3. Do **not** promote the failed `rcN` to a stable tag — fix and bump `rcN+1` first.
+
+### Verification after recovery
+
+After any recovery action, re-run the smoke jobs against the published artifacts:
+
+```bash
+# Find the smoke workflow run that corresponds to the recovered release
+gh run list --repo kusari-oss/darnit --workflow "Release Smoke Tests" --limit 5
+gh run rerun <smoke-run-id> --repo kusari-oss/darnit
+```
+
+The smoke job is read-only and safe to re-run any number of times.
 
 ---
 

--- a/specs/012-packaging-distribution/tasks.md
+++ b/specs/012-packaging-distribution/tasks.md
@@ -66,12 +66,12 @@ description: "Task list for 012-packaging-distribution"
 
 ### Implementation for User Story 1
 
-- [ ] T013 [US1] Add a `pypi_publish` job to `.github/workflows/release.yml` that runs after `preflight`. For each package in `packaging/pypi/public-packages.txt`: `uv build --package <pkg> --out-dir dist/<pkg>/`. Assert that the package name appears in `public-packages.txt` before any upload (refuse to publish unlisted packages).
-- [ ] T014 [US1] In the `pypi_publish` job, use `pypa/gh-action-pypi-publish@release/v1` with `attestations: true`. Target `https://upload.pypi.org/legacy/` for stable tags and `https://test.pypi.org/legacy/` for pre-release tags (detected via the `rc` suffix in `github.ref_name`).
-- [ ] T015 [US1] Add a `pypi_smoke` job to `.github/workflows/release-smoke.yml` that triggers after the release workflow's `pypi_publish` completes. In a clean Python container, `pip install --index-url <selected> --pre <pkg>==<version>` for each public package and run a per-package smoke (for `darnit-mcp`: `darnit --version` matches `<version>`; for others: import smoke).
-- [ ] T016 [US1] Extend `pypi_smoke` to verify the Sigstore bundle for `darnit_mcp` via `python -m sigstore verify identity --cert-identity-regexp '^https://github\\.com/kusari-oss/darnit/' --cert-oidc-issuer https://token.actions.githubusercontent.com`. Fail the smoke if the signature does not verify.
-- [ ] T017 [P] [US1] Write `docs/install/pypi.md` per the PyPI section of `quickstart.md`, including the Sigstore verification command
-- [ ] T018 [P] [US1] Populate the `pypi` section of `packaging/RECOVERY.md` with the manual yank-and-retry recipe when an upload fails mid-flight
+- [X] T013 [US1] Add a `pypi_publish` job to `.github/workflows/release.yml` that runs after `preflight`. For each package in `packaging/pypi/public-packages.txt`: `uv build --package <pkg> --out-dir dist/<pkg>/`. Assert that the package name appears in `public-packages.txt` before any upload (refuse to publish unlisted packages).
+- [X] T014 [US1] In the `pypi_publish` job, use `pypa/gh-action-pypi-publish@release/v1` with `attestations: true`. Target `https://upload.pypi.org/legacy/` for stable tags and `https://test.pypi.org/legacy/` for pre-release tags (detected via the `rc` suffix in `github.ref_name`).
+- [X] T015 [US1] Add a `pypi_smoke` job to `.github/workflows/release-smoke.yml` that triggers after the release workflow's `pypi_publish` completes. In a clean Python container, `pip install --index-url <selected> --pre <pkg>==<version>` for each public package and run a per-package smoke (for `darnit-mcp`: `darnit --version` matches `<version>`; for others: import smoke).
+- [X] T016 [US1] Extend `pypi_smoke` to verify the Sigstore bundle for `darnit_mcp` via `python -m sigstore verify identity --cert-identity-regexp '^https://github\\.com/kusari-oss/darnit/' --cert-oidc-issuer https://token.actions.githubusercontent.com`. Fail the smoke if the signature does not verify.
+- [X] T017 [P] [US1] Write `docs/install/pypi.md` per the PyPI section of `quickstart.md`, including the Sigstore verification command
+- [X] T018 [P] [US1] Populate the `pypi` section of `packaging/RECOVERY.md` with the manual yank-and-retry recipe when an upload fails mid-flight
 - [ ] T019 [US1] Run the end-to-end test from the Independent Test above against a real `v0.0.0rc1` tag; confirm all assertions hold
 
 **Checkpoint US1**: PyPI/pipx install path is live; pre-release flow validated against TestPyPI.


### PR DESCRIPTION
## Summary

**Phase 3 of #234** — User Story 1 (PyPI publishing). After this merges and the Trusted Publishers are configured on pypi.org / test.pypi.org, a tag push results in four Sigstore-signed wheels on the right index, each verifiable by anyone via PEP 740.

This unblocks every downstream channel: the container image installs darnit from PyPI, the Homebrew formula references the same PyPI versions, and the Claude Code plugin invokes `uvx darnit-mcp@<version>`.

Builds on #234. Addresses #228.

## What's in this PR

### `release.yml` — per-package publish chain

A `build` job builds all four public packages into per-package dist directories, then four sequenced publish jobs:

```
preflight → build → publish-darnit ─┬─► publish-darnit-baseline ─┐
                                     ├─► publish-darnit-gittuf ───┴─► publish-darnit-mcp
```

- `darnit` publishes first (it's a runtime dep of the others)
- `darnit-baseline` and `darnit-gittuf` publish in parallel after `darnit`
- `darnit-mcp` publishes last (depends on all three)
- TestPyPI is selected automatically for `rcN` tags via dynamic `repository-url`
- All publishes use Trusted Publishing (OIDC) and emit PEP 740 attestations
- `skip-existing: false` — refuses to re-upload; recovery is per-channel

### `release-smoke.yml` — pypi_smoke (matrix of 4)

`workflow_run`-triggered after the Release workflow completes. For each public package:

1. Installs the exact version from the right index in a clean venv (`--index-url <selected>` + `--extra-index-url https://pypi.org/simple/` for transitive deps)
2. Runs the per-package smoke check (`darnit --version` for `darnit-mcp`; `import` for the others)
3. Downloads the wheel + the provenance bundle from PyPI's `/integrity/.../provenance` API
4. Verifies the Sigstore identity against `release.yml`'s canonical OIDC URI

Smoke is matrix-parallel and `fail-fast: false` so a single broken signature doesn't mask other channels' smoke failures.

### `docs/install/pypi.md` — end-user install guide

Covers `pip` / `pipx` / `uv tool install`, TestPyPI for pre-releases, two verification paths (`pip --verify-attestations` for pip 25+, manual `sigstore` CLI for older pip), and a troubleshooting table.

### `packaging/RECOVERY.md` — PyPI section filled

Three concrete failure modes with recovery procedures:

1. **Mid-flight upload failure** — PyPI version immutability means roll-forward to `X.Y.Z+1`, then yank the orphaned partial.
2. **Sigstore attestation upload failed** — same roll-forward; attestations can't be added retroactively.
3. **TestPyPI flake** — bump to `rcN+1`; pre-releases are cheap.

## Test plan

- [x] `actionlint` passes locally on all three release workflows
- [x] `uv run ruff check .` clean
- [x] `uv run python scripts/validate_sync.py --verbose` passes
- [x] `uv run python scripts/generate_docs.py` produces no diff
- [ ] After merge: configure 4 Trusted Publishers on pypi.org (one per public package — `darnit`, `darnit-baseline`, `darnit-gittuf`, `darnit-mcp`) all pointing to environment `release`
- [ ] After merge: same configuration on test.pypi.org
- [ ] After merge: push `v0.0.0rc0` to dry-run the whole pipeline against TestPyPI; smoke should report 4 signed wheels installed + verified

## Tasks completed

Marks T013, T014, T015, T016, T017, T018 done in `specs/012-packaging-distribution/tasks.md`. 16 of 76 tasks total complete; Phase 3 (US1) is functionally done pending the external Trusted Publisher setup.

## Not in this PR

- T019 (end-to-end test against a real `v0.0.0rc1` tag) — blocked on Trusted Publisher configuration
- Phase 4–8 (container, binary, Homebrew, Claude plugin, third-party plugin guide, polish) — future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)