### PR TITLE
ci(packaging): bump pinned actionlint to v1.7.12 + add SHA-256 verify

### DIFF
--- a/.github/workflows/release-yml-lint.yml
+++ b/.github/workflows/release-yml-lint.yml
@@ -32,9 +32,18 @@ jobs:
           persist-credentials: false
 
       - name: Install actionlint
+        # Version pin must match .github/workflows/release.yml's inline copy
+        # and the version documented in packaging/README.md (the
+        # contributor-runs-locally version). Bumping requires updating all
+        # three call sites in lockstep.
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
         run: |
           set -euo pipefail
-          curl -sSLo /tmp/actionlint.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSLo /tmp/actionlint.tar.gz "$url"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum -c -
           tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
           sudo mv /tmp/actionlint /usr/local/bin/actionlint
           actionlint -version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,10 +159,18 @@ jobs:
 
       # T008a: actionlint over the release workflow files. Catches static issues
       # (typos, undefined matrices) before publishing anything.
+      # Version pin must match .github/workflows/release-yml-lint.yml and the
+      # version documented in packaging/README.md (the contributor-runs-locally
+      # version). Bumping requires updating both call sites + the docs.
       - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
         run: |
           set -euo pipefail
-          curl -sSLo /tmp/actionlint.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSLo /tmp/actionlint.tar.gz "$url"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum -c -
           tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
           sudo mv /tmp/actionlint /usr/local/bin/actionlint
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -71,6 +71,27 @@ See [`RECOVERY.md`](RECOVERY.md). Each channel has a documented recovery path. R
 | `.github/workflows/container-edge.yml` | `main`-branch builds tagged `:edge` (unsigned, non-release) |
 | `.github/workflows/homebrew-bump.yml` | Cross-repo dispatch to `kusari-oss/homebrew-tap` (stable tags only) |
 
+### Pinned tool versions
+
+These tools are pinned in the release workflows. **Local installations must match** so contributors catch issues before CI does. If you bump one, update all three sites (the two workflow files and this table) in the same PR.
+
+| Tool | Pinned version | Where |
+|---|---|---|
+| `actionlint` | `v1.7.12` (linux/amd64 sha256 `8aca8db9...349a3d8`) | `release.yml` preflight + `release-yml-lint.yml` |
+
+#### Local install (macOS via Homebrew)
+
+```bash
+brew install actionlint
+# Verify the version matches the CI pin
+actionlint -version
+# Expected first line: 1.7.12
+```
+
+If `brew install actionlint` gives you an older version, force the pinned version with `brew install rhysd/tap/actionlint` or download the binary directly from the [releases page](https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+
+Why bumping matters: the runner-label database is built into actionlint, so an older local copy will miss newer GitHub-hosted runners (e.g., `ubuntu-24.04-arm`). A workflow that lints clean locally on an older `actionlint` may still fail CI's pinned version, or vice-versa.
+
 ## Where things live
 
 - `packaging/pypi/` — public package list


### PR DESCRIPTION
## Summary

Follow-up to #237's `macos-15-intel` post-mortem. Bumps the pinned `actionlint` version in the release workflows from v1.7.7 → v1.7.12 (the current Homebrew default), adds SHA-256 verification of the downloaded tarball, and documents the pin in `packaging/README.md`.

## Why

In #237 my local `actionlint` (v1.7.12, from Homebrew) accepted `macos-15-intel`. CI's pinned `actionlint` (v1.7.7) didn't know that runner label — which was right; we ended up dropping the runner anyway, but the lesson is: **local-CI version drift hides issues until a PR fails CI**.

Bumping the pin closes that gap. The newer `actionlint` also knows about `ubuntu-24.04-arm` and other newer runner labels we'll eventually want to use.

## What changed

- **`.github/workflows/release.yml`** preflight step: pinned `actionlint` v1.7.12 + SHA-256 verify
- **`.github/workflows/release-yml-lint.yml`** PR-time lint step: same pin + same verify
- **`packaging/README.md`**: new `### Pinned tool versions` subsection under `## Workflow files`, listing the actionlint pin + matching local-install recipe + an explanation of why pin parity matters

### Hardening: SHA-256 verification

The old install step was:

```bash
curl -sSLo /tmp/actionlint.tar.gz https://.../v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz
tar -xzf /tmp/actionlint.tar.gz ...
```

No checksum. If GitHub's CDN or the release tarball were tampered with between publish and our fetch, we'd never notice. New install step verifies the SHA-256 against the upstream-published checksum:

```bash
url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
curl -fsSLo /tmp/actionlint.tar.gz "$url"
echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum -c -
tar -xzf /tmp/actionlint.tar.gz ...
```

`-fsSLo` also flips silent-on-error to fail-on-HTTP-error, so a 404 / 5xx surfaces instead of being treated as a successful download of an HTML error page.

## Three pin sites must stay in lockstep

The pin is referenced in three places:
1. `release.yml` (inline preflight step)
2. `release-yml-lint.yml` (PR check)
3. `packaging/README.md` "Pinned tool versions" table

Inline comments in both workflow files name the sister sites. Bumping in the future requires updating all three in one PR.

## Test plan

- [x] `actionlint` v1.7.12 locally lints all four release workflows clean
- [x] `uv run ruff check .` clean
- [x] `uv run python scripts/validate_sync.py --verbose` passes
- [x] `uv run python scripts/generate_docs.py` produces no diff
- [x] SHA-256 verified locally against the v1.7.12 checksums.txt (`8aca8db9...349a3d8`)
- [ ] CI's `actionlint` job uses the new version and emits `v1.7.12` in its log

## Reviewer notes

- This is a CI-only change. No effect on shipped artifacts.
- If `brew install actionlint` doesn't give v1.7.12 (Homebrew sometimes lags by a release), contributors can use `brew install rhysd/tap/actionlint` or grab the binary directly — documented in `packaging/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)