### PR TITLE
fix(test): use caplog for install confirmation assertion (closes #248)

### DIFF
--- a/tests/darnit/test_cli.py
+++ b/tests/darnit/test_cli.py
@@ -7,7 +7,7 @@ import pytest
 from darnit.cli import create_parser, format_result_text, format_results_json, main
 
 
-def test_install_claude_creates_settings(tmp_path, monkeypatch, capsys, caplog):
+def test_install_claude_creates_settings(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
 
     exit_code = main(["install"])
@@ -23,8 +23,15 @@ def test_install_claude_creates_settings(tmp_path, monkeypatch, capsys, caplog):
     assert data["mcpServers"]["darnit"]["command"] == "uvx"
     assert data["mcpServers"]["darnit"]["args"] == ["--from", "darnit", "darnit", "serve"]
 
-    captured = capsys.readouterr()
-    assert "Installed darnit MCP server config" in captured.err
+    # The install function emits via logger.info(...), so we need pytest's
+    # logging-record capture (caplog), not its stderr-FD capture (capsys).
+    # When another test installs a logging handler that intercepts records
+    # before they reach the stderr FD, capsys sees nothing while caplog
+    # still captures every record. See issue #248 for the full post-mortem.
+    assert any(
+        "Installed darnit MCP server config" in record.message
+        for record in caplog.records
+    ), "expected install confirmation log message was not emitted"
 
 def test_install_cursor_creates_settings(tmp_path, monkeypatch):
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)


### PR DESCRIPTION
## Summary

Re-do of the test-flake fix. Closes #248 — the long-running flake in `test_install_claude_creates_settings` that's been red on every PR's CI in the recent packaging series.

**Important: this PR is a re-do.** The previous attempt (#249) was supposed to land this fix but a `git rebase` mishap caused the branch tip to detach from the test-fix commit. The squash merge picked up the Phase 8 work that was on the branch's base instead. So Phase 8 landed under #249's banner, and the test fix did not. Verified by `git show 17fb2e0` (the merge commit) — it changes 5 files, none of them `tests/darnit/test_cli.py`.

This PR is **branched directly from current `main` with no rebase, no stash** — just the test fix.

## Verification

Locally, all four invocation modes:

| Mode | Command | Result |
|---|---|---|
| Isolation | `pytest tests/darnit/test_cli.py::test_install_claude_creates_settings` | 1 passed |
| Single file | `pytest tests/darnit/test_cli.py` | 16 passed |
| Single dir | `pytest tests/darnit/` | 1352 passed |
| Full suite | `pytest tests/ --ignore=tests/integration/ -q` | **2074 passed, 0 failed** |

Before the fix (current `main` HEAD): `1 failed, 2073 passed`.

## Diff

One file, +10/-3:

- Remove `capsys` from the test's fixture parameter list (it's no longer used)
- Drop `captured = capsys.readouterr()` + the brittle `assert ... in captured.err`
- Replace with a `caplog.records` walk + a 5-line inline comment citing #248

## Why `caplog` over the alternatives

Per #248, three options were considered:

| Option | Trade-off | Decision |
|---|---|---|
| Drop the assertion entirely | Smallest diff. **Sacrifices regression coverage** — the user-visible log message IS a contract; a test that doesn't verify it leaves a coverage gap. | Rejected |
| Switch `capsys` → `caplog` | Preserves regression coverage; works regardless of which handler other tests have installed. | **Chosen** |
| Autouse logging-reset fixture | Wider blast radius than this scope allows. | Rejected |

## Regression smoke

Temporarily corrupted the install function's log string in `packages/darnit/src/darnit/cli.py` ("Installed darnit MCP server config" → "BORKED FOR TEST"). Ran the test in both isolation and full-suite modes. Both failed with:

```
AssertionError: expected install confirmation log message was not emitted
```

Reverted the source edit. Both modes pass again. The fix preserves the test's regression-detection intent.

## Fix locality

```bash
$ git diff --name-only main..HEAD
tests/darnit/test_cli.py

$ git diff main..HEAD -- conftest.py '**/conftest.py' pyproject.toml
# (empty)
```

Only `tests/darnit/test_cli.py`. No conftest, no pytest config, no source-code changes.

## Recommended cleanup after merge

- **Close PR #247** (Phase 8). It's now redundant — its content already landed via #249's accidental contents.

## Test plan

- [x] `actionlint` clean (no workflow changes, checked anyway)
- [x] `uv run ruff check .` clean
- [x] `uv run python scripts/validate_sync.py --verbose` passes
- [x] `uv run python scripts/generate_docs.py` produces no diff
- [x] All four pytest invocation modes pass
- [x] Regression smoke confirms the test still catches log-message changes
- [ ] CI's full suite passes (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)