### PR TITLE
feat(composition): foundational scaffolding (013, PR 1 of 6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,6 +367,8 @@ else:
 ## Active Technologies
 - Python 3.11/3.12 (workspace targets) plus bash for release scripts and GitHub Actions YAML + `shiv` (binary builder), `cosign` (image + binary signing), `syft` (SBOM generation), `docker buildx` (multi-arch images), `gh` CLI (release creation), Sigstore-action (PyPI wheel signing via `pypa/gh-action-pypi-publish`). No new runtime dependencies in any darnit Python package. (012-packaging-distribution)
 - External release surfaces only — PyPI, TestPyPI, GHCR, GitHub Releases (binary assets + attestations), `kusari-oss/homebrew-tap` repo (formula). Repo itself stores only build configs and workflow definitions. (012-packaging-distribution)
+- Python 3.11/3.12 (workspace targets — same as the rest of darnit) + `pydantic >= 2.0` (already used for `FrameworkConfig`); `packaging` (already a transitive dep via setuptools metadata) for PEP 440 `SpecifierSet`. `tomllib` from stdlib for TOML parsing. No new runtime dependencies. (013-plugin-composition)
+- Filesystem only. Composition is resolved in-memory at framework-config load time; no new persistent state. (013-plugin-composition)
 
 ## Recent Changes
 - 012-packaging-distribution: Added Python 3.11/3.12 (workspace targets) plus bash for release scripts and GitHub Actions YAML + `shiv` (binary builder), `cosign` (image + binary signing), `syft` (SBOM generation), `docker buildx` (multi-arch images), `gh` CLI (release creation), Sigstore-action (PyPI wheel signing via `pypa/gh-action-pypi-publish`). No new runtime dependencies in any darnit Python package.

--- a/packages/darnit/src/darnit/config/framework_schema.py
+++ b/packages/darnit/src/darnit/config/framework_schema.py
@@ -1205,6 +1205,148 @@ class AuditProfileConfig(BaseModel):
 
 
 # =============================================================================
+# Composition Primitives (feature 013-plugin-composition)
+# =============================================================================
+
+
+class ComposeBlock(BaseModel):
+    """One ``[[compose]]`` table-array entry in a composite framework TOML.
+
+    Names a source implementation plus the inclusion/exclusion filters that
+    select controls from it. See
+    ``specs/013-plugin-composition/contracts/toml-schema.md`` §2 for the
+    user-visible contract and ``data-model.md`` §Entity 1 for validation
+    rules (V1.1–V1.4).
+
+    Field semantics (intersection, not union — R-009):
+
+    - If ``include_all`` is True, start with the source's full control set;
+      the other ``include_*`` fields MUST be empty.
+    - Otherwise the result is the **intersection** of every named
+      ``include_*`` filter, then ``exclude_controls`` is subtracted.
+    """
+
+    source: str
+    include_all: bool = False
+    include_levels: list[int] = Field(default_factory=list)
+    include_controls: list[str] = Field(default_factory=list)
+    include_tags: dict[str, Any] = Field(default_factory=dict)
+    exclude_controls: list[str] = Field(default_factory=list)
+    version_constraint: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_inclusion_present(self) -> "ComposeBlock":
+        """V1.1: at least one inclusion expression must be set.
+
+        ``exclude_controls`` alone does not satisfy this requirement — a
+        block with only excludes is a no-op and almost certainly an
+        authoring mistake.
+        """
+        has_any_include = (
+            self.include_all
+            or bool(self.include_levels)
+            or bool(self.include_controls)
+            or bool(self.include_tags)
+        )
+        if not has_any_include:
+            raise ValueError(
+                f"[[compose]] block for source {self.source!r} declares no "
+                f"inclusion expression. Set one of `include_all = true`, "
+                f"`include_levels = [...]`, `include_controls = [...]`, or "
+                f"`include_tags = {{...}}`. `exclude_controls` alone is not "
+                f"a valid selector."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_include_all_exclusivity(self) -> "ComposeBlock":
+        """V1.2: ``include_all`` is mutually exclusive with other includes."""
+        if self.include_all and (
+            self.include_levels or self.include_controls or self.include_tags
+        ):
+            raise ValueError(
+                f"[[compose]] block for source {self.source!r}: "
+                f"`include_all = true` MUST NOT be combined with "
+                f"`include_levels`, `include_controls`, or `include_tags`. "
+                f"Pick one of the inclusion expressions."
+            )
+        return self
+
+    @field_validator("version_constraint")
+    @classmethod
+    def _validate_version_constraint_syntax(cls, v: str | None) -> str | None:
+        """V1.3: ``version_constraint``, if present, must parse as PEP 440."""
+        if v is None:
+            return v
+        try:
+            # Imported lazily; `packaging` is a transitive dep via setuptools
+            # and is already part of every Python install with pip available.
+            from packaging.specifiers import SpecifierSet
+
+            SpecifierSet(v)
+        except Exception as exc:  # noqa: BLE001 — surface any parser error.
+            raise ValueError(
+                f"Invalid PEP 440 `version_constraint` {v!r}: {exc}"
+            ) from exc
+        return v
+
+
+class OverrideBlock(BaseModel):
+    """One ``[overrides."CONTROL-ID"]`` block in a composite framework TOML.
+
+    Replaces specific fields of a control already present in the resolved
+    set (whether composed-in or inline). Field names match the real
+    ``ControlConfig`` schema exactly — there are no friendly aliases (so
+    ``severity`` and ``help_url`` are not valid; use ``security_severity``
+    and ``docs_url``). See
+    ``specs/013-plugin-composition/contracts/toml-schema.md`` §3 for the
+    user-visible contract and ``data-model.md`` §Entity 2 for validation
+    rules (V2.1–V2.4).
+
+    The actual field-name validation against ``ControlConfig.model_fields``
+    happens in the composition resolver (T030 / FR-008), not here, because
+    we only know the target ``ControlConfig`` once resolution is in motion.
+    This model accepts ``extra="allow"`` so authors can name any field they
+    expect to override; the resolver rejects unknown ones with a clear
+    ``CompositionUnknownFieldError`` naming the offending field.
+    """
+
+    # Known override-able scalar fields, declared explicitly so authors
+    # get autocomplete and type checks on the common case.
+    passes: list[Any] | None = None
+    remediation: Any | None = None
+    security_severity: float | None = None
+    description: str | None = None
+    docs_url: str | None = None
+    tags: dict[str, Any] = Field(default_factory=dict)
+
+    # extra="allow" lets the resolver inspect `model_extra` for fields the
+    # author named that are NOT in this declared set, and either accept
+    # them (if they match ControlConfig.model_fields) or raise
+    # CompositionUnknownFieldError. The strict "no aliases" guarantee
+    # comes from the resolver's validation pass, not from this model.
+    model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="after")
+    def _validate_at_least_one_field(self) -> "OverrideBlock":
+        """V2.3: an override block must define at least one field."""
+        declared_set = self.model_fields_set
+        # `tags` defaulting to {} doesn't count as "set" unless the author
+        # actually provided it; pydantic v2's `model_fields_set` tracks that.
+        extras = self.model_extra or {}
+        if not declared_set and not extras:
+            raise ValueError(
+                "[overrides.\"…\"] block declares no fields. Remove the "
+                "empty override or add at least one field to replace "
+                "(e.g., `remediation`, `security_severity`, `description`, "
+                "`docs_url`, or a key under `tags`)."
+            )
+        return self
+
+
+# =============================================================================
 # Main Framework Configuration
 # =============================================================================
 
@@ -1271,6 +1413,19 @@ class FrameworkConfig(BaseModel):
 
     # Named audit profiles (optional, for multi-scenario implementations)
     audit_profiles: dict[str, AuditProfileConfig] = Field(default_factory=dict)
+
+    # ---------------------------------------------------------------------
+    # Composition primitives (feature 013-plugin-composition).
+    #
+    # A framework is treated as a composite IFF `compose` is non-empty.
+    # After `resolve_composition` runs, both `compose` and `overrides` are
+    # cleared on the returned config (invariant I3.2), and `controls`
+    # contains the resolved flat dict. Downstream consumers do not need
+    # to know whether composition happened.
+    # ---------------------------------------------------------------------
+    compose: list[ComposeBlock] = Field(default_factory=list)
+    overrides: dict[str, OverrideBlock] = Field(default_factory=dict)
+    allow_conflicts: bool = False
 
     model_config = ConfigDict(extra="allow")
 

--- a/packages/darnit/src/darnit/config/merger.py
+++ b/packages/darnit/src/darnit/config/merger.py
@@ -406,14 +406,26 @@ def merge_configs(
 # =============================================================================
 
 
-def load_framework_config(path: Path) -> FrameworkConfig:
-    """Load framework configuration from TOML file.
+def _parse_framework_only(path: Path) -> FrameworkConfig:
+    """Parse + template-validate a framework TOML — WITHOUT resolving composition.
+
+    This is the helper that the composition resolver's default
+    ``source_loader`` routes through, so recursive source loads do NOT
+    re-enter composition with a fresh ``_resolution_stack``. Cycle
+    detection (FR-012) and recursive composition (FR-018) depend on this
+    split — see ``specs/013-plugin-composition/research.md`` §R-002 for
+    the full rationale.
+
+    Callers OUTSIDE the composition resolver should generally call
+    :func:`load_framework_config` instead; this helper produces a
+    parsed-but-not-composition-resolved ``FrameworkConfig`` that is NOT
+    safe to hand to the audit pipeline if it has composition state.
 
     Args:
         path: Path to framework TOML file
 
     Returns:
-        Parsed FrameworkConfig
+        Parsed FrameworkConfig (composition state still present if any)
 
     Raises:
         FileNotFoundError: If file doesn't exist
@@ -457,6 +469,44 @@ def load_framework_config(path: Path) -> FrameworkConfig:
                     f"Template file '{template.file}' for template '{name}' "
                     f"not found relative to framework config '{path}'"
                 )
+
+    return config
+
+
+def load_framework_config(path: Path) -> FrameworkConfig:
+    """Load framework configuration from TOML file.
+
+    If the parsed config has any ``[[compose]]`` blocks or
+    ``[overrides."…"]`` blocks, this function resolves composition exactly
+    once before returning, so callers receive a flat ``FrameworkConfig``
+    that is shape-identical to a non-composite's. The resolver itself uses
+    :func:`_parse_framework_only` (NOT this function) to load source
+    frameworks recursively; that split is load-bearing for cycle
+    detection — see ``specs/013-plugin-composition/contracts/resolver-api.md``
+    §Integration contract.
+
+    Args:
+        path: Path to framework TOML file
+
+    Returns:
+        Fully-resolved FrameworkConfig (composition state cleared if any)
+
+    Raises:
+        FileNotFoundError: If file doesn't exist
+        ValueError: If file is invalid
+        CompositionError: Any composition-resolution failure (missing
+            source, cycle, conflict, orphan override, etc.).
+    """
+    config = _parse_framework_only(path)
+
+    # Composition resolution runs EXACTLY ONCE at the top of this call chain.
+    # The resolver's `source_loader` calls `_parse_framework_only` (not this
+    # function) for recursive source loads, so the resolver's per-call
+    # `_resolution_stack` is the single source of truth for cycle detection.
+    if config.compose or config.overrides:
+        from darnit.core.composition import resolve_composition
+
+        config = resolve_composition(config)
 
     return config
 

--- a/packages/darnit/src/darnit/core/composition.py
+++ b/packages/darnit/src/darnit/core/composition.py
@@ -1,0 +1,268 @@
+"""Composition resolution for darnit compliance implementations.
+
+This module is the framework-internal entrypoint for the TOML-only composition
+primitive defined in feature 013-plugin-composition. A composite implementation
+declares ``[[compose]]`` blocks, ``[overrides."ID"]`` blocks, and an optional
+``allow_conflicts`` flag in its TOML; this module resolves all of that into a
+flat ``FrameworkConfig.controls`` dict that the rest of the framework can
+consume without knowing composition exists.
+
+Canonical references:
+
+- Spec:  ``specs/013-plugin-composition/spec.md``
+- Plan:  ``specs/013-plugin-composition/plan.md``
+- TOML schema contract:
+  ``specs/013-plugin-composition/contracts/toml-schema.md``
+- Resolver API contract:
+  ``specs/013-plugin-composition/contracts/resolver-api.md``
+- Data model + resolution algorithm:
+  ``specs/013-plugin-composition/data-model.md``
+
+This module MUST NOT import any implementation package (Constitution
+Principle I: Plugin Separation). Source frameworks are resolved via the
+``darnit.implementations`` entry-point group through a parse-only loader
+helper (``darnit.config.merger._parse_framework_only``); composition
+recursion is the resolver's exclusive responsibility so its
+``_resolution_stack`` is the single source of truth for cycle detection
+(F-1 fix; research.md R-002).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+log = logging.getLogger("darnit.core.composition")
+
+
+# =============================================================================
+# Exception hierarchy
+# =============================================================================
+
+
+class CompositionError(Exception):
+    """Base class for all composition-resolution errors.
+
+    Concrete subclasses provide structured attributes; this base class
+    exists so consumers can ``except CompositionError`` to catch every
+    composition failure with a single clause.
+    """
+
+
+class CompositionMissingSourceError(CompositionError):
+    """A ``[[compose]]`` block names a source slug not installed on the host.
+
+    Attributes:
+        source: The missing source slug.
+    """
+
+    def __init__(self, source: str) -> None:
+        self.source = source
+        super().__init__(
+            f"Composition source not installed: {source!r}. "
+            f"Install the package providing this source implementation, or "
+            f"remove the [[compose]] block referencing it."
+        )
+
+
+class CompositionConflictError(CompositionError):
+    """Two ``[[compose]]`` blocks contribute the same control ID in strict mode.
+
+    Attributes:
+        control_id: The conflicting control ID.
+        sources: A 2-tuple ``(earlier_source, later_source)`` naming the two
+            contributing slugs in TOML file order.
+    """
+
+    def __init__(self, control_id: str, sources: tuple[str, str]) -> None:
+        self.control_id = control_id
+        self.sources = sources
+        earlier, later = sources
+        super().__init__(
+            f"Composition conflict on control {control_id!r}: contributed by "
+            f"both {earlier!r} and {later!r}. Resolve explicitly by either "
+            f"(a) adding `allow_conflicts = true` at the composition root "
+            f"(later compose block wins by TOML file order; INFO log emitted), "
+            f"or (b) adding an explicit `[overrides.\"{control_id}\"]` block "
+            f"(overrides always win and resolve conflicts in any mode)."
+        )
+
+
+class CompositionOrphanOverrideError(CompositionError):
+    """An ``[overrides."ID"]`` block targets an ID not in the resolved set.
+
+    Attributes:
+        orphan_id: The control ID the override targets.
+    """
+
+    def __init__(self, orphan_id: str) -> None:
+        self.orphan_id = orphan_id
+        super().__init__(
+            f"Override targets control {orphan_id!r} but no [[compose]] block "
+            f"or inline [controls.\"{orphan_id}\"] entry contributes it. "
+            f"Remove the orphan override, or add a compose block / inline "
+            f"control that includes this ID."
+        )
+
+
+class CompositionUnknownFieldError(CompositionError):
+    """An override block names a field not present on the ``ControlConfig`` schema.
+
+    Attributes:
+        control_id: The override target.
+        field: The unknown field name.
+    """
+
+    def __init__(self, control_id: str, field: str) -> None:
+        self.control_id = control_id
+        self.field = field
+        super().__init__(
+            f"Override for control {control_id!r} names unknown field "
+            f"{field!r}. Override field names match the real ControlConfig "
+            f"schema exactly — common confusions: use `security_severity` "
+            f"(not `severity`) and `docs_url` (not `help_url`)."
+        )
+
+
+class CompositionCycleError(CompositionError):
+    """The composition graph contains a cycle.
+
+    Attributes:
+        chain: The full cycle chain in resolution order, ending with the
+            slug that re-entered the stack. For example, ``["A", "B", "A"]``
+            for an A→B→A cycle.
+    """
+
+    def __init__(self, chain: list[str]) -> None:
+        self.chain = list(chain)
+        rendered = " → ".join(self.chain)
+        super().__init__(
+            f"Composition cycle detected: {rendered}. Composites cannot "
+            f"transitively include themselves; remove or rewire one of the "
+            f"[[compose]] blocks in the chain."
+        )
+
+
+class CompositionVersionMismatchError(CompositionError):
+    """A ``[[compose]]`` block's ``version_constraint`` is not satisfied.
+
+    Attributes:
+        source: The source slug.
+        constraint: The PEP 440 specifier string from the composite's TOML.
+        installed: The source's installed ``metadata.version``.
+    """
+
+    def __init__(self, source: str, constraint: str, installed: str) -> None:
+        self.source = source
+        self.constraint = constraint
+        self.installed = installed
+        super().__init__(
+            f"Composition version mismatch for source {source!r}: "
+            f"installed version {installed!r} does not satisfy constraint "
+            f"{constraint!r}. Install a compatible source version or relax "
+            f"the constraint in the [[compose]] block."
+        )
+
+
+__all__ = [
+    "CompositionError",
+    "CompositionMissingSourceError",
+    "CompositionConflictError",
+    "CompositionOrphanOverrideError",
+    "CompositionUnknownFieldError",
+    "CompositionCycleError",
+    "CompositionVersionMismatchError",
+    "resolve_composition",
+]
+
+
+# =============================================================================
+# Resolver (skeleton — Foundational phase only; full body lands in US1+)
+# =============================================================================
+
+
+def resolve_composition(
+    composite,
+    *,
+    source_loader=None,
+    _source_cache: dict | None = None,
+    _resolution_stack: list[str] | None = None,
+):
+    """Resolve a composite ``FrameworkConfig`` into a flat control set.
+
+    See ``specs/013-plugin-composition/contracts/resolver-api.md`` for the
+    full contract and ``specs/013-plugin-composition/data-model.md``
+    §Resolution algorithm for the canonical pseudocode.
+
+    This is the Foundational-phase skeleton: idempotence (invariant I3.3),
+    cycle-stack threading (invariant feeding FR-012), and the "clear
+    composition state on return" pattern (invariant I3.2) are wired up.
+    The compose-block iteration body and the override-application body are
+    placeholders raised as :class:`NotImplementedError`; US1 fills the
+    former, US2 fills the latter.
+    """
+    # Import inside to avoid an import cycle: composition.py is imported by
+    # merger.py, and merger.py defines FrameworkConfig.
+    from darnit.config.framework_schema import FrameworkConfig  # noqa: F401
+
+    if _source_cache is None:
+        _source_cache = {}
+    if _resolution_stack is None:
+        _resolution_stack = []
+
+    # Pure short-circuit (invariant I3.3): a non-composite config returns
+    # unchanged. This is also what makes the resolver safe to call twice on
+    # the same already-resolved config.
+    if not composite.compose and not composite.overrides:
+        return composite
+
+    composite_slug = composite.metadata.name
+
+    # Cycle detection (FR-012) — check BEFORE pushing onto the stack so a
+    # self-cycle (A → A) is caught on the first repeat, not on a hypothetical
+    # second one. See R-004.
+    if composite_slug in _resolution_stack:
+        raise CompositionCycleError(chain=_resolution_stack + [composite_slug])
+
+    # Recursive calls in US1 will pass `_resolution_stack + [composite_slug]`
+    # into themselves so any source that re-enters this slug raises
+    # CompositionCycleError. Stored locally below once the iteration body
+    # lands (T017); for the skeleton we just confirm the slug is not
+    # already on the stack above.
+
+    # ---------------------------------------------------------------------
+    # Foundational phase body intentionally minimal. The full pseudocode
+    # from data-model.md §Resolution algorithm lands across US1 (compose
+    # iteration), US2 (override application), and US3 (conflict detection).
+    # ---------------------------------------------------------------------
+    if composite.compose:
+        # US1 (T017) replaces this with the compose-block iteration loop.
+        raise NotImplementedError(
+            "Compose-block iteration not yet implemented (lands in US1 / T017). "
+            f"Composite {composite_slug!r} declares {len(composite.compose)} "
+            f"[[compose]] block(s) but the resolver body is still the "
+            f"Foundational skeleton."
+        )
+
+    if composite.overrides:
+        # US2 (T032) replaces this with the override-application loop. Orphan
+        # detection (V2.1 / FR-007) catches "overrides without composes" here
+        # in the meantime once US2 lands.
+        raise NotImplementedError(
+            "Override application not yet implemented (lands in US2 / T032). "
+            f"Composite {composite_slug!r} declares "
+            f"{len(composite.overrides)} [overrides.\"…\"] block(s)."
+        )
+
+    # Unreachable today because both branches above raise; left in place so
+    # the structure is obvious for the US1 / US2 fill-ins.
+    return composite.model_copy(  # pragma: no cover
+        update={
+            "controls": dict(composite.controls),
+            "compose": [],
+            "overrides": {},
+        }
+    )

--- a/specs/013-plugin-composition/checklists/requirements.md
+++ b/specs/013-plugin-composition/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Composition of compliance implementations
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec captures both the v1 surface (TOML-only composition with inclusion/exclusion/overrides) and the explicit out-of-scope items (cross-host, partial-pass-override, Python composition hooks, hot-reload). Five user stories ranked P1–P3, with the highest-priority items being the org-baseline assembly (Story 1), the targeted override (Story 2), and the conflict-resolution rule (Story 3). Cycle detection and version pinning are P3 — important guardrails but not the primary value.
+- TOML keywords like `[[compose]]`, `include_levels`, `exclude_controls`, `[overrides.X]`, `strict_conflicts`, `version_constraint` are named in the FRs because they ARE part of the user-visible contract (composite authors will type them by hand). The spec's "no implementation details" rule covers internal languages/frameworks/APIs; user-facing schema names are legitimate scope.
+- Three issues from #233's original Open Questions are addressed in the spec (conflict resolution, override scope, version pinning) and four genuinely ambiguous shape decisions are documented as Assumptions for the clarify phase to interrogate:
+  1. Where conflict resolution lands (last-wins default vs. strict opt-in) — addressed in FR-009/FR-010.
+  2. Override field scope (which fields are override-able) — addressed in FR-006 (limited list) + FR-008 (reject unknown fields).
+  3. Version-pinning default (float vs. pin) — addressed in FR-014 (default-floating, opt-in pinning).
+- Items marked incomplete would require spec updates before `/speckit.clarify` or `/speckit.plan`. Current status: all 16 items pass on first review.

--- a/specs/013-plugin-composition/contracts/resolver-api.md
+++ b/specs/013-plugin-composition/contracts/resolver-api.md
@@ -1,0 +1,174 @@
+# Contract: Composition Resolver — Internal Python API
+
+**Feature**: 013-plugin-composition · **Status**: Authoritative for v1 · **Date**: 2026-05-13
+
+This is the framework-internal contract for `darnit.core.composition`. It is consumed by `darnit.config.merger.load_framework_config(...)` and by unit tests. It is NOT part of the public Python API; implementation packages MUST NOT import it directly.
+
+---
+
+## Module: `darnit.core.composition`
+
+### Public surface
+
+```python
+__all__ = [
+    "resolve_composition",
+    "CompositionError",
+    "CompositionMissingSourceError",
+    "CompositionConflictError",
+    "CompositionOrphanOverrideError",
+    "CompositionUnknownFieldError",
+    "CompositionCycleError",
+    "CompositionVersionMismatchError",
+]
+```
+
+---
+
+### Function: `resolve_composition`
+
+```python
+def resolve_composition(
+    composite: FrameworkConfig,
+    *,
+    source_loader: Callable[[str], FrameworkConfig | None] | None = None,
+) -> FrameworkConfig:
+    ...
+```
+
+**Inputs**
+
+- `composite` — A `FrameworkConfig` freshly parsed from a composite's TOML. May have non-empty `compose`, `overrides`, or `allow_conflicts`.
+- `source_loader` — Optional injection point for tests. Default: an internal wrapper that does slug → path lookup via `PluginRegistry`, then loads the source TOML through `darnit.config.merger._parse_framework_only(path)`. **The default loader MUST return a parsed-but-NOT-resolved `FrameworkConfig`** — it must NOT itself invoke `resolve_composition`, or cycle detection (FR-012) would not catch cycles routed through composite-of-composite chains. The contract is: given a source slug, return a parsed-but-not-composition-resolved `FrameworkConfig` for that source, or `None` if the source is not installed.
+
+**Output**
+
+- A new `FrameworkConfig` with:
+  - `controls`: the resolved flat dict, with every value provenance-stamped (R-006).
+  - `compose`: `[]` (cleared per invariant I3.2).
+  - `overrides`: `{}` (cleared per invariant I3.2).
+  - `allow_conflicts`: preserved from input (not load-bearing post-resolution, but kept for telemetry).
+  - All other fields unchanged.
+
+**Idempotence**: calling on an input with `compose == []` and `overrides == {}` returns the input unchanged (invariant I3.3).
+
+**Exceptions** (all subclasses of `CompositionError`):
+
+| Exception | Trigger | Attributes |
+|---|---|---|
+| `CompositionMissingSourceError` | `source_loader(slug)` returned `None`. | `.source: str` |
+| `CompositionConflictError` | Two `[[compose]]` blocks contribute the same control ID, no override resolves it, `allow_conflicts` is `false`. | `.control_id: str`, `.sources: tuple[str, str]` |
+| `CompositionOrphanOverrideError` | `[overrides."ID"]` targets a control ID not in the resolved set. | `.orphan_id: str` |
+| `CompositionUnknownFieldError` | An override names a field not on `ControlConfig`. | `.field: str`, `.control_id: str` |
+| `CompositionCycleError` | The resolution stack already contains the current composite's slug. | `.chain: list[str]` |
+| `CompositionVersionMismatchError` | The installed source's `metadata.version` does not satisfy a `[[compose]]` block's `version_constraint`. | `.source: str`, `.constraint: str`, `.installed: str` |
+
+**Side effects**
+
+- Emits `INFO`-level log messages on `darnit.core.composition` logger:
+  - `"Composition conflict on %s: %s overrides %s (allow_conflicts=true)"` — once per allow_conflicts override.
+- Emits `DEBUG`-level log messages:
+  - `"Compose block on source %s contributed 0 controls after filtering"` — once per empty-result compose block.
+  - `"Resolved composite %s: %d controls (%d composed, %d inline, %d overrides applied)"` — once per resolution.
+- Emits `WARNING`-level log messages:
+  - `"Override on %s defined a reserved tag key (%s); ignoring"` — once per offending override key.
+
+**Thread-safety**: the function is pure (no shared module-level state beyond logging). Multiple resolutions can run concurrently as long as `source_loader` is thread-safe (the default — `PluginRegistry` lookup + `_parse_framework_only(path)` — is read-only over the filesystem and entry-point registry).
+
+**Performance**: SC-002 requires ≤200 ms for 50 + 5 controls on a developer laptop. Achieved via single-pass resolution with memoized `source_loader` results across recursive entries within one top-level call.
+
+---
+
+### Class: `CompositionError`
+
+```python
+class CompositionError(Exception):
+    """Base class for all composition-resolution errors.
+
+    Concrete subclasses provide structured attributes; the base class
+    exists for consumers that want a single catch-all clause.
+    """
+```
+
+All subclasses MUST:
+
+- Inherit from `CompositionError` directly (not from each other).
+- Set `__str__` to a human-readable message that includes every attribute the subclass exposes.
+- Be importable from `darnit.core.composition` at module level.
+
+---
+
+## Integration contract: `darnit.config.merger.load_framework_config`
+
+`load_framework_config(path: Path) -> FrameworkConfig` is refactored into a thin wrapper around a new internal helper `_parse_framework_only(path)` that does parse + template-validate WITHOUT touching composition. The public function becomes:
+
+```python
+def _parse_framework_only(path: Path) -> FrameworkConfig:
+    """Parse + template-validate a framework TOML. Does NOT resolve composition.
+
+    This is the helper that the composition resolver's default `source_loader`
+    routes through, so recursive source loads do NOT re-enter composition with
+    a fresh `_resolution_stack`. Cycle detection (FR-012) depends on this split.
+    """
+    config = _parse_toml(path)          # existing — pydantic validation
+    _validate_templates(config, path)   # existing — template path checks
+    return config
+
+
+def load_framework_config(path: Path) -> FrameworkConfig:
+    config = _parse_framework_only(path)
+
+    # Composition resolution runs EXACTLY ONCE at the top of this call chain.
+    # The resolver's `source_loader` calls `_parse_framework_only` (not this
+    # function) for recursive source loads, so the resolver's per-call
+    # `_resolution_stack` is the single source of truth for cycle detection.
+    if config.compose or config.overrides:
+        from darnit.core.composition import resolve_composition
+        config = resolve_composition(config)
+
+    return config
+```
+
+**Properties**:
+
+- Composition resolution is transparent to callers — they receive a `FrameworkConfig` that is shape-identical to a non-composite's.
+- All `CompositionError` subclasses propagate out of `load_framework_config` unchanged.
+- The framework name in error messages comes from the composite's `metadata.name`, which is set before composition runs (otherwise resolution couldn't have started).
+- `load_framework_by_name(slug)` (existing, no signature change) calls `load_framework_config(resolved_path)` internally. **Callers outside the resolver MAY continue to use it** — at the top of any call chain it produces a fully-resolved config. **The resolver itself MUST NOT call it** — it calls `_parse_framework_only` via the injected `source_loader` to keep cycle detection sound.
+
+---
+
+## Test contract
+
+Unit tests in `tests/darnit/test_composition.py` MUST cover at minimum:
+
+| Test | Asserts |
+|---|---|
+| `test_basic_include_all` | Compose `include_all = true` from one source; resolved set equals source's full set. |
+| `test_include_levels_filter` | Compose `include_levels = [1, 2]`; level-3 controls absent from resolved set. |
+| `test_include_controls_filter` | Compose `include_controls = ["A", "B"]`; only those two appear. |
+| `test_exclude_controls_after_include` | Compose `include_all = true` + `exclude_controls = ["X"]`; X absent, everything else present. |
+| `test_intersection_of_includes` | Compose `include_levels = [1]` + `include_controls = ["L1-A", "L3-B"]`; only `L1-A` appears (intersection narrows). |
+| `test_overrides_replace_fields` | Override `remediation` only; pass logic unchanged, remediation matches override. |
+| `test_overrides_preserve_provenance` | After an override on a composed control, `_composed_from` still points at the original source. |
+| `test_strict_conflict_raises` | Two compose blocks contribute same ID, `allow_conflicts` unset → `CompositionConflictError` with both source slugs. |
+| `test_allow_conflicts_last_wins` | Same fixture with `allow_conflicts = true` → registration succeeds, later compose block's contribution wins, INFO log emitted. |
+| `test_override_resolves_conflict_in_strict_mode` | Same fixture with `[overrides."ID"]` present → registration succeeds in strict mode; override fields applied. |
+| `test_orphan_override_raises` | `[overrides."BOGUS"]` with no matching compose contribution → `CompositionOrphanOverrideError`. |
+| `test_unknown_field_override_raises` | Override naming `nonexistent_field` → `CompositionUnknownFieldError`. |
+| `test_missing_source_raises` | Compose block references uninstalled slug → `CompositionMissingSourceError`. |
+| `test_self_cycle_raises` | Composite includes itself → `CompositionCycleError(chain=["A", "A"])`. |
+| `test_two_cycle_raises` | A↔B → `CompositionCycleError` from whichever loads first. |
+| `test_three_level_chain_resolves` | A→B→C (C non-composite) → A's resolved set includes C's selected controls. **Each control's `_composed_from` is `"C"` (the ultimate source), not `"B"`** (FR-018 + FR-015). |
+| `test_diamond_resolves_once` | A includes B and C; B and C both include D. D's controls appear once in A; `source_loader` called once per unique slug. |
+| `test_version_pin_satisfied` | Compose block has `version_constraint = ">=1.0"`, source's version is `1.5.0` → resolves. |
+| `test_version_pin_violated` | Same constraint, source's version is `0.9.0` → `CompositionVersionMismatchError`. |
+| `test_version_pin_missing_uses_floating` | No `version_constraint` → resolves with whatever version is installed. |
+| `test_empty_compose_block_rejected` | `[[compose]]` with no inclusion expressions → registration error. |
+| `test_empty_override_block_rejected` | `[overrides."ID"]` with no fields → registration error. |
+| `test_idempotent_resolution` | Resolve a config, resolve again → identical result. |
+| `test_resolution_performance` | 50 composed + 5 inline controls; resolution time < 200 ms (SC-002). |
+| `test_provenance_for_inline_controls` | A composite's own inline controls carry `_composed_from = "<composite-slug>"`. |
+| `test_audit_pipeline_unchanged` | End-to-end: register composite, run audit against a fixture repo, assert result shape matches a non-composite audit result. |
+
+Each fixture is a hand-authored TOML file under `tests/darnit/fixtures/composite/`. Resolver tests load each via the real production `load_framework_config(...)` rather than constructing `FrameworkConfig` objects in Python (R-010).

--- a/specs/013-plugin-composition/contracts/toml-schema.md
+++ b/specs/013-plugin-composition/contracts/toml-schema.md
@@ -1,0 +1,175 @@
+# Contract: TOML Schema for Composite Implementations
+
+**Feature**: 013-plugin-composition · **Status**: Authoritative for v1 · **Date**: 2026-05-13
+
+This is the user-visible contract a composite-implementation author types by hand. It extends the existing `FrameworkConfig` TOML schema with three new constructs: `[[compose]]` blocks, `[overrides."ID"]` blocks, and a root-level `allow_conflicts` flag.
+
+A framework is treated as a composite **if and only if** it has at least one `[[compose]]` block in its TOML.
+
+---
+
+## 1. Anatomy of a composite TOML
+
+```toml
+[metadata]
+name = "acme-baseline"
+display_name = "Acme Baseline"
+version = "1.0.0"
+spec_version = "Acme v1"
+
+# Optional. Default: false. When true, conflicting control IDs across compose
+# blocks fall back to last-wins (by file order) with an INFO log. Default
+# behavior (false) raises CompositionConflictError at registration time.
+allow_conflicts = false
+
+# ---------------------------------------------------------------------------
+# Composition: zero or more [[compose]] blocks, each pulling controls from
+# one source implementation.
+# ---------------------------------------------------------------------------
+
+[[compose]]
+source = "openssf-baseline"
+include_levels = [1, 2]
+exclude_controls = ["OSPS-AC-02.01"]
+version_constraint = ">=1.5,<2.0"   # optional, PEP 440
+
+[[compose]]
+source = "darnit-gittuf"
+include_all = true
+
+[[compose]]
+source = "openssf-baseline"
+include_controls = [
+    "OSPS-AC-03.01",
+    "OSPS-VM-03.01",
+    "OSPS-QA-07.01",
+]
+# version_constraint omitted → default-floating (FR-014)
+
+# ---------------------------------------------------------------------------
+# Optional inline controls. These live in the composite's own TOML and are
+# merged with composed-in controls (union; subject to conflict rules).
+# ---------------------------------------------------------------------------
+
+[controls."ACME-DEPLOY-01.01"]
+name = "DeployWindowEnforced"
+level = 1
+domain = "AC"
+description = "Production deploys happen only during the published window."
+# ... standard passes/remediation as for any non-composite control ...
+
+# ---------------------------------------------------------------------------
+# Optional overrides. Each [overrides."ID"] replaces specific fields of a
+# control already present in the resolved set (inline or composed-in).
+# ---------------------------------------------------------------------------
+
+[overrides."OSPS-AC-01.01"]
+remediation = """
+Update SSO config in https://sso.acme.example/admin → "Require MFA".
+See the Acme runbook at https://internal.acme.example/runbooks/sso.
+"""
+
+[overrides."OSPS-VM-03.01"]
+security_severity = 8.5
+docs_url = "https://internal.acme.example/runbooks/vuln-management"
+```
+
+---
+
+## 2. `[[compose]]` block — field-by-field contract
+
+| Field | Type | Required | Default | Behavior |
+|---|---|---|---|---|
+| `source` | `string` | yes | — | The slug of the source implementation (matches `[metadata].name` of the source's TOML). Resolved via the `darnit.implementations` entry-point group. |
+| `include_all` | `bool` | no | `false` | When `true`, pull every control from the source. MUST NOT be combined with the other `include_*` fields. |
+| `include_levels` | `array<int>` | no | `[]` | Pull controls whose `level` is in this list. |
+| `include_controls` | `array<string>` | no | `[]` | Pull controls by exact control ID. |
+| `include_tags` | `table<string, any>` | no | `{}` | Pull controls whose `tags` dict contains every key/value pair in this table (AND across keys). |
+| `exclude_controls` | `array<string>` | no | `[]` | Applied AFTER the inclusion expressions. Removes named IDs from the set selected by inclusion. |
+| `version_constraint` | `string` | no | `None` | PEP 440 specifier. When present, the source's installed `version` MUST satisfy it; mismatch → registration error. |
+
+**Rules**:
+
+- A `[[compose]]` block MUST define at least one inclusion expression (either `include_all = true` OR at least one of `include_levels`, `include_controls`, `include_tags`). A block with only `exclude_controls` is rejected.
+- `include_all = true` is mutually exclusive with the other `include_*` fields.
+- Inclusion expressions are evaluated as the **intersection** of all expressions present in the block (R-009). Then `exclude_controls` is subtracted from that intersection.
+- An empty result (filters narrow to zero controls) is NOT an error — it contributes nothing and emits a DEBUG log.
+
+---
+
+## 3. `[overrides."CONTROL-ID"]` block — field-by-field contract
+
+The key in the table header is the target control ID, quoted because control IDs contain dots.
+
+| Field | Type | Required | Behavior |
+|---|---|---|---|
+| `passes` | `array<table>` | no | If present, **wholesale replaces** the underlying control's `passes`. Partial pass-block edits are out of scope for v1. |
+| `remediation` | `table` | no | If present, replaces the control's `remediation` block. |
+| `security_severity` | `number` | no | If present, replaces the control's `security_severity` (0.0–10.0 CVSS-like). |
+| `description` | `string` | no | If present, replaces the control's `description`. |
+| `docs_url` | `string` | no | If present, replaces the control's `docs_url`. |
+| `tags` | `table<string, any>` | no | Shallow-merged into the control's `tags`. Reserved keys `_composed_from` and `_original_control_id` are silently dropped if redefined (with a WARNING log). |
+
+**Rules**:
+
+- The target control ID MUST exist in the resolved set after `[[compose]]` blocks have run. Orphan overrides → registration error.
+- Every field named MUST be a known field on `ControlConfig`. Unknown fields → registration error. **Override field names match the real `ControlConfig` schema** (so `severity` and `help_url` are rejected as unknown — use `security_severity` and `docs_url`). The framework offers no friendly aliases in v1.
+- A `[overrides."ID"]` block MUST define at least one field. An empty block is rejected.
+
+---
+
+## 4. Root-level `allow_conflicts` flag
+
+| Field | Type | Required | Default | Behavior |
+|---|---|---|---|---|
+| `allow_conflicts` | `bool` | no | `false` | Top-level (sibling of `[metadata]`, NOT inside any `[[compose]]` block). Default `false` → conflicts raise. Set to `true` → conflicts last-wins by TOML file order with an INFO log. Does NOT suppress orphan-override, unknown-field, missing-source, cycle, or version-mismatch errors. |
+
+---
+
+## 5. Conflict resolution — precedence summary
+
+When two paths through the composition produce the same control ID:
+
+1. **`[overrides."ID"]` always wins.** Even in strict mode (`allow_conflicts = false`), the presence of an explicit override on the conflicting ID is treated as the composite author's acknowledgement of the conflict, so registration succeeds and the override's fields replace whatever the compose phase produced. The override's fields layer onto the **earliest** compose block's contribution (by TOML file order); later compose blocks contributing the same ID are skipped entirely. **This earliest-base rule is mode-independent — it holds under `allow_conflicts = false` AND `allow_conflicts = true`.** To pick a later compose block as the base, replicate its relevant fields inside the override.
+2. **Otherwise, with `allow_conflicts = true`**: the LATER `[[compose]]` block in TOML file order wins; INFO log emitted naming both sources and the winner.
+3. **Otherwise (strict, default)**: registration fails with `CompositionConflictError(control_id, sources=[earlier, later])`.
+
+---
+
+## 6. Provenance contract
+
+Every control in the resolved set carries two framework-stamped tags:
+
+| Tag key | Meaning |
+|---|---|
+| `_composed_from` | The slug of the **ultimate non-composite** source the control originated in. For recursive composition (composite-includes-composite), this is preserved from the source's already-resolved control, not overwritten with the intermediate composite's slug. |
+| `_original_control_id` | The control's ID as it appears in the originating non-composite source. Identical to the resolved control's ID in v1; recorded explicitly to future-proof for rename support. |
+
+Inline controls (defined directly in the composite's own TOML) are stamped with `_composed_from = "<composite-slug>"` and `_original_control_id = "<their-own-id>"`.
+
+Audit results, list-controls output, and any consumer that serializes `tags` automatically inherits this provenance — no consumer-side schema change is required.
+
+---
+
+## 7. Error contract (registration time)
+
+A composite registers via the standard `darnit.implementations` entry point. Its TOML is loaded through `darnit.config.merger.load_framework_config(...)`, which delegates to the composition resolver when `[[compose]]` blocks are present. All errors below are raised during this load, BEFORE any audit code runs:
+
+| Error class | Raised when | Message MUST name |
+|---|---|---|
+| `CompositionMissingSourceError` | A `[[compose]]` block names a `source` slug not installed on the host. | The missing slug. |
+| `CompositionConflictError` | Two `[[compose]]` blocks contribute the same control ID, no override resolves it, `allow_conflicts` is false. | Both source slugs, the conflicting control ID, and the two opt-out mechanisms. |
+| `CompositionOrphanOverrideError` | An `[overrides."ID"]` block targets a control ID not present in the resolved set. | The orphan ID. |
+| `CompositionUnknownFieldError` | An override names a field not on `ControlConfig`. | The unknown field name and the control ID. |
+| `CompositionCycleError` | A composition graph contains a cycle (self, A↔B, A→B→C→A, etc.). | The full cycle chain in resolution order. |
+| `CompositionVersionMismatchError` | A `[[compose]]` block's `version_constraint` is not satisfied by the installed source's version. | The constraint, the source slug, and the installed version. |
+
+All inherit from a common base `CompositionError(Exception)` so consumers can catch all composition errors uniformly via one `except` clause.
+
+---
+
+## 8. Backward compatibility
+
+- Non-composite frameworks (no `[[compose]]` block, no `[overrides]` block, no `allow_conflicts`) load with **identical** behavior to today. SC-008.
+- All existing implementations (`darnit-baseline`, `darnit-gittuf`, `darnit-example`, `darnit-hello`, `darnit-testchecks`) require zero changes.
+- Downstream consumers of `FrameworkConfig.controls` (audit pipeline, sieve, list-controls, remediation) see the same shape after resolution as before. The `controls` dict's value type, `ControlConfig`, gains no new required fields.

--- a/specs/013-plugin-composition/data-model.md
+++ b/specs/013-plugin-composition/data-model.md
@@ -1,0 +1,220 @@
+# Phase 1 Data Model: Composition of compliance implementations
+
+**Feature**: 013-plugin-composition · **Date**: 2026-05-13
+
+Composition introduces **three new entities** in the TOML schema and **one resolution algorithm**. Everything below targets `packages/darnit/src/darnit/config/framework_schema.py` (new pydantic models) and `packages/darnit/src/darnit/core/composition.py` (the resolver).
+
+---
+
+## Entity 1 — `ComposeBlock`
+
+One entry in a composite's `[[compose]]` table-array. Names a source implementation plus the inclusion/exclusion filters that select controls from it.
+
+### Fields
+
+| Field | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `source` | `str` | yes | — | The source implementation's slug (e.g., `"openssf-baseline"`). Resolved via `darnit.implementations` entry points. |
+| `include_all` | `bool` | no | `false` | Pull every control from the source. Mutually exclusive with the other `include_*` fields (FR-003). |
+| `include_levels` | `list[int]` | no | `[]` | Pull controls whose `level` is in this list. |
+| `include_controls` | `list[str]` | no | `[]` | Pull controls by exact ID. |
+| `include_tags` | `dict[str, Any]` | no | `{}` | Pull controls matching every tag/value pair (AND semantics across keys). |
+| `exclude_controls` | `list[str]` | no | `[]` | After inclusion filters are applied, drop these IDs from the result. |
+| `version_constraint` | `str \| None` | no | `None` | PEP 440 specifier (`">=1.5,<2.0"`). When present, source's `metadata.version` must satisfy it (FR-013). |
+
+### Validation rules
+
+- **V1.1** — Exactly one of `include_all` or one-or-more of (`include_levels`, `include_controls`, `include_tags`) MUST be set. A `[[compose]]` block with no inclusion expressions is a registration error: "No controls selected from source `<slug>`."
+- **V1.2** — If `include_all = true`, the other `include_*` fields MUST be empty. Mixing is a registration error.
+- **V1.3** — `version_constraint`, if present, MUST parse via `packaging.specifiers.SpecifierSet(...)`. A malformed specifier is a registration error naming the offending string.
+- **V1.4** — `exclude_controls` is applied AFTER the inclusion expressions. If `exclude_controls` is non-empty AND no inclusion expression is set, that's covered by V1.1's error.
+
+### State / lifecycle
+
+`ComposeBlock` is read-only after TOML load. No mutation during resolution; the resolver constructs new `ControlConfig` instances from the source's controls + provenance stamps.
+
+---
+
+## Entity 2 — `OverrideBlock`
+
+One `[overrides."CONTROL-ID"]` entry. Replaces specific fields of a control already present in the resolved set.
+
+### Fields
+
+| Field | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `passes` | `list[PassConfig] \| None` | no | `None` | If present, replaces the underlying control's `passes` list wholesale (FR-006). Partial pass edits are out of scope. |
+| `remediation` | `RemediationConfig \| None` | no | `None` | If present, replaces the control's `remediation` block. |
+| `security_severity` | `float \| None` | no | `None` | If present, replaces the control's `security_severity` field (CVSS-like 0.0–10.0). Field name matches the underlying `ControlConfig` schema exactly. |
+| `description` | `str \| None` | no | `None` | If present, replaces the control's `description`. |
+| `docs_url` | `str \| None` | no | `None` | If present, replaces the control's `docs_url`. Field name matches the underlying `ControlConfig` schema; v1 does NOT touch `help_md` / `help_file` separately. |
+| `tags` | `dict[str, Any]` | no | `{}` | Shallow-merged into the control's `tags`. Framework-stamped provenance keys (`_composed_from`, `_original_control_id`) are NOT overwritten. |
+
+**Key**: `OverrideBlock` instances are stored in `FrameworkConfig.overrides: dict[str, OverrideBlock]`, keyed by the target control ID.
+
+### Validation rules
+
+- **V2.1** — The target control ID (the dict key) MUST be present in the composite's resolved control set. An orphan override → `CompositionOrphanOverrideError` (FR-007). Checked AFTER `[[compose]]` blocks have populated the resolved set.
+- **V2.2** — Every field named in the override MUST be a known field on `ControlConfig`. Unknown fields → `CompositionUnknownFieldError` (FR-008). Validated against `ControlConfig.model_fields.keys()` (Pydantic v2). Names that LOOK like aliases (e.g., `severity`, `help_url`) but don't appear on the real schema are unknown fields and rejected — the override-able names in this document match the schema's real field names.
+- **V2.3** — At least one field MUST be set. An empty `[overrides."ID"]` block is a registration error: "Override for `<ID>` defines no fields."
+- **V2.4** — `tags` overrides may NOT redefine `_composed_from` or `_original_control_id`. If present in the override's `tags`, the resolver silently drops them and emits a WARNING log (these keys are reserved-internal).
+
+---
+
+## Entity 3 — `FrameworkConfig` (existing — extended)
+
+Two new top-level fields plus one Boolean flag.
+
+### New fields on existing model
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `compose` | `list[ComposeBlock]` | `[]` | TOML `[[compose]]` table-array. Presence triggers resolution at load time. |
+| `overrides` | `dict[str, OverrideBlock]` | `{}` | TOML `[overrides."ID"]` blocks. Keyed by target control ID. |
+| `allow_conflicts` | `bool` | `false` | Opt-out flag at the composition root (top-level TOML, NOT inside a `[[compose]]` block). When `true`, conflicts last-wins-by-file-order with an INFO log; when `false` (default), conflicts → `CompositionConflictError`. |
+
+### Behavioral invariants
+
+- **I3.1** — If `compose == []` AND `overrides == {}`, the framework is NOT a composite. Loader skips resolution and returns the parsed config unchanged. Composites are detected purely by presence of `[[compose]]` blocks (overrides without composes is meaningless and rejected by V2.1 — orphan overrides).
+- **I3.2** — After resolution, `compose` and `overrides` are CLEARED on the returned `FrameworkConfig`. The resolved `controls` dict is the only post-resolution surface; downstream consumers MUST NOT see composition state. (Implementation note: the resolver returns a new `FrameworkConfig` rather than mutating in place, since pydantic models are immutable-by-convention here.)
+- **I3.3** — Resolution is idempotent. Calling the resolver on an already-resolved `FrameworkConfig` (empty `compose`, populated `controls`) is a no-op.
+- **I3.4** — `allow_conflicts = true` does NOT suppress orphan-override, unknown-field, missing-source, cycle, or version-mismatch errors. It governs ONLY the strict-conflict path (FR-009 / FR-010).
+
+---
+
+## Entity 4 — `ControlConfig` (existing — extended via `tags`)
+
+No structural change. Provenance is stamped into the existing `tags: dict[str, Any]` field by the resolver:
+
+| Stamped tag key | Type | Source | Notes |
+|---|---|---|---|
+| `_composed_from` | `str` | Resolver | The slug named in the composite's `[[compose]]` block that contributed this control. For recursively composed sources, this is overwritten with the ultimate non-composite source's slug (FR-018 → FR-015). |
+| `_original_control_id` | `str` | Resolver | The control's ID as it appears in the originating non-composite source. In v1 this equals the control's own ID, but recording it explicitly future-proofs against rename support. |
+
+Underscore-prefix follows Python's "internal" convention and signals to UI/serializer code that these are framework-stamped tags.
+
+Provenance is also mirrored into `ControlSpec.tags` automatically — `ControlSpec.__post_init__` already copies `tags` from `ControlConfig` when the framework registers controls into the runtime registry.
+
+---
+
+## Resolution algorithm (canonical pseudocode)
+
+```text
+def resolve_composition(
+    composite: FrameworkConfig,
+    *,
+    _source_cache: dict[str, FrameworkConfig] = None,
+    _resolution_stack: list[str] = None,
+) -> FrameworkConfig:
+    _source_cache = _source_cache if _source_cache is not None else {}
+    _resolution_stack = _resolution_stack or []
+
+    # Idempotence (invariant I3.3)
+    if not composite.compose and not composite.overrides:
+        return composite
+
+    composite_slug = composite.metadata.name
+
+    # Self-cycle check (FR-012)
+    if composite_slug in _resolution_stack:
+        raise CompositionCycleError(chain=_resolution_stack + [composite_slug])
+    _resolution_stack = _resolution_stack + [composite_slug]
+
+    # Start with inline controls (preserve them as-is — they're the composite's own,
+    # no provenance stamping needed beyond their natural origin)
+    resolved: dict[str, ControlConfig] = dict(composite.controls)
+    contributor: dict[str, str] = {cid: composite_slug for cid in resolved}
+
+    # Walk compose blocks in TOML file order
+    for block in composite.compose:
+        # FR-013: version constraint check, applied to whatever the source's metadata.version is
+        source_config = _load_source_with_cache(block.source, _source_cache)
+        if source_config is None:
+            raise CompositionMissingSourceError(source=block.source)
+
+        # If source is itself a composite, resolve it RECURSIVELY through this
+        # same resolver so the _resolution_stack and _source_cache are shared.
+        # NOTE: source_loader returns a parsed-but-NOT-resolved FrameworkConfig
+        # (it calls _parse_framework_only, not load_framework_config). This is
+        # the load-bearing detail for cycle detection (FR-012): the only place
+        # composition recursion happens is HERE, so the only stack that exists
+        # is _resolution_stack.
+        source_config = resolve_composition(
+            source_config,
+            _source_cache=_source_cache,
+            _resolution_stack=_resolution_stack,
+        )
+
+        if block.version_constraint is not None:
+            _check_version(block, source_config)
+
+        # Apply inclusion/exclusion filters (R-009: intersection semantics)
+        selected_ids = _select_controls(block, source_config.controls)
+
+        # Resolve each selected control's effective source slug for provenance.
+        # If the source is a composite, its controls already carry _composed_from /
+        # _original_control_id pointing at their ultimate origin — preserve those.
+        # Otherwise, stamp them now.
+        for ctrl_id in selected_ids:
+            src_ctrl = source_config.controls[ctrl_id]
+            new_ctrl = _clone_with_provenance(
+                src_ctrl,
+                composed_from=src_ctrl.tags.get("_composed_from", block.source),
+                original_id=src_ctrl.tags.get("_original_control_id", ctrl_id),
+            )
+
+            if ctrl_id in resolved:
+                # Conflict path (FR-009, FR-010, FR-011)
+                if ctrl_id in composite.overrides:
+                    # Override will win regardless; skip the compose-block contribution
+                    # silently (the override phase replaces it anyway).
+                    continue
+                if composite.allow_conflicts:
+                    log.info(
+                        "Composition conflict on %s: %s overrides %s (allow_conflicts=true)",
+                        ctrl_id, block.source, contributor[ctrl_id],
+                    )
+                    resolved[ctrl_id] = new_ctrl
+                    contributor[ctrl_id] = block.source
+                else:
+                    raise CompositionConflictError(
+                        control_id=ctrl_id,
+                        sources=[contributor[ctrl_id], block.source],
+                    )
+            else:
+                resolved[ctrl_id] = new_ctrl
+                contributor[ctrl_id] = block.source
+
+    # Apply overrides AFTER all compose blocks (R-007)
+    for override_id, override in composite.overrides.items():
+        if override_id not in resolved:
+            raise CompositionOrphanOverrideError(orphan_id=override_id)
+        _validate_override_fields(override)  # FR-008
+        resolved[override_id] = _apply_override(resolved[override_id], override)
+
+    # Return a new FrameworkConfig with composition state cleared (invariant I3.2)
+    return composite.model_copy(
+        update={"controls": resolved, "compose": [], "overrides": {}},
+    )
+```
+
+### Algorithm properties
+
+- **Linear in unique-source count** thanks to `_source_cache` (R-003).
+- **Cycle detection** via `_resolution_stack` membership check before recursion (R-004).
+- **Strict-by-default conflicts** with two named escape hatches (R-008).
+- **Provenance preserved across recursion** by reading `_composed_from` / `_original_control_id` from the source's already-stamped tags before overstamping (R-006).
+- **Overrides last** so their precedence is unambiguous (R-007). When an override targets a control ID contributed by two or more compose blocks (in ANY mode — strict OR `allow_conflicts = true`), the override layers onto the **earliest** compose block's contribution; later compose blocks are skipped on the `continue` branch, never written. (The `continue` runs BEFORE the `allow_conflicts` check in the pseudocode above, so this rule is mode-independent.) Authors who need a later block's base must replicate it inside the override.
+- **Idempotent** because the returned config has `compose=[]` and `overrides={}` (I3.3).
+
+---
+
+## Cross-references
+
+| Entity | FRs it satisfies | SCs it supports |
+|---|---|---|
+| `ComposeBlock` | FR-001, FR-002, FR-003, FR-013, FR-014 | SC-001, SC-002, SC-004 |
+| `OverrideBlock` | FR-006, FR-007, FR-008, FR-011 | SC-007 |
+| `FrameworkConfig.compose / overrides / allow_conflicts` | FR-005, FR-009, FR-010, FR-016, FR-017, FR-018 | SC-006, SC-008 |
+| `tags["_composed_from"]` + `tags["_original_control_id"]` | FR-015, FR-018 | SC-003 |
+| Resolution algorithm | FR-004, FR-012 | SC-002, SC-004, SC-005 |

--- a/specs/013-plugin-composition/plan.md
+++ b/specs/013-plugin-composition/plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan: Composition of compliance implementations
+
+**Branch**: `013-plugin-composition` | **Date**: 2026-05-13 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/013-plugin-composition/spec.md`
+
+## Summary
+
+Add a TOML-only **composition** primitive so a darnit implementation can declare its control set as the union of (a) named slices of other installed implementations and (b) its own inline controls — without inheritance, forking, or any new Python API. Resolution runs once at framework-config load time inside `packages/darnit/`, produces a flat `FrameworkConfig.controls` dict identical in shape to today's non-composite frameworks, and stamps provenance metadata into each resolved control's `tags` so audit results trace back to the originating non-composite source. The existing audit, list-controls, and remediation pipelines see no schema change.
+
+The two non-obvious behaviors locked in by the clarify session:
+
+- **Strict-by-default conflicts.** Two `[[compose]]` blocks contributing the same control ID is a registration error unless the composite opts out with `allow_conflicts = true` (last-wins by file order) or resolves the conflict explicitly with an `[overrides."ID"]` block (always wins, even in strict mode).
+- **Recursive composition is supported.** A `[[compose]]` block may name a composite source; the resolver fetches the source's fully-resolved control set, not its raw configuration. Cycle detection (FR-012) is the load-bearing guardrail; provenance traces to the ultimate non-composite source.
+
+## Technical Context
+
+**Language/Version**: Python 3.11/3.12 (workspace targets — same as the rest of darnit)
+**Primary Dependencies**: `pydantic >= 2.0` (already used for `FrameworkConfig`); `packaging` (already a transitive dep via setuptools metadata) for PEP 440 `SpecifierSet`. `tomllib` from stdlib for TOML parsing. No new runtime dependencies.
+**Storage**: Filesystem only. Composition is resolved in-memory at framework-config load time; no new persistent state.
+**Testing**: `pytest` with fixtures generated under `tests/fixtures/composite/` (TOML-only minimal composites). Reuses the existing `darnit-hello` worked-example pattern for fixture shape.
+**Target Platform**: Same as darnit itself — Linux/macOS developer laptops + CI runners. No platform-specific behavior.
+**Project Type**: Single project (Python workspace of plugin packages). Composition is an additive primitive inside the `packages/darnit/` core framework; no new top-level package.
+**Performance Goals**: SC-002 — resolve a composite with 50 upstream + 5 inline controls in **≤200 ms** on a developer laptop. Resolution is pure-Python dict merging over already-parsed `FrameworkConfig` objects; memoization of source loads handles the diamond case.
+**Constraints**:
+- Plugin Separation (Constitution I): the composition module lives in `packages/darnit/` and MUST NOT import any implementation package. It resolves sources via the existing `darnit.implementations` entry-point group; source slugs are mapped to TOML paths via `PluginRegistry`, then loaded through `_parse_framework_only(path)` (NOT `load_framework_by_name`, which would re-enter composition with a fresh cycle stack — see F-1 fix in research.md R-002).
+- TOML-First (Constitution III): every composition primitive is TOML-expressible; no new Python protocol method.
+- Conservative-by-Default (Constitution II): strict-by-default conflict resolution; missing source → registration error; cycle → registration error; orphan override → registration error.
+**Scale/Scope**: Realistic composites land in the 20–80 control range. Worst case in scope: ~150 controls across 4–5 sources with one diamond merge. Cycle-detection stack is bounded by source-graph depth (typically ≤3 in practice; no artificial limit imposed beyond cycle detection).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| **I. Plugin Separation** | ✅ Pass | Composition module lives in `packages/darnit/src/darnit/core/composition.py`. Source resolution uses the existing `darnit.implementations` entry-point group (slug → path via `PluginRegistry`, then `_parse_framework_only(path)`) — no `import darnit_baseline` style coupling. The resolver does NOT call `load_framework_by_name` (which would re-enter composition with a fresh cycle stack — F-1 fix). New protocol fields (if any) guarded with `hasattr()`. |
+| **II. Conservative-by-Default** | ✅ Pass | Strict conflicts are the default (FR-009). Missing source = registration error (FR-004). Cycle = registration error (FR-012). Orphan override / unknown-field override = registration error (FR-007, FR-008). Version mismatch = registration error (FR-013). No silent fallback path. |
+| **III. TOML-First Architecture** | ✅ Pass | All composition primitives (`[[compose]]`, `[overrides."..."]`, `allow_conflicts`, `version_constraint`, inclusion/exclusion filters) are TOML schema additions. No Python override hook in v1. Resolved controls retain their original TOML-defined pass logic. |
+| **IV. Never Guess User Values** | ✅ Pass | Composition does not infer membership, levels, or overrides from heuristics. The composite author types every selector by hand. INFO log on `allow_conflicts = true` is the audit-trail breadcrumb, not silent guesswork. |
+| **V. Sieve Pipeline Integrity** | ✅ Pass | Composition is **upstream** of the sieve. After resolution, the framework's controls dict is shape-identical to a non-composite's. The sieve never sees a `[[compose]]` block. PASS/FAIL/INCONCLUSIVE semantics are unaffected. |
+
+No principle violations. No `Complexity Tracking` entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-plugin-composition/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (Phase 0 of /speckit.plan)
+├── data-model.md        # Phase 1 output (Phase 1 of /speckit.plan)
+├── quickstart.md        # Phase 1 output (Phase 1 of /speckit.plan)
+├── contracts/           # Phase 1 output: TOML schema contract + resolver-API contract
+│   ├── toml-schema.md
+│   └── resolver-api.md
+├── checklists/
+│   └── requirements.md  # Already passing 16/16
+└── tasks.md             # Phase 2 output (created later by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+Composition is purely additive inside `packages/darnit/`. No new top-level package.
+
+```text
+packages/darnit/src/darnit/
+├── config/
+│   ├── framework_schema.py     # ⊕ ADD: ComposeBlock, OverrideBlock pydantic models;
+│   │                           #         FrameworkConfig.compose, .overrides, .allow_conflicts fields
+│   └── merger.py               # ⊕ REFACTOR: extract _parse_framework_only(path) helper that does
+│                               #              parse + template-validate WITHOUT touching composition.
+│                               #              load_framework_config() becomes a thin wrapper:
+│                               #              _parse_framework_only → conditional resolve_composition.
+│                               #              The resolver's source_loader routes through
+│                               #              _parse_framework_only so cycle detection holds (F-1).
+├── core/
+│   ├── composition.py          # ⊕ NEW: resolve_composition(), cycle detection, conflict
+│   │                           #         enforcement, override application, provenance stamping
+│   ├── plugin.py               # (unchanged — ControlSpec.tags already carries provenance)
+│   └── discovery.py            # (unchanged)
+└── (rest of the tree untouched — sieve, audit, remediation see no schema change)
+
+tests/darnit/
+├── test_composition.py         # ⊕ NEW: unit tests for resolver (filters, overrides,
+│                               #         conflicts, cycles, version pinning, provenance)
+└── fixtures/
+    └── composite/              # ⊕ NEW: minimal TOML fixtures, one per scenario
+        ├── basic-include-all.toml
+        ├── include-levels.toml
+        ├── include-controls.toml
+        ├── exclude-controls.toml
+        ├── overrides-remediation.toml
+        ├── strict-conflict-rejects.toml
+        ├── allow-conflicts-last-wins.toml
+        ├── override-resolves-conflict.toml
+        ├── orphan-override-rejects.toml
+        ├── unknown-field-override-rejects.toml
+        ├── missing-source-rejects.toml
+        ├── self-cycle-rejects.toml
+        ├── two-cycle-rejects.toml
+        ├── three-level-recursive-resolves.toml
+        ├── version-pin-satisfied.toml
+        └── version-pin-violated.toml
+```
+
+**Structure Decision**: Single project (Python workspace). All new code lands in `packages/darnit/src/darnit/{core,config}/`. No changes to implementation packages (`darnit-baseline`, `darnit-gittuf`, `darnit-hello`, `darnit-testchecks`) — they remain valid non-composite implementations. Composition is detected by the presence of a `[[compose]]` table-array in a framework's TOML at load time.
+
+## Complexity Tracking
+
+> No constitution violations; this section intentionally empty.

--- a/specs/013-plugin-composition/quickstart.md
+++ b/specs/013-plugin-composition/quickstart.md
@@ -1,0 +1,204 @@
+# Quickstart: Composing your own compliance implementation
+
+**Feature**: 013-plugin-composition · **Audience**: composite-implementation authors · **Date**: 2026-05-13
+
+This walks through the canonical Story 1 scenario from the spec: building an `acme-baseline` implementation that pulls slices from `openssf-baseline` and `darnit-gittuf`, adds an internal control inline, overrides one inherited control's remediation, and registers like any other implementation. No Python composition code needed.
+
+## Prerequisites
+
+- darnit installed in your environment (any of the v0.1.0+ distribution channels — PyPI, container, binary).
+- The source implementations you want to compose are installed alongside (`darnit-baseline`, `darnit-gittuf` in this example).
+- You can already author a non-composite implementation. (If you can't, work through the `darnit-hello` template first — composition is purely additive on top of it.)
+
+## Step 1 — Create the package skeleton
+
+```text
+acme-baseline/
+├── pyproject.toml
+├── README.md
+└── src/
+    └── acme_baseline/
+        ├── __init__.py
+        ├── implementation.py
+        └── acme-baseline.toml
+```
+
+`pyproject.toml` (key fragment):
+
+```toml
+[project]
+name = "acme-baseline"
+version = "1.0.0"
+
+[project.entry-points."darnit.implementations"]
+acme-baseline = "acme_baseline:register"
+```
+
+`src/acme_baseline/__init__.py`:
+
+```python
+def register():
+    from .implementation import AcmeBaselineImplementation
+    return AcmeBaselineImplementation()
+```
+
+`src/acme_baseline/implementation.py` — note this is the **same `ComplianceImplementation` stub** any non-composite uses. No composition awareness needed.
+
+```python
+from pathlib import Path
+from darnit.core.plugin import ComplianceImplementation, ControlSpec
+
+class AcmeBaselineImplementation:
+    @property
+    def name(self) -> str: return "acme-baseline"
+    @property
+    def display_name(self) -> str: return "Acme Baseline"
+    @property
+    def version(self) -> str: return "1.0.0"
+    @property
+    def spec_version(self) -> str: return "Acme v1"
+
+    def get_framework_config_path(self) -> Path:
+        return Path(__file__).parent / "acme-baseline.toml"
+
+    def get_all_controls(self) -> list[ControlSpec]:
+        # Standard pattern: load via the framework loader and return controls.
+        # Composition resolution happens transparently inside load_framework_config.
+        from darnit.config.merger import load_framework_config
+        cfg = load_framework_config(self.get_framework_config_path())
+        return [ControlSpec(...) for cid, c in cfg.controls.items()]
+
+    def register_controls(self) -> None:
+        pass  # TOML-only; nothing to register in Python.
+```
+
+## Step 2 — Author the composite TOML
+
+`src/acme_baseline/acme-baseline.toml`:
+
+```toml
+[metadata]
+name = "acme-baseline"
+display_name = "Acme Baseline"
+version = "1.0.0"
+spec_version = "Acme v1"
+
+# Strict-by-default conflict resolution. Leave at default unless you need
+# the last-wins escape hatch.
+# allow_conflicts = false
+
+# Pull OpenSSF Baseline levels 1 and 2, but drop a control Acme doesn't
+# care about. Pin to the 1.x line so an upstream major bump fails loudly.
+[[compose]]
+source = "openssf-baseline"
+include_levels = [1, 2]
+exclude_controls = ["OSPS-AC-02.01"]
+version_constraint = ">=1.0,<2.0"
+
+# Pull every gittuf control, default-floating on the source's version.
+[[compose]]
+source = "darnit-gittuf"
+include_all = true
+
+# Cherry-pick three specific level-3 OSPS controls.
+[[compose]]
+source = "openssf-baseline"
+include_controls = [
+    "OSPS-AC-03.01",
+    "OSPS-VM-03.01",
+    "OSPS-QA-07.01",
+]
+version_constraint = ">=1.0,<2.0"
+
+# An inline control of Acme's own. Exactly the same shape as in any non-
+# composite implementation.
+[controls."ACME-DEPLOY-01.01"]
+name = "DeployWindowEnforced"
+level = 1
+domain = "AC"
+description = "Production deploys happen only during the published window."
+
+[[controls."ACME-DEPLOY-01.01".passes]]
+handler = "exec"
+command = ["gh", "api", "/repos/{owner}/{repo}/actions/variables/DEPLOY_WINDOW"]
+output_format = "json"
+expr = 'output.json.value != ""'
+
+# Override the remediation on an inherited control to point at Acme's
+# internal SSO console, without touching its pass logic.
+[overrides."OSPS-AC-01.01"]
+remediation = """
+1. Open https://sso.acme.example/admin → Policies → Authentication.
+2. Set "Require multi-factor for all sign-ins" → ON.
+3. Save and refresh the user audit log to confirm enforcement is active.
+"""
+```
+
+## Step 3 — Install and verify
+
+```bash
+# In the acme-baseline package directory:
+uv pip install -e .
+
+# Confirm the framework loads. The composition resolver runs at load time;
+# any of the error classes from contracts/resolver-api.md surface here.
+darnit validate src/acme_baseline/acme-baseline.toml
+
+# List the resolved control set — should be:
+#   openssf-baseline L1+L2 (minus OSPS-AC-02.01) +
+#   all darnit-gittuf controls +
+#   3 OSPS L3 controls +
+#   1 inline ACME control
+darnit list-controls --implementation acme-baseline
+
+# Run an audit. The output shape is identical to a non-composite audit.
+darnit audit --implementation acme-baseline /path/to/repo
+```
+
+## Step 4 — Sanity-check provenance
+
+Every control in the resolved set carries two framework-stamped tags:
+
+```bash
+darnit list-controls --implementation acme-baseline --output json \
+  | jq '.controls[0].tags | {_composed_from, _original_control_id}'
+
+# Example output for a control inherited from openssf-baseline:
+# {
+#   "_composed_from": "openssf-baseline",
+#   "_original_control_id": "OSPS-AC-03.01"
+# }
+
+# Example output for the inline ACME control:
+# {
+#   "_composed_from": "acme-baseline",
+#   "_original_control_id": "ACME-DEPLOY-01.01"
+# }
+```
+
+These tags are how audit reviewers trace any finding back to its source implementation.
+
+## Common errors
+
+**`CompositionMissingSourceError`** — A `[[compose]]` block names a source not installed on the host. Install the source package (e.g., `uv pip install darnit-baseline`) and retry.
+
+**`CompositionConflictError`** — Two `[[compose]]` blocks contributed the same control ID. The error lists both source slugs and the conflicting ID. Resolve by either:
+- Adding `allow_conflicts = true` at the top level (later compose block wins; INFO log emitted), OR
+- Adding `[overrides."<ID>"]` to pin the conflict resolution explicitly (always wins, even in strict mode).
+
+**`CompositionOrphanOverrideError`** — An `[overrides."ID"]` block targets a control ID not present in the resolved set (maybe a typo, maybe the source was filtered out). Either remove the override or adjust the compose block to include the ID.
+
+**`CompositionUnknownFieldError`** — An override names a field not on `ControlConfig`. Check the field name; v1 supports `passes`, `remediation`, `security_severity`, `description`, `docs_url`, and `tags`. (The override-able names match the real schema — `severity` and `help_url` are rejected. There are no friendly aliases in v1.)
+
+**`CompositionCycleError`** — A composition graph has a cycle. The error names the chain (`acme-baseline → other-composite → acme-baseline`). Composites cannot transitively include themselves.
+
+**`CompositionVersionMismatchError`** — A `[[compose]]` block's `version_constraint` is not satisfied by the installed source's version. Either install a compatible source version or relax the constraint.
+
+## When to use composition vs. forking
+
+- **Use composition** when your posture is "the upstream framework + a few named slices and overrides." Composition keeps you upgrade-current on the source's pass logic and remediation.
+- **Use a fork** only if you need to fundamentally re-author a source's pass logic, restructure its control IDs, or maintain divergent semantics. Forking is heavyweight; composition is the additive default.
+
+## Performance budget
+
+Resolution runs once at framework-config load time (effectively once per process). The target (SC-002) is **<200 ms for 50 composed + 5 inline controls** on a developer laptop. Larger composites still resolve in linear time relative to unique source count thanks to memoization. If you observe surprisingly long load times, file an issue with your composite's TOML and the resolution time — the resolver should not be a noticeable cost.

--- a/specs/013-plugin-composition/research.md
+++ b/specs/013-plugin-composition/research.md
@@ -1,0 +1,128 @@
+# Phase 0 Research: Composition of compliance implementations
+
+**Feature**: 013-plugin-composition · **Date**: 2026-05-13
+
+The clarify session resolved the two highest-impact ambiguities (strict-by-default conflicts; recursive composition is allowed). This document captures the remaining design-shaped questions surfaced during planning, the chosen answer, and the alternatives considered. No `NEEDS CLARIFICATION` markers remain in the plan after this phase.
+
+## R-001 — Where does composition resolution run?
+
+- **Decision**: Inside `load_framework_config(path)` in `packages/darnit/src/darnit/config/merger.py`. When the parsed `FrameworkConfig` has a non-empty `compose` list, the loader delegates to `darnit.core.composition.resolve_composition(...)` BEFORE returning.
+- **Rationale**: Resolution must happen exactly once per `FrameworkConfig` load and must produce a config object indistinguishable from a non-composite's. The loader is the only chokepoint every call site already passes through (CLI, audit tools, registry validation). Putting resolution behind a separate "composite loader" would force every call site to branch.
+- **Alternatives considered**:
+  - **At plugin-discovery time (in `core/discovery.py`)**: rejected — discovery returns `ComplianceImplementation` instances, not `FrameworkConfig` objects. The TOML hasn't been parsed yet.
+  - **Lazy / on first `get_all_controls()` call**: rejected — performance is fine at load time (SC-002), and lazy resolution moves cycle errors from "registration time" to "first audit", which violates FR-012's "at registration time" requirement.
+  - **In a separate wrapper `load_composite_framework_config(...)`**: rejected — forces callers to know whether a framework is composite. The spec is explicit (Assumption: "Composites are themselves discoverable") that composites must look like non-composites to consumers.
+
+## R-002 — How are source frameworks fetched during resolution?
+
+- **Decision**: The composition resolver is the **single recursive entrypoint** for composition resolution. Its `source_loader` parameter returns a **parsed-but-not-resolved** `FrameworkConfig` for any given source slug. A new internal helper `_parse_framework_only(path: Path) -> FrameworkConfig` in `darnit.config.merger` does the pydantic parse + template-path validation but **does NOT invoke `resolve_composition`**. The default `source_loader` does slug → path lookup via the existing `PluginRegistry` and then calls `_parse_framework_only` on the path. `resolve_composition` is the only function that drives composition recursion, and it owns the only `_resolution_stack`. Recursive composition (FR-018) is handled by `resolve_composition` calling itself on the parsed-but-not-resolved source with the **same** stack.
+- **Rationale**: This is the load-bearing decision for cycle detection. If the source loader itself invoked `resolve_composition` (transitively through `load_framework_config`), each recursive load would start a **fresh** `_resolution_stack` and cycles would infinite-loop instead of raising. By making the source loader resolution-free and putting all recursion under one stack, FR-012 / FR-018 / SC-005 hold in code, not just in design intent. The existing `load_framework_config` becomes a thin wrapper: parse + template-validate via `_parse_framework_only`, then conditionally call `resolve_composition` exactly once at the top level (idempotence per I3.3 makes this safe).
+- **Alternatives considered**:
+  - **Original draft: `source_loader` = `load_framework_by_name`**: rejected (this was the F-1 defect from the analyze pass) — `load_framework_by_name` calls `load_framework_config`, which re-enters `resolve_composition` with an empty stack. Cycles silently infinite-loop. The fix is precisely to break this cycle of call-chains.
+  - **Thread-local resolution stack**: rejected — would make resolution non-reentrant in surprising ways (e.g., test parallelism, future async loaders). Explicit per-call stack threading is simpler.
+  - **Read the source's TOML file directly without pydantic validation**: rejected — would bypass template-path validation and schema-evolution checks. `_parse_framework_only` reuses the existing parse + template-validate pipeline; the ONLY thing it skips is the composition step.
+  - **Walk `darnit.core.discovery.discover_implementations()` and call `impl.get_all_controls()`**: rejected — that returns `ControlSpec` objects (a presentation type), not `ControlConfig` (the schema type with full pass/remediation data needed to merge into the composite's framework config).
+
+## R-003 — Diamond resolution & memoization
+
+- **Decision**: `resolve_composition` accepts an optional `_source_cache: dict[str, FrameworkConfig]` and an `_resolution_stack: list[str]`. Each `[[compose]]` source is loaded at most once per top-level resolution; the cache key is the source slug. If the same slug appears in two different paths through the graph (e.g., composite A includes B and C; both B and C include leaf X), X is loaded once.
+- **Rationale**: Without memoization, the diamond case re-parses TOML files unnecessarily. SC-002 (≤200 ms for 50 + 5 controls) is achievable either way, but memoization makes the resolver linear in the unique-source count instead of polynomial in graph paths.
+- **Alternatives considered**:
+  - **Global module-level cache**: rejected — would persist across resolutions and require explicit invalidation in tests. The discovery cache is already module-level; adding another would compound the test-cleanup burden.
+  - **No memoization**: acceptable for v1's scale but not future-proof. Single-loop memoization is ~10 lines of code; the cost/benefit doesn't favor skipping it.
+
+## R-004 — Cycle detection algorithm
+
+- **Decision**: Use a per-resolution `_resolution_stack: list[str]` (ordered, allows reproducing the cycle chain in the error message). Before resolving a source, check `source_slug in _resolution_stack` — if so, raise `CompositionCycleError(chain=_resolution_stack + [source_slug])`. Push before recursing, pop after. Self-cycle (A includes A) is handled by the same check.
+- **Rationale**: Depth-first walk with an explicit stack is the textbook approach. Using a `list` rather than a `set` lets the error message render `"A → B → C → A"` (the chain order matters for debuggability).
+- **Alternatives considered**:
+  - **Bounded depth limit (e.g., max depth 5)**: rejected per the clarify session's Q2 answer — depth limits add cognitive overhead without proportional safety. Cycle detection is sufficient.
+  - **Topological sort up front**: rejected — requires materializing the full graph before any resolution, which complicates the loader's single-pass model. Depth-first detection is strictly cheaper.
+
+## R-005 — Version-constraint enforcement
+
+- **Decision**: Use `packaging.specifiers.SpecifierSet` (stdlib-adjacent — already a transitive dep through setuptools/build tooling). When a `[[compose]]` block carries `version_constraint = "<spec>"`, parse it into a `SpecifierSet` and check the loaded source's `FrameworkConfig.metadata.version` field against it via `Version(version_str) in specifier_set`. On mismatch, raise `CompositionVersionMismatchError` naming the constraint, the source slug, and the actual installed version.
+- **Rationale**: PEP 440 is the Python ecosystem standard. Re-using `packaging` keeps semantics identical to pip/uv constraint checks the composite author already understands. No new comparator code to test.
+- **Alternatives considered**:
+  - **Hand-rolled comparator**: rejected — re-implementing PEP 440 is a footgun (pre-release handling, local versions, etc.).
+  - **SemVer-only**: rejected — Python frameworks don't always follow SemVer, and OpenSSF Baseline's `spec_version` is calendar-based ("OSPS v2025.10.10"). PEP 440 absorbs both conventions cleanly.
+
+## R-006 — Provenance stamping
+
+- **Decision**: During resolution, every control pulled in via a `[[compose]]` block has two keys stamped into its `tags` dict before being inserted into the composite's `FrameworkConfig.controls`:
+  - `tags["_composed_from"] = "<source-slug>"` — the immediate source the composite named in its `[[compose]]` block.
+  - `tags["_original_control_id"] = "<id>"` — the control's ID as defined upstream (identical to its key in v1, but recorded explicitly so future rename support doesn't break provenance).
+  - For recursive composition: if the source is itself a composite, the resolver overwrites these tags with the *ultimate non-composite* source's slug and original ID (i.e., what the source's already-resolved control already carries). This satisfies FR-018's "provenance traces to the ultimate source — C, not B" requirement.
+- **Rationale**: `ControlConfig.tags` and `ControlSpec.tags` already exist as the standard sidecar-metadata channel and already propagate through `__post_init__` in `ControlSpec`. Audit results already serialize tags. Reusing this channel means zero schema changes downstream.
+- **Alternatives considered**:
+  - **New top-level `provenance: Provenance` field on `ControlConfig`**: rejected — would require schema migration and a corresponding `ControlSpec` field, plus changes to every serializer and audit-result formatter. Tags route is non-invasive.
+  - **Compose the source-of-record into the control ID itself (e.g., `openssf-baseline::OSPS-AC-01.01`)**: rejected — would break every existing audit consumer that filters by control ID.
+
+The underscore prefix on `_composed_from` / `_original_control_id` follows Python's "internal" convention and signals to UI code that these are framework-stamped rather than author-defined tags.
+
+## R-007 — Override merge mechanics
+
+- **Decision**: Overrides are applied AFTER all `[[compose]]` blocks have contributed their controls AND after strict-conflict detection has run. For each `[overrides."ID"]` block:
+  1. If `ID` is not present in the resolved set → raise `CompositionOrphanOverrideError(orphan_id=ID)` (FR-007).
+  2. For each field named under the override, validate against the underlying `ControlConfig`'s schema. Unknown fields → raise `CompositionUnknownFieldError(field=...)` (FR-008).
+  3. The override fields shallow-replace the corresponding fields on the resolved control. Specifically: the `passes` list is replaced wholesale if present (consistent with FR-006's "wholesale replacement only"); scalar fields (`remediation`, `security_severity`, `description`, `docs_url`) replace directly; `tags` dict-merges (override keys win; framework-stamped provenance keys are NOT erased even if the override redefines `tags` — provenance is non-overridable). Override field names match the real `ControlConfig` schema exactly; aliases like `severity` / `help_url` are NOT supported.
+- **Rationale**: Two-pass resolution (compose → conflict-detect → override) keeps the override semantics simple to reason about: "an override always wins over whatever the compose phase produced." Out-of-order application would force complex precedence chains. Provenance non-overridability prevents an override from disguising the origin of an inherited control.
+- **Alternatives considered**:
+  - **Deep-merge inside `passes`**: rejected per FR-006 — "partial pass-block edits are out of scope for v1."
+  - **Validate override field names against pydantic introspection of `ControlConfig` rather than a hand-maintained allowlist**: chosen — pydantic's `model_fields` is the authoritative schema; an allowlist would drift. Implementation uses `ControlConfig.model_fields.keys()` (Pydantic v2 API).
+
+## R-008 — Strict-conflict detection mechanics
+
+- **Decision**: Track each control ID's provenance as compose blocks are applied in order. When a `[[compose]]` block tries to write to an ID that's already been written by a prior compose block (in the same composite, after filters), check:
+  - Is `allow_conflicts = true` on the composite? → emit INFO log, last-wins (later compose block's contribution overwrites). FR-010.
+  - Is there an `[overrides."ID"]` block targeting this ID? → no error; the override phase will resolve it. FR-011.
+  - Otherwise → raise `CompositionConflictError(control_id=ID, sources=[earlier_source, later_source])` with both source slugs and the conflicting ID.
+- **Rationale**: Checking against the overrides table during compose-block iteration is what makes the override-resolves-conflict pathway work without false positives in strict mode. The INFO log under `allow_conflicts` provides the audit-trail breadcrumb required by SC-006 and FR-010.
+- **Alternatives considered**:
+  - **Detect conflicts only after all compose blocks have been applied (one final pass)**: rejected — would lose the "earlier source" identity needed for the error message. Per-block tracking is one extra dict.
+  - **Treat overrides as making conflicts always-allowed globally**: rejected — overrides are per-control; an override for `ID-A` should not silently permit a separate conflict on `ID-B`.
+
+## R-009 — Inclusion-filter semantics
+
+- **Decision**: Per FR-003, multiple inclusion expressions within a single `[[compose]]` block are evaluated as an **intersection**:
+  - If `include_all = true`, start with the source's full control set.
+  - Else if `include_levels` is present, start with controls whose level ∈ `include_levels`.
+  - Then if `include_controls` is present, intersect: only keep controls whose ID ∈ `include_controls`.
+  - Then if `include_tags` is present, intersect: only keep controls whose tags satisfy ALL named tag-value pairs.
+  - Finally, `exclude_controls` removes its named IDs from whatever set is left.
+- **Rationale**: Intersection-semantics for inclusion is the principle of least surprise — adding a second selector narrows the result, never broadens it. "Union of selectors" would create surprising behavior (e.g., `include_levels = [1]` + `include_controls = ["L3-CTRL"]` would silently pull a level-3 control, which the level filter implied was excluded).
+- **Alternatives considered**:
+  - **Union of selectors**: rejected for the reason above; documented here as an explicit "this is NOT how it works."
+  - **First-match wins**: rejected — order-dependent semantics for what is conceptually a set operation.
+- **Empty-result behavior**: if filters narrow to zero controls, the `[[compose]]` block contributes nothing. This is NOT an error (a composite might legitimately layer optional sources). Emit a DEBUG log noting the empty contribution.
+
+## R-010 — Test-fixture strategy
+
+- **Decision**: Use minimal hand-authored TOML fixtures under `tests/darnit/fixtures/composite/` rather than dynamically constructing `FrameworkConfig` objects in code. Each scenario gets one fixture. The resolver's unit tests load each fixture through `load_framework_config(...)` (the real production loader) and assert on the resolved `FrameworkConfig.controls` dict (or on the raised exception).
+- **Rationale**:
+  - Tests through the loader (not the resolver in isolation) catch schema-binding bugs as well as resolution bugs.
+  - Hand-authored TOML matches the actual composite-author experience and acts as documentation for the contract.
+  - Fixtures double as concrete examples in `quickstart.md`.
+- **Alternatives considered**:
+  - **Programmatic `FrameworkConfig` construction in test code**: rejected — bypasses the schema layer, which is half the surface area being tested.
+  - **Single mega-fixture with toggles**: rejected — couples scenarios that should fail independently.
+
+## R-011 — Error class taxonomy
+
+- **Decision**: Define one base exception `CompositionError(Exception)` in `darnit.core.composition`, with concrete subclasses:
+  - `CompositionMissingSourceError` (FR-004)
+  - `CompositionConflictError` (FR-009)
+  - `CompositionOrphanOverrideError` (FR-007)
+  - `CompositionUnknownFieldError` (FR-008)
+  - `CompositionCycleError` (FR-012)
+  - `CompositionVersionMismatchError` (FR-013)
+- **Rationale**: Distinct subclasses let `merger.load_framework_config` callers catch composition errors discriminantly, and let CLI / MCP-tool surfaces translate each into a specific exit code or user-facing message. Single base class lets generic error-handling catch all composition issues uniformly.
+- **Alternatives considered**:
+  - **Single `CompositionError` with a `kind` field**: rejected — Python exception hierarchies are the idiomatic discriminator; the `isinstance` check is what consumers will write.
+  - **Reuse existing `ValueError`**: rejected — composition errors are recoverable in callers' view (e.g., a CLI can suggest the specific fix from the error type); homogenizing into `ValueError` loses that signal.
+
+---
+
+## Summary of unresolved items going into Phase 1
+
+None. All Technical Context fields have concrete values; no `NEEDS CLARIFICATION` markers remain. Phase 1 (data-model.md, contracts/, quickstart.md) can proceed.

--- a/specs/013-plugin-composition/spec.md
+++ b/specs/013-plugin-composition/spec.md
@@ -1,0 +1,221 @@
+# Feature Specification: Composition of compliance implementations
+
+**Feature Branch**: `013-plugin-composition`
+**Created**: 2026-05-13
+**Status**: Draft
+**Input**: User description: "Design composition of compliance implementations per #233 — let a plugin assemble its controls from parts of other implementations (e.g., 'include OpenSSF Baseline L1+L2, plus SLSA L3, plus three named OSPS L3 controls, plus my own'), without inheritance."
+
+## Context
+
+Today, every darnit compliance implementation is a self-contained plugin (`darnit-baseline`, `darnit-gittuf`, `darnit-example`, the worked-example `darnit-hello`). Each lives at the same conceptual level: a registered implementation under the `darnit.implementations` entry point, with its own framework name, its own TOML config, and its own controls. A user audits one implementation at a time (`darnit audit --implementation openssf-baseline`).
+
+Real organizations don't think in terms of one implementation. A typical org-policy looks like: "we follow OpenSSF Baseline through level 2, take SLSA up to level 3, AND require three specific level-3 OSPS controls, AND have these six internal controls." Today there is no way to express that without forking and rewriting an entire implementation.
+
+This feature defines **composition** — a way for an implementation to declare which controls it wants from other implementations, in TOML, without writing Python or forking source. The framework resolves the composition at registration time and produces a single flat list of controls that the existing audit pipeline already knows how to handle. No changes to the sieve, the audit tool, or the remediation pipeline are required.
+
+## Clarifications
+
+### Session 2026-05-13
+
+- Q: When two `[[compose]]` blocks contribute a control with the same ID, should the framework fail the registration by default (strict) or silently last-wins by file order? → A: **Strict by default.** Any control-ID conflict between `[[compose]]` blocks fails registration with a clear error naming both sources. The composite author opts out explicitly via `allow_conflicts = true` (which falls back to last-wins by TOML file order) OR resolves the conflict with an explicit `[overrides."ID"]` block (which always wins over any compose-block contribution). Reason: predictability is load-bearing for compliance frameworks; silent precedence is exactly the footgun that breaks under refactoring. Aligns with the Constitution's "Conservative-by-Default" principle (already cited in the spec).
+- Q: Should v1 support recursive composition (composites composing other composites), or restrict sources to non-composite "leaf" implementations? → A: **Allow recursive composition in v1.** The resolution algorithm is the same regardless of source type — we're composing fully-resolved control sets, not configuration text. Cycle detection (FR-012) is the load-bearing guardrail; depth limits add complexity without proportional safety. A new FR-018 explicitly admits composite sources; Story 4 gains a positive acceptance scenario covering a non-cyclic 3-level chain.
+
+The design follows two principles from the project constitution:
+
+- **Composition over inheritance** (issue #233's original framing). An implementation enumerates the specific controls it pulls from other sources, not a parent it derives from. This keeps the relationship explicit and surfaces upstream changes as additive choices rather than silently-inherited behavior.
+- **TOML-first**. Composition is expressed entirely in the implementation's TOML config. Python is the escape hatch, not the surface.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Organization assembles its own compliance baseline from existing ones (Priority: P1)
+
+A security architect at a software vendor wants to encode their organization's compliance posture as a single darnit implementation that downstream teams can audit against with one command. The posture isn't novel — it's a curated mix: the entire OpenSSF Baseline at levels 1 and 2, the SLSA controls up to level 3, plus three specific OSPS level-3 controls the security team has decided are critical now, plus four internal controls about deploy windows and rotation.
+
+Today, the architect has to either ship a long internal runbook telling teams "run these three darnit commands and intersect the results manually" — which never happens — or fork OpenSSF Baseline, copy controls into the fork, and maintain a divergent codebase.
+
+After this change, the architect creates a single `acme-baseline` implementation. Its TOML config declares the composition: which levels and named controls to pull from each source implementation, plus the four internal controls inline. The implementation registers via the existing `darnit.implementations` entry point and behaves like any built-in implementation to downstream teams: `darnit audit --implementation acme-baseline` produces one flat audit result.
+
+**Why this priority**: This is the core user value. Every other story in this feature is in service of making this scenario work cleanly. An architect who gets this one flow working has already extracted most of the feature's value.
+
+**Independent Test**: Author a minimal composite implementation (`acme-baseline`) that pulls 3 controls from `darnit-baseline` and adds 1 control of its own in TOML. Install it alongside `darnit-baseline`. Running `darnit list-controls --implementation acme-baseline` lists exactly 4 controls (3 from baseline + 1 local). Running `darnit audit --implementation acme-baseline` produces a single audit result covering all 4. No Python composition code is required in the composite's `implementation.py` beyond the standard `ComplianceImplementation` protocol stubs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a composite implementation `acme-baseline` whose TOML declares `compose` blocks pulling controls from `openssf-baseline` and `darnit-gittuf` plus its own inline controls, **When** the framework resolves the composition at registration time, **Then** `acme-baseline.get_all_controls()` returns one flat list containing every requested upstream control and every local control, with each control's pass logic intact and its identifying source recorded as metadata.
+2. **Given** the same composite, **When** `darnit audit --implementation acme-baseline` runs against a sample repository, **Then** the audit produces a single result set in the same shape as a non-composite audit. Each result is labelled with its original control ID so reviewers can trace it back to the source.
+3. **Given** a composite that pulls `openssf-baseline` levels 1 and 2 (not 3), **When** an audit runs, **Then** only level-1 and level-2 controls from `openssf-baseline` execute. Level-3 OSPS controls do not appear in the result set unless they were explicitly named under a separate `compose` block.
+4. **Given** a composite that names specific controls (e.g., `include_controls = ["OSPS-AC-01.01", "OSPS-VM-03.01"]`), **When** the composite resolves, **Then** exactly those controls — and no others from that source — are in scope.
+
+---
+
+### User Story 2 — Override a single inherited control without forking the source (Priority: P2)
+
+The architect from Story 1 reviews `OSPS-AC-01.01` (an access-control check) and realises Acme's internal remediation procedure differs from the upstream remediation darnit-baseline ships. The control's pass logic is fine; the remediation steps need to point at Acme's internal SSO console rather than the upstream "click here in GitHub settings" instructions.
+
+Today there's no way to do this without forking `darnit-baseline`. With this feature, the architect adds an `[overrides."OSPS-AC-01.01"]` block in their composite's TOML that replaces only the remediation, leaving the pass logic and metadata intact.
+
+**Why this priority**: Without overrides, organizations would either accept that some inherited control behaves wrong for their environment, or be forced to fork. The override mechanism is what keeps composition genuinely additive rather than a half-solution.
+
+**Independent Test**: Add an `[overrides."OSPS-AC-01.01"]` block to a composite implementation that replaces the control's `remediation` field. Run an audit and `darnit list-controls --implementation acme-baseline --show OSPS-AC-01.01`. The pass logic must match the upstream `openssf-baseline` version exactly; the remediation must match the override.
+
+**Acceptance Scenarios**:
+
+1. **Given** a composite that inherits `OSPS-AC-01.01` from `openssf-baseline` and overrides its `remediation` field, **When** the composite resolves, **Then** the merged control has the upstream pass logic and the override's remediation. The metadata (description, severity, help URL) defaults to upstream unless explicitly overridden.
+2. **Given** the same composite, **When** the upstream `openssf-baseline` releases a new version that changes the pass logic of `OSPS-AC-01.01`, **Then** the composite picks up the new pass logic on next install. The override only governs the fields it explicitly names.
+3. **Given** a composite that overrides a field the upstream control doesn't have (e.g., a non-existent `severity_override`), **When** the composite resolves, **Then** the framework reports a clear error at registration time naming the unknown field. (Don't silently store unused overrides.)
+
+---
+
+### User Story 3 — Conflicting controls across composed sources resolve predictably (Priority: P2)
+
+A composite implementation includes both `openssf-baseline` and a vendor framework. Both define a control with ID `OSPS-AC-01.01` but the vendor framework has different pass logic (a deeper check). The architect needs to know which one wins, and the answer needs to be predictable, documented, and not silent.
+
+**Why this priority**: Without a defined conflict-resolution rule, composing two real-world implementations becomes a guessing game. The cost of an unclear rule is silent behavioral drift between dev/prod or between teams.
+
+**Independent Test**: Author a composite that pulls `OSPS-AC-01.01` from two sources with intentionally different pass logic. Resolve the composition. The framework MUST refuse registration with a clear conflict-error by default, naming both sources and the conflicting control ID. Adding `allow_conflicts = true` (or an explicit `[overrides."OSPS-AC-01.01"]` block) MUST make registration succeed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a composite where two `compose` blocks both contribute a control with the same ID, **When** the composite resolves, **Then** the framework refuses registration with a clear error naming both sources, the conflicting control ID, and the two opt-out mechanisms (`allow_conflicts = true` or an explicit `[overrides."ID"]` block).
+2. **Given** the same composite, **When** the architect adds `allow_conflicts = true` at the composition root, **Then** registration succeeds: the LATER `[[compose]]` block (in TOML file order) wins, and the framework emits a non-fatal INFO log line naming both sources and the winning one.
+3. **Given** a composite with an explicit `[overrides."OSPS-AC-01.01"]` block in addition to the conflicting `compose` sources, **When** the composite resolves, **Then** the override wins regardless of whether `allow_conflicts` is set. Explicit overrides are a per-control acknowledgement of the conflict, so even strict mode treats them as resolved.
+
+---
+
+### User Story 4 — Composition cycles are detected and rejected (Priority: P3)
+
+Composite A composes from composite B which (deliberately or accidentally) composes from A. Today this is impossible because we don't have composition at all. After this feature, cycles become a real failure mode worth handling explicitly.
+
+**Why this priority**: Cycles produce infinite loops at registration time, which would either crash the framework or hang it. A clear error message is significantly better than either. P3 because in practice this only happens with deliberate misuse or unusual cross-org plugin ecosystems; most teams will hit conflicts (Story 3) far more often than cycles.
+
+**Independent Test**: Author two composites that reference each other. Install both. The framework rejects registration of either composite with a clear cycle error naming the chain.
+
+**Acceptance Scenarios**:
+
+1. **Given** composite A includes composite B, and composite B includes composite A, **When** either is loaded via the framework's plugin-discovery mechanism, **Then** the framework refuses to register either implementation and emits a clear error naming the cycle (`A → B → A`).
+2. **Given** a longer cycle (A → B → C → A), **When** any of A/B/C is loaded, **Then** the cycle is detected at the first composite to attempt resolution; the error names the full chain.
+3. **Given** a self-cycle (A includes A), **When** loaded, **Then** the framework rejects A with a clear "self-reference" error.
+4. **Given** a non-cyclic three-level chain (composite A sources from composite B, which sources from non-composite C), **When** A is registered, **Then** registration succeeds and `A.get_all_controls()` returns the resolved set produced by walking the chain end-to-end. Provenance metadata (per FR-015) MUST identify each control's ultimate source — C, not B — so auditors trace results to the originating implementation, not the intermediate composite.
+
+---
+
+### User Story 5 — Version pinning makes composites reproducible (Priority: P3)
+
+The architect ships `acme-baseline 1.0.0` referencing `openssf-baseline`. Six months later, `openssf-baseline 2.0.0` is released with breaking changes to some control IDs. Without version pinning, every audit of `acme-baseline 1.0.0` against the new `openssf-baseline` silently produces different results. With version pinning, the composite either continues to behave as it did or fails loudly with a version-mismatch error.
+
+**Why this priority**: For most users, the default behavior matters more than this knob. Most composites will track HEAD of their sources by default. But for orgs running compliance against regulators (SOC 2, HIPAA, ISO 27001), reproducibility of last quarter's audit results is a real requirement. P3 because the default-floating behavior is fine for v1; explicit pinning is a knob to add for users who need it.
+
+**Independent Test**: Pin a composite to a specific upstream version (`openssf-baseline >= 1.5,<2.0`). Install upstream `openssf-baseline 1.5.0`; composite resolves. Upgrade upstream to `2.0.0`; composite fails to register with a clear version-mismatch error naming the constraint and the installed version.
+
+**Acceptance Scenarios**:
+
+1. **Given** a composite that declares `version_constraint = ">=1.5,<2.0"` against an upstream source, **When** the installed upstream version is 1.5.0, **Then** the composite registers successfully and the resolved controls come from upstream 1.5.0.
+2. **Given** the same composite, **When** the installed upstream version is 2.0.0, **Then** the composite refuses to register and emits an error message naming the constraint and the installed version.
+3. **Given** a composite without an explicit `version_constraint`, **When** any version of the upstream is installed, **Then** the composite resolves with that version. Default-floating behavior is preserved for the no-pin case.
+
+---
+
+### Edge Cases
+
+- **Empty composition**: a composite that declares no `compose` blocks and no inline controls. Should it register? Probably yes (it's a valid-but-empty implementation), with `get_all_controls()` returning `[]`. Auditing it should produce an empty result set, not error.
+- **Composition of a non-composite that doesn't exist on the host**: a composite references `slsa-implementation` which isn't installed. The composite must fail to register with a clear "required source not installed" error, naming the missing source. (Per Constitution Principle II: Conservative-by-Default — never silently skip.)
+- **Recursive composition (composites composing composites)**: supported in v1 per FR-018. The resolution algorithm is the same depth-first walk regardless of source type; cycle detection (FR-012) is the load-bearing guardrail. Provenance traces to the originating non-composite source, not the intermediate composite.
+- **Override that names a control NOT pulled in by any `compose` block**: e.g., `[overrides."FOO-99.99"]` but no `compose` block includes `FOO-99.99`. Should this error? Yes — silent acceptance of dead overrides is a footgun. The framework rejects at registration time naming the orphan override.
+- **Include filter exclusion**: a composite that says `include_levels = [1, 2]` AND `exclude_controls = ["OSPS-AC-02.01"]`. Both constraints apply: the result is "everything at levels 1+2 EXCEPT OSPS-AC-02.01". Composition primitives must support both inclusion and exclusion expressions.
+- **Source upstream's own composition**: if a composed source is itself a composite, what does "the source's controls" mean? The fully-resolved set, not the source's own `compose` blocks. (We're composing *effective behavior*, not *configuration text*.)
+- **Same control included via two different paths** (A → B includes X; A also directly includes X via C): the resolver must surface this as a single included control (deduplicate), with the resolution order applying the standard last-wins/strict rules from Story 3.
+- **MCP tool ownership of inherited controls**: each inherited control's `audit_*` MCP tool — does the composite re-expose it under its own name, or does the upstream's name remain? For v1: the composite's `audit_<composite_name>` tool covers ALL controls in the composite; upstream tools remain exposed at their own names. Two ways to audit; not a conflict.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### TOML composition primitives
+
+- **FR-001**: A composite implementation MUST declare its composition entirely in TOML under a dedicated `[[compose]]` table-array (one entry per source-implementation pulled from). No new Python API is required for the common case; the composite's Python `ComplianceImplementation` class may be the same stub-style class used by the `darnit-hello` example.
+- **FR-002**: Each `[[compose]]` block MUST identify its source by the same slug the framework already uses (`name` field of the source implementation, e.g., `"openssf-baseline"`).
+- **FR-003**: Each `[[compose]]` block MUST support at least the following inclusion expressions, evaluated as the intersection of all expressions present in that block:
+  - `include_all = true` — pull every control from the source.
+  - `include_levels = [N, ...]` — pull controls whose level matches one of the named integers.
+  - `include_controls = ["ID", ...]` — pull controls by exact ID.
+  - `include_tags = { tag = "value", ... }` — pull controls matching the named tag/value pair (uses the existing `ControlSpec.tags` filter).
+  - `exclude_controls = ["ID", ...]` — drop these specific IDs from the otherwise-included set.
+- **FR-004**: The framework MUST refuse to register a composite that requires a source implementation not installed on the host. The error MUST name the missing source slug.
+- **FR-005**: Inline controls (defined directly under `[controls."..."]` in the composite's TOML, the same way non-composite implementations define their controls today) MUST coexist with `[[compose]]` blocks in the same TOML file. The effective control set is the union of all composed sources plus all inline controls.
+
+#### Override primitives
+
+- **FR-006**: A composite MAY declare `[overrides."CONTROL-ID"]` blocks that override specific fields of inherited controls. Override-able fields include at minimum: `remediation`, `security_severity`, `description`, `docs_url`, and metadata keys under `tags`. (Field names match the underlying control-config schema exactly; the framework's TOML-First principle means override authors type the schema's real field names, not user-friendly aliases.) The pass logic (the sieve `passes` array) MAY be overridden in v1 only if the composite replaces the entire `passes` array — partial pass-block edits are out of scope.
+- **FR-007**: The framework MUST reject an override that references a control ID NOT present in the composite's resolved set (no orphan overrides). The error MUST name the orphan ID.
+- **FR-008**: The framework MUST reject an override that names a field NOT present on the underlying control's data model (no unknown-field overrides). The error MUST name the unknown field.
+
+#### Conflict resolution
+
+- **FR-009**: When two `[[compose]]` blocks contribute a control with the same ID, the framework MUST refuse registration by default. The error MUST name both contributing sources, the conflicting control ID, and the two ways the composite author can resolve the conflict explicitly (add `allow_conflicts = true` at the composition root, OR add an explicit `[overrides."CONTROL-ID"]` block).
+- **FR-010**: A composite MAY declare `allow_conflicts = true` at the composition root to opt out of strict-mode and fall back to last-wins behavior — the LATER `[[compose]]` block (by TOML file order) wins. When this opt-out is active, the framework MUST still emit an INFO-level log line at resolution time naming both contributing sources and the winning one.
+- **FR-011**: Explicit `[overrides."..."]` blocks have the highest precedence — they always win over any `[[compose]]`-block contribution, regardless of whether `allow_conflicts` is set. An explicit override is a per-control acknowledgement of the conflict, so even strict mode treats it as resolved. When an override targets a control ID that two or more `[[compose]]` blocks would contribute (in any mode — strict OR `allow_conflicts = true`), the override's fields layer onto the **earliest** compose block's contribution (by TOML file order); later compose blocks for that ID are skipped entirely. If the author needs a later compose block's contribution as the base, they MUST replicate the relevant fields inside the override block.
+
+#### Cycle detection
+
+- **FR-012**: The framework MUST detect composition cycles (composite A composes composite B which composes A, including self-cycles and longer chains) at registration time and refuse to register any implementation in the cycle. The error MUST name the full cycle chain.
+
+#### Version pinning
+
+- **FR-013**: A `[[compose]]` block MAY include `version_constraint = "<PEP 440 specifier>"` (e.g., `">=1.5,<2.0"`). If present, the framework MUST verify the installed source's `version` property satisfies the constraint at registration time. A mismatch MUST refuse registration with a clear error naming the constraint and the installed version.
+- **FR-014**: If `version_constraint` is absent, the composite MUST register against whatever version of the source is installed (default-floating).
+
+#### Provenance
+
+- **FR-015**: Each control in the resolved set MUST carry metadata identifying the composite's slug AND the original source (composite slug + source slug + original control ID). Audit results inherit this metadata so reviewers can trace any result back to its source implementation.
+
+#### Audit pipeline compatibility
+
+- **FR-016**: Composite implementations MUST work with the existing audit, remediate, and list-controls MCP tools without modification to those tools' interfaces. The resolved control set is the single contract; nothing downstream of resolution needs to know whether the controls came from composition.
+- **FR-017**: The framework's existing `--implementation <slug>` CLI flag MUST work against composite slugs the same way it works against non-composite slugs.
+
+#### Recursive composition
+
+- **FR-018**: A composite MAY source from another composite. When a `[[compose]]` block references a source that is itself a composite, the framework MUST fetch the source's FULLY RESOLVED control set (not its raw `[[compose]]` configuration) and apply the composite's inclusion/exclusion filters against that resolved set. Depth is bounded only by FR-012's cycle detection.
+
+### Key Entities
+
+- **Composite implementation**: A darnit implementation whose controls are at least partially assembled from other implementations. Identified by its own slug; registers via the standard `darnit.implementations` entry point.
+- **Compose block**: One `[[compose]]` entry in a composite's TOML config. Names a source implementation and the inclusion/exclusion filters that select controls from it.
+- **Override block**: One `[overrides."CONTROL-ID"]` entry. Replaces specific fields of an inherited control without forking it.
+- **Resolution**: The framework's process of walking a composite's TOML at registration time, fetching each source's controls, applying inclusion/exclusion filters and overrides, detecting conflicts and cycles, and producing a flat list of controls the rest of the framework consumes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An organization can express their compliance posture (parts of OpenSSF Baseline + parts of SLSA + their own controls) as a single composite implementation, in TOML alone, in under 30 minutes for someone familiar with darnit. (Today: impossible without forking.)
+- **SC-002**: A composite implementation that pulls 50 controls from upstream sources and adds 5 of its own resolves in under 200 ms at registration time on a developer laptop. (Performance: composition is upstream of every audit, must not be a noticeable cost.)
+- **SC-003**: Every audit result from a composite carries traceable provenance — a reviewer can identify the original source implementation and original control ID for any reported result in 100% of cases.
+- **SC-004**: A composite that references a non-installed source fails to register with a clear error in 100% of cases. No silent skip, no half-resolved composite.
+- **SC-005**: A composite with a cycle (any length, including self) fails to register with a clear error naming the cycle chain in 100% of cases. No infinite loop, no stack overflow.
+- **SC-006**: A composite with conflicting control IDs across sources fails registration in 100% of default-mode cases, and resolves predictably (by TOML file order) in 100% of `allow_conflicts = true` cases. Verified by a test fixture covering both modes plus the `[overrides."..."]` escape hatch.
+- **SC-007**: A composite override that names an orphan control ID OR an unknown field fails to register with a clear error in 100% of cases. No silent acceptance.
+- **SC-008**: All existing implementations (`darnit-baseline`, `darnit-gittuf`, `darnit-example`, `darnit-hello`) continue to work without modification. The composition feature is purely additive at the framework level; no existing TOML config is invalidated.
+
+## Assumptions
+
+- **Resolution happens at registration time, not at audit time.** The composite's `register()` does the full walk; downstream audit code sees only the resolved flat list. This matches today's pattern where `register()` is called once per process, not per audit.
+- **Source slugs are stable identifiers.** A composite that references `"openssf-baseline"` continues to work across versions of the source as long as the source keeps its slug. If a source ever renames itself, the framework reports the mismatch as "source not installed" per FR-004 — that's the desired failure mode (loud, explicit).
+- **Composition is intra-host.** A composite can only reference source implementations installed on the same host (via the same `darnit.implementations` entry-point group). Cross-host composition (fetching a source over the network, etc.) is out of scope.
+- **Composites are themselves discoverable.** A composite registers via the existing `darnit.implementations` entry point exactly like a non-composite. The framework decides whether to do composition resolution by inspecting the TOML at registration time, not by a separate entry-point group.
+- **TOML is the source of truth for composition.** All composition primitives are TOML-expressible. Python override hooks are NOT part of v1 — if a composite needs custom resolution logic, the composite author should subclass `ComplianceImplementation` directly and forget composition altogether, OR file a follow-up to extend the TOML primitives.
+- **Conflict-resolution defaults to strict (registration error), not last-wins.** Last-wins is the conventional TOML/dict-merge behavior, but compliance frameworks live or die by predictability — silent precedence is exactly what breaks under refactoring. The composite author opts out explicitly with `allow_conflicts = true` (fall back to last-wins) or with a per-control `[overrides."..."]` block (the override always wins). This aligns with the Constitution's "Conservative-by-Default" principle.
+- **Versioning of the composite itself is independent of source versioning.** `acme-baseline 1.0.0` may pin `openssf-baseline >=1.5,<2.0`. Bumping `acme-baseline` to 1.0.1 does not require any change to the upstream pin. This is the standard Python-packaging dependency model.
+- **The Constitution's TOML-First principle is not violated.** Composition is a new TOML schema feature; new control sources (composed-in controls) all originate from TOML (the source implementation's TOML). No Python-defined control becomes the source of truth via composition.
+
+## Out of Scope
+
+- **Composition through a non-darnit registry / remote URL / git ref.** Composites pull from locally-installed implementations only. Network composition (fetch from GitHub release, fetch from URL, fetch from a darnit registry) is a follow-up.
+- **Composition of pass logic.** The sieve `passes` array can be wholesale-replaced by an override, but partial edits ("override the third pass only", "add a new pass between existing passes") are out of scope for v1. Wholesale replacement is the only override mode supported.
+- **Composition of remediation handlers in Python.** Inline remediation steps in TOML can be overridden per FR-006; Python-registered remediation handlers cannot be inherited or overridden through composition in v1. (They are referenced by name in TOML, so as long as the named handler is registered, it works — but composing a handler from one source into another is out of scope.)
+- **Cross-implementation tag namespace coordination.** If `darnit-baseline` uses `severity` ranged 1–10 and another source uses `severity` ranged A–E, composition won't reconcile them. Authors of composite implementations must ensure their sources use compatible conventions. The framework reports the values it finds; it doesn't normalize across sources.
+- **Hot-reload of composites without restart.** Composition resolution happens once at process registration. Editing a composite's TOML at runtime requires restarting the host process. Live-reload is a separate feature with its own design questions.
+- **Composition-aware UI.** Today's MCP tools and CLI list controls by ID. There's no special "composed from <source>" UI affordance in v1. The provenance metadata is exposed in audit-result objects (FR-015), but rendering it in user-facing output is a separate UX task.
+- **GUI / wizard for authoring composites.** Composites are authored in TOML files by hand or via simple templates. A guided composition wizard or web UI is not part of this feature.
+- **Override of a control's identity (renaming an ID, splitting one control into two).** Overrides modify fields of an existing control identified by its source ID. Renaming, splitting, or merging are out of scope.
+- **Cross-composite composition (composite A composes parts of composite B's compose blocks).** A composite imports a source's *effective* controls, not its TOML configuration. If composite B includes some controls and composite A wants the same subset, A composes from B directly (which works per the recursive case in edge cases) — not from B's source list.

--- a/specs/013-plugin-composition/tasks.md
+++ b/specs/013-plugin-composition/tasks.md
@@ -1,0 +1,267 @@
+---
+description: "Task list for feature 013-plugin-composition"
+---
+
+# Tasks: Composition of compliance implementations
+
+**Input**: Design documents under `/specs/013-plugin-composition/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+
+**Tests**: Included. Composition is a compliance-critical primitive; the spec defines 26 explicit acceptance scenarios (5 user stories × multiple scenarios each). Test-fixture-driven validation through the production loader is the spec's stated approach (R-010, contracts/resolver-api.md §Test contract).
+
+**Organization**: Tasks are grouped by user story so each story can be implemented, tested, and delivered as an independent MVP increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story (US1..US5) — Setup/Foundational/Polish have no story label
+- Every task names exact file paths
+
+## Path Conventions
+
+Single Python workspace. All new code lands inside `packages/darnit/src/darnit/`; all tests under `tests/darnit/`. No new top-level package.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Test infrastructure — fixture directory, mock source TOMLs, conftest helper providing an injectable `source_loader` so tests don't have to register real entry points.
+
+- [X] T001 Create `tests/darnit/fixtures/composite/` directory (with a placeholder `__init__.py` and a short `README.md` explaining the fixture-driven testing approach from R-010).
+- [X] T002 [P] Author `tests/darnit/fixtures/composite/_sources/mock-source-a.toml` — a minimal non-composite framework with 5 controls spanning levels 1/2/3 and domains AC/VM/QA. Set `[metadata].name = "mock-source-a"`, `version = "1.5.0"`. Controls: `MOCK-AC-01.01` (L1), `MOCK-AC-02.01` (L1), `MOCK-VM-01.01` (L2), `MOCK-VM-02.01` (L3), `MOCK-QA-01.01` (L2). Each control has one trivial `file_must_exist` pass with `path = "DOES_NOT_EXIST.fixture"` (intentionally unsatisfiable — tests are SHAPE-only per F-3, so a FAIL result is the expected outcome whenever the audit pipeline actually runs).
+- [X] T003 [P] Author `tests/darnit/fixtures/composite/_sources/mock-source-b.toml` — a minimal non-composite framework with 3 level-1 controls and `[metadata].version = "0.9.0"`. Controls: `MOCK-B-01.01`, `MOCK-B-02.01`, `MOCK-B-03.01`. Use the same `file_must_exist` with `path = "DOES_NOT_EXIST.fixture"` pattern as T002.
+- [X] T004 [P] Author `tests/darnit/fixtures/composite/_sources/mock-source-c-leaf.toml` — a non-composite source with 2 controls (`LEAF-01.01`, `LEAF-02.01`) used as the ultimate origin in the three-level recursive scenario. Use the same unsatisfiable `file_must_exist` path as T002.
+- [X] T005 [P] Author `tests/darnit/fixtures/composite/_sources/mock-source-mid-composite.toml` — a composite that pulls `include_all` from `mock-source-c-leaf`. Used as the middle layer of the three-level chain in US4's positive scenario.
+- [X] T006 Add `tests/darnit/conftest.py` fixtures `composite_fixtures_dir` (returns the absolute path to `_sources/`) and `fixture_source_loader` (returns a `Callable[[str], FrameworkConfig | None]` that loads any of the `_sources/*.toml` files by slug **via `darnit.config.merger._parse_framework_only(path)` — NOT `load_framework_config`**). The fixture loader MUST be parse-only so tests exercise the same F-1 path as production: composition recursion is owned by the resolver under one shared `_resolution_stack`. Document this constraint in a docstring on the fixture so future contributors don't switch it back to a resolving loader.
+
+**Checkpoint**: fixtures + loader helper available; foundational schema work can begin.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: New pydantic schema entities, error class hierarchy, resolver skeleton, and the loader integration shim. Every user story depends on this phase.
+
+**⚠️ CRITICAL**: No user story work begins until this phase is complete.
+
+- [X] T007 Create `packages/darnit/src/darnit/core/composition.py` with the public `__all__` from contracts/resolver-api.md and module-level docstring referencing the spec. Define base class `CompositionError(Exception)` plus the six concrete subclasses (`CompositionMissingSourceError`, `CompositionConflictError`, `CompositionOrphanOverrideError`, `CompositionUnknownFieldError`, `CompositionCycleError`, `CompositionVersionMismatchError`) with the attribute signatures specified in contracts/resolver-api.md §Exceptions. Each subclass overrides `__str__` to render every named attribute.
+- [X] T008 [P] Add `ComposeBlock(BaseModel)` to `packages/darnit/src/darnit/config/framework_schema.py` with the fields and validators from data-model.md §Entity 1 (`source`, `include_all`, `include_levels`, `include_controls`, `include_tags`, `exclude_controls`, `version_constraint`). Implement validators V1.1–V1.4 (at-least-one-inclusion, mutual exclusion of `include_all`, PEP 440 specifier parsing via `packaging.specifiers.SpecifierSet`, error message naming malformed specifier).
+- [X] T009 [P] Add `OverrideBlock(BaseModel)` to `packages/darnit/src/darnit/config/framework_schema.py` with the fields from data-model.md §Entity 2 (`passes`, `remediation`, `security_severity`, `description`, `docs_url`, `tags`) and validator V2.3 (at-least-one-field-set). **Field names match the real `ControlConfig` schema exactly** — do NOT add aliases for `severity` / `help_url`.
+- [X] T010 Extend the existing `FrameworkConfig` class in `packages/darnit/src/darnit/config/framework_schema.py` with `compose: list[ComposeBlock] = Field(default_factory=list)`, `overrides: dict[str, OverrideBlock] = Field(default_factory=dict)`, and `allow_conflicts: bool = False`. Keep `model_config = ConfigDict(extra="allow")` intact; do NOT remove or rename any existing field.
+- [X] T011 Implement the `resolve_composition` function skeleton in `packages/darnit/src/darnit/core/composition.py` per data-model.md §Resolution algorithm pseudocode. Cover idempotence (invariant I3.3 — return input unchanged if `compose == []` and `overrides == {}`), the `_resolution_stack` threading (a single stack threaded through every recursive call — this is the ONLY stack; cycle detection's correctness depends on it), basic self-cycle detection (raise `CompositionCycleError` before recursing if `composite_slug in _resolution_stack`), and returning a new `FrameworkConfig` via `model_copy(update={"controls": ..., "compose": [], "overrides": {}})` (invariant I3.2). Leave compose-block iteration and override application as `pass`/`raise NotImplementedError` markers — US1 fills the compose half, US2 fills the override half.
+- [X] T012 Refactor `darnit.config.merger.load_framework_config` per contracts/resolver-api.md §Integration contract. Extract a new private helper `_parse_framework_only(path: Path) -> FrameworkConfig` that does the existing pydantic parse + template-path validation but does NOT touch composition. Then make `load_framework_config(path)` a thin wrapper: call `_parse_framework_only(path)`, and IF `config.compose or config.overrides` is non-empty, call `resolve_composition(config)` exactly once before returning. This split is load-bearing for F-1 / FR-012 — the resolver's `source_loader` routes through `_parse_framework_only` so recursive source loads don't re-enter composition with a fresh `_resolution_stack`. Preserve all existing behavior for non-composite frameworks.
+- [X] T013 Add a module-level logger `log = logging.getLogger("darnit.core.composition")` in `composition.py` and import it. All log emissions in later tasks route through this logger.
+
+**Checkpoint**: schema accepts composite TOML, loader invokes resolver, resolver short-circuits idempotently. Existing tests still pass; no behavioral change for non-composite frameworks.
+
+---
+
+## Phase 3: User Story 1 — Organization assembles its own compliance baseline (Priority: P1) 🎯 MVP
+
+**Goal**: A composite implementation can declare `[[compose]]` blocks plus inline controls and produce a flat resolved control set through the existing audit pipeline.
+
+**Independent Test**: A minimal `acme-baseline` composite that pulls 3 controls from `mock-source-a` and adds 1 inline control resolves to exactly 4 controls; `darnit list-controls --implementation acme-baseline` lists them; `darnit audit ...` produces a single non-composite-shaped result set. No Python composition code in the implementation class.
+
+### Compose-block resolution
+
+- [ ] T014 [P] [US1] Implement `_select_controls(block: ComposeBlock, source_controls: dict) -> set[str]` in `packages/darnit/src/darnit/core/composition.py` per R-009 (intersection semantics). Order: start with full set if `include_all`, else apply `include_levels` ∩ `include_controls` ∩ `include_tags`; finally subtract `exclude_controls`. DEBUG-log empty results.
+- [ ] T015 [P] [US1] Implement `_load_source_with_cache(slug: str, cache: dict, loader: Callable) -> FrameworkConfig | None` in `composition.py`. Returns `None` if loader returns `None` (caller raises `CompositionMissingSourceError`). Memoizes per slug for the lifetime of one top-level resolution (R-003). The `loader` argument MUST be a parse-only function (the resolver's default routes through `darnit.config.merger._parse_framework_only`, not `load_framework_by_name`) — this is the F-1 fix and is non-negotiable for cycle detection.
+- [ ] T016 [P] [US1] Implement `_clone_with_provenance(ctrl: ControlConfig, composed_from: str, original_id: str) -> ControlConfig` in `composition.py`. Uses `ctrl.model_copy(update={"tags": {**ctrl.tags, "_composed_from": composed_from, "_original_control_id": original_id}})`. Reads existing `_composed_from` / `_original_control_id` from the source's tags first so recursive provenance preserves the ultimate non-composite origin (R-006 / FR-018).
+- [ ] T017 [US1] Fill the compose-block iteration loop in `resolve_composition` per data-model.md §Resolution algorithm: for each block, load source via `_load_source_with_cache` (raise `CompositionMissingSourceError` on `None`) — the loader returns a parsed-but-NOT-resolved `FrameworkConfig` per T015 — then **recurse via `resolve_composition(source, _source_cache=..., _resolution_stack=...)`** to drive composition resolution under the SHARED cycle-detection stack (this is how FR-018's recursive composition works AND how F-1's cycle detection holds). Call `_select_controls`, clone each selected control with provenance, and insert into `resolved` dict. Track `contributor: dict[str, str]` per-ID for later conflict messages. Stash inline controls into `resolved` and `contributor` first so they look like a "compose source = self" for conflict-detection purposes.
+- [ ] T018 [US1] Inject the `source_loader` parameter into `resolve_composition` per contracts/resolver-api.md §Function signature. **Default to a private wrapper that does slug → path via `PluginRegistry` and then loads via `darnit.config.merger._parse_framework_only(path)` — NOT `load_framework_by_name`** (that would re-enter `resolve_composition` with a fresh stack and break F-1's cycle detection). Tests inject the `fixture_source_loader` from T006, which is also parse-only.
+- [ ] T019 [US1] Stamp inline controls with `_composed_from = "<composite-slug>"` and `_original_control_id = "<own ID>"` so SC-003 holds uniformly across composed and inline controls.
+
+### US1 fixtures and tests
+
+- [ ] T020 [P] [US1] Author `tests/darnit/fixtures/composite/basic-include-all.toml` — composes `include_all = true` from `mock-source-a`. Add `test_basic_include_all` in `tests/darnit/test_composition.py` asserting the resolved set equals all 5 mock-source-a controls.
+- [ ] T021 [P] [US1] Author `tests/darnit/fixtures/composite/include-levels.toml` — `include_levels = [1, 2]` from `mock-source-a`. Add `test_include_levels_filter` asserting the level-3 control (`MOCK-VM-02.01`) is absent.
+- [ ] T022 [P] [US1] Author `tests/darnit/fixtures/composite/include-controls.toml` — `include_controls = ["MOCK-AC-01.01", "MOCK-QA-01.01"]`. Add `test_include_controls_filter` asserting only those two appear.
+- [ ] T023 [P] [US1] Author `tests/darnit/fixtures/composite/exclude-after-include.toml` — `include_all = true` + `exclude_controls = ["MOCK-AC-02.01"]`. Add `test_exclude_controls_after_include` asserting AC-02.01 absent and the other four present.
+- [ ] T024 [P] [US1] Author `tests/darnit/fixtures/composite/intersection-of-includes.toml` — `include_levels = [1]` + `include_controls = ["MOCK-AC-01.01", "MOCK-VM-02.01"]`. Add `test_intersection_of_includes` asserting only `MOCK-AC-01.01` appears (the level filter intersects with the ID filter, so the L3 ID drops out).
+- [ ] T025 [P] [US1] Author `tests/darnit/fixtures/composite/inline-with-compose.toml` — one `[[compose]]` block + one `[controls."ACME-LOCAL-01.01"]` block. Add `test_provenance_for_inline_controls` asserting the inline control's tags carry `_composed_from = "<composite-slug>"` and `_original_control_id = "ACME-LOCAL-01.01"`, and that composed controls carry the source's slug.
+- [ ] T026 [P] [US1] Author `tests/darnit/fixtures/composite/missing-source.toml` — `[[compose]]` block names a slug like `"does-not-exist-impl"`. Add `test_missing_source_raises` asserting `CompositionMissingSourceError` raised with `.source == "does-not-exist-impl"`.
+- [ ] T027 [P] [US1] Author `tests/darnit/fixtures/composite/empty-compose-block.toml` — `[[compose]]` block with only `source = "mock-source-a"` and no inclusion expressions. Add `test_empty_compose_block_rejected` asserting registration error from validator V1.1 names the source slug.
+- [ ] T028 [P] [US1] Author `tests/darnit/fixtures/composite/diamond.toml` — composes from `mock-source-mid-composite` AND directly from `mock-source-c-leaf`. Add `test_diamond_resolves_once` asserting `LEAF-01.01` and `LEAF-02.01` appear exactly once and that the wrapped `source_loader` was called once per unique slug (use a counting wrapper around `fixture_source_loader`).
+- [ ] T029 [P] [US1] Author `tests/darnit/fixtures/composite/audit-pipeline.toml` — small composite (3 composed + 1 inline). Add `test_audit_pipeline_unchanged` that uses the standard `tools.audit` entry point through `load_framework_config` and asserts the result list is **shape-identical** to a non-composite audit result: no new keys, no missing keys, control IDs match the resolved set. The test is SHAPE-only — individual control status (PASS/FAIL/WARN/INCONCLUSIVE) is irrelevant; the fixtures use unsatisfiable `file_must_exist` paths (T002–T005) so every audit returns FAIL, which is sufficient because what's being verified is that composition leaves the result-object schema unchanged, not that any particular control passes.
+
+**Checkpoint**: US1 is independently shippable. Resolver handles inclusion/exclusion, source loading, provenance, missing sources, diamonds, and end-to-end audit shape. Conflicts produce a still-incomplete error path until US2 + US3 land — composites that produce conflicts in US1 trigger a `NotImplementedError` from T011's marker. Tests in T020–T029 are constructed to avoid conflicts.
+
+---
+
+## Phase 4: User Story 2 — Override a single inherited control (Priority: P2)
+
+**Goal**: A composite can override specific fields of an inherited control without forking the source.
+
+**Independent Test**: A composite that pulls `MOCK-AC-01.01` from `mock-source-a` and adds `[overrides."MOCK-AC-01.01"]` with a custom `remediation`. The resolved control retains the upstream pass logic; the remediation matches the override.
+
+- [ ] T030 [US2] Implement `_validate_override_fields(override: OverrideBlock) -> None` in `packages/darnit/src/darnit/core/composition.py`. Iterate `override.model_fields_set` (Pydantic v2); for each set field, confirm it appears in `ControlConfig.model_fields.keys()`. Raise `CompositionUnknownFieldError(field=..., control_id=...)` on miss.
+- [ ] T031 [US2] Implement `_apply_override(ctrl: ControlConfig, override: OverrideBlock) -> ControlConfig` in `composition.py`. Build an `update` dict containing only the override's set fields. Handle `passes` (wholesale replacement, FR-006), scalars (`remediation`, `security_severity`, `description`, `docs_url` — direct replacement; these names match the real `ControlConfig` schema), and `tags` (shallow merge with reserved-key guard — silently drop `_composed_from` / `_original_control_id` if present in override.tags, emit WARNING log).
+- [ ] T032 [US2] Fill the override-application loop at the tail end of `resolve_composition` per data-model.md §Resolution algorithm. For each `override_id` in `composite.overrides`: if not in `resolved` → `CompositionOrphanOverrideError(orphan_id=override_id)`; else call `_validate_override_fields` then `_apply_override`. Replace `resolved[override_id]` with the result. Remove the `NotImplementedError` marker from T011's skeleton.
+
+### US2 fixtures and tests
+
+- [ ] T033 [P] [US2] Author `tests/darnit/fixtures/composite/override-remediation.toml` — composes `MOCK-AC-01.01` from `mock-source-a`, overrides only `remediation`. Add `test_overrides_replace_fields` asserting passes match the source verbatim and remediation matches the override string.
+- [ ] T034 [P] [US2] Author `tests/darnit/fixtures/composite/override-preserves-provenance.toml` — same shape as T033 but assert in `test_overrides_preserve_provenance` that `tags["_composed_from"] == "mock-source-a"` and `tags["_original_control_id"] == "MOCK-AC-01.01"` AFTER the override applies.
+- [ ] T035 [P] [US2] Author `tests/darnit/fixtures/composite/orphan-override.toml` — `[overrides."DOES-NOT-EXIST"]` with no compose block contributing that ID. Add `test_orphan_override_raises` asserting `CompositionOrphanOverrideError.orphan_id == "DOES-NOT-EXIST"`.
+- [ ] T036 [P] [US2] Author `tests/darnit/fixtures/composite/unknown-field-override.toml` — `[overrides."MOCK-AC-01.01"]` with a `bogus_field = "x"` entry plus a valid `description` field. Add `test_unknown_field_override_raises` asserting `CompositionUnknownFieldError.field == "bogus_field"`. Also add a sub-test `test_alias_field_names_rejected` using `severity = 8.5` (no underscore prefix) in another override fixture and asserting the same error class with `.field == "severity"` — this pins down the "no friendly aliases" guarantee from F-2.
+- [ ] T037 [P] [US2] Author `tests/darnit/fixtures/composite/empty-override.toml` — `[overrides."MOCK-AC-01.01"]` with NO fields under it. Add `test_empty_override_block_rejected` asserting V2.3 validator error names the offending control ID.
+
+**Checkpoint**: US2 is independently shippable. Override-only composites work; override-resolves-conflict cases still raise `NotImplementedError` from T011 because the conflict-detection branch is not yet wired — left for US3.
+
+---
+
+## Phase 5: User Story 3 — Conflicting controls resolve predictably (Priority: P2)
+
+**Goal**: Strict-by-default conflict resolution with two named escape hatches (`allow_conflicts` and `[overrides."..."]`).
+
+**Independent Test**: A composite that pulls `MOCK-AC-01.01` from two compose blocks with different selectors fails registration; adding `allow_conflicts = true` makes it succeed last-wins with an INFO log; replacing `allow_conflicts` with an explicit `[overrides."MOCK-AC-01.01"]` block makes it succeed in strict mode.
+
+- [ ] T038 [US3] In `resolve_composition`'s compose-block loop, replace the T011 conflict-marker with the conflict-detection logic from data-model.md pseudocode: when `ctrl_id in resolved` AND `ctrl_id in composite.overrides` → `continue` (override-resolves-conflict, FR-011); else when `composite.allow_conflicts` → INFO log + overwrite (FR-010); else → `raise CompositionConflictError(control_id, sources=(contributor[ctrl_id], block.source))` (FR-009).
+- [ ] T039 [US3] Add the INFO log emission: `log.info("Composition conflict on %s: %s overrides %s (allow_conflicts=true)", ctrl_id, block.source, contributor[ctrl_id])` exactly per contracts/resolver-api.md §Side effects.
+
+### US3 fixtures and tests
+
+- [ ] T040 [P] [US3] Author `tests/darnit/fixtures/composite/strict-conflict.toml` — two `[[compose]]` blocks, both `mock-source-a`, both `include_controls = ["MOCK-AC-01.01"]`. Add `test_strict_conflict_raises` asserting `CompositionConflictError.control_id == "MOCK-AC-01.01"` AND `.sources` contains `"mock-source-a"` twice (or whatever the contributor tracking surfaces — verify the error message mentions both opt-outs `allow_conflicts = true` and `[overrides."..."]`).
+- [ ] T041 [P] [US3] Author `tests/darnit/fixtures/composite/allow-conflicts-last-wins.toml` — same shape as T040 but two distinct sources (`mock-source-a` and a NEW `_sources/mock-source-a-variant.toml` you create with one differing-field `MOCK-AC-01.01`) and `allow_conflicts = true` at the top level. Add `test_allow_conflicts_last_wins` asserting registration succeeds, the resolved `MOCK-AC-01.01` matches the LATER compose block's source, and `caplog.records` contains an INFO line naming both sources.
+- [ ] T042 [P] [US3] Author `tests/darnit/fixtures/composite/override-resolves-conflict.toml` — same dual-source conflict shape as T041 but with `[overrides."MOCK-AC-01.01"]` and `allow_conflicts` UNSET. Add `test_override_resolves_conflict_in_strict_mode` asserting registration succeeds, the override's fields are applied, no `CompositionConflictError` is raised, and **the resolved control's non-overridden fields come from the EARLIER compose block** (not the later one — verifies the earliest-base rule from F-11/FR-011). Also assert no INFO log line is emitted (overrides resolve conflicts silently because the per-control acknowledgement is explicit). Add a companion test `test_override_with_allow_conflicts_still_uses_earliest_base` using the same fixture pattern but with `allow_conflicts = true` added — assert the same earliest-base outcome to lock down the mode-independence of FR-011.
+
+**Checkpoint**: US3 is independently shippable. All three conflict-resolution pathways are tested. The override-resolves-conflict case (T042) is the integration point that proves US2 + US3 cooperate correctly.
+
+---
+
+## Phase 6: User Story 4 — Composition cycles detected and rejected (Priority: P3)
+
+**Goal**: Self-cycles, two-cycles, and arbitrary-length cycles all fail registration with a clear chain-naming error message. Non-cyclic recursive composition succeeds with provenance traced to the ultimate source.
+
+**Independent Test**: Two composites referencing each other fail to register; a non-cyclic three-level chain (A→B→C, C non-composite) resolves with every control's `_composed_from` pointing at C, not B.
+
+- [ ] T043 [US4] Enrich the `CompositionCycleError` raised from `resolve_composition` (existing T011 skeleton) to render `__str__` as the chain joined by ` → ` (e.g., `"Composition cycle detected: acme-baseline → middle-comp → acme-baseline"`). Store `chain: list[str]` as the attribute.
+
+### US4 fixtures and tests
+
+- [ ] T044 [P] [US4] Author `tests/darnit/fixtures/composite/_sources/cycle-a.toml` — composes `include_all` from `cycle-a` (itself). Add `test_self_cycle_raises` asserting `CompositionCycleError.chain == ["cycle-a", "cycle-a"]` and the error message contains `"cycle-a → cycle-a"`.
+- [ ] T045 [P] [US4] Author `tests/darnit/fixtures/composite/_sources/cycle-x.toml` + `tests/darnit/fixtures/composite/_sources/cycle-y.toml` — X composes Y, Y composes X. Add `test_two_cycle_raises` asserting `CompositionCycleError` raised on first load with chain `["cycle-x", "cycle-y", "cycle-x"]` (or whichever order matches load order — assert the chain length is 3 and starts+ends with the same slug).
+- [ ] T046 [P] [US4] Author `tests/darnit/fixtures/composite/three-level-chain.toml` — composes from `mock-source-mid-composite` (which itself composes from `mock-source-c-leaf`, both created in T004–T005). Add `test_three_level_chain_resolves` asserting registration succeeds, every resolved control's `tags["_composed_from"] == "mock-source-c-leaf"` (the ULTIMATE non-composite source per FR-018), NOT `"mock-source-mid-composite"`.
+- [ ] T046b [P] [US4] Regression test for F-1: author `tests/darnit/fixtures/composite/_sources/loader-cycle-x.toml` and `_sources/loader-cycle-y.toml` where X composes Y and Y composes X. Add `test_loader_path_cycle_through_public_loader` that loads X via the production `darnit.config.merger.load_framework_config(...)` (NOT through the injected fixture loader) and asserts `CompositionCycleError` is raised within a short bounded time. **Preferred approach** — wrap the call with `t0 = time.perf_counter(); pytest.raises(CompositionCycleError): load_framework_config(...); assert time.perf_counter() - t0 < 1.0` (no new dependency). Avoid `pytest.timeout` unless `pytest-timeout` is already in the project's dev deps. This test would have hung indefinitely under the pre-F-1 design and is the canonical regression guarantee that the resolver / loader split is correct.
+
+**Checkpoint**: US4 is independently shippable. Cycle protection is in place from foundational (T011) — this story adds the chain-rich error message and exercises the recursive-composition positive path that proves FR-018.
+
+---
+
+## Phase 7: User Story 5 — Version pinning (Priority: P3)
+
+**Goal**: A `[[compose]]` block can pin to a PEP 440 specifier; mismatches fail with a clear error.
+
+**Independent Test**: A composite that pins `mock-source-a >=1.0,<2.0` resolves (installed version is `1.5.0`); changing the pin to `>=2.0` fails registration.
+
+- [ ] T047 [US5] In `_load_source_with_cache` or the compose-block iteration in T017, after loading the source `FrameworkConfig`, evaluate `block.version_constraint` if set: parse with `packaging.specifiers.SpecifierSet(block.version_constraint)`, compare against `source_config.metadata.version` via `Version(...) in specifier_set`. On mismatch, raise `CompositionVersionMismatchError(source=block.source, constraint=block.version_constraint, installed=source_config.metadata.version)`. (The specifier-parse step itself is validated at TOML load time by T008's V1.3 validator; this is the runtime version check.)
+
+### US5 fixtures and tests
+
+- [ ] T048 [P] [US5] Author `tests/darnit/fixtures/composite/version-pin-satisfied.toml` — composes `mock-source-a` with `version_constraint = ">=1.0,<2.0"`. Add `test_version_pin_satisfied` asserting registration succeeds.
+- [ ] T049 [P] [US5] Author `tests/darnit/fixtures/composite/version-pin-violated.toml` — composes `mock-source-a` with `version_constraint = ">=2.0"`. Add `test_version_pin_violated` asserting `CompositionVersionMismatchError` raised with `.source`, `.constraint`, and `.installed = "1.5.0"`.
+- [ ] T050 [P] [US5] Add `test_version_pin_missing_uses_floating` reusing `basic-include-all.toml` (T020) — no `version_constraint`. Assert registration succeeds against the installed source version with no version-check error path entered.
+
+**Checkpoint**: US5 is independently shippable. Composites can pin or float per the spec's FR-013/FR-014 split.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Performance verification, idempotence smoke, doc sync, and the quickstart-walkthrough end-to-end check.
+
+- [ ] T051 [P] Add `test_idempotent_resolution` in `tests/darnit/test_composition.py`: load `basic-include-all.toml` via `load_framework_config` once, call `resolve_composition` on the result a second time, assert the second call returns a structurally equal `FrameworkConfig` (same `controls` dict, still empty `compose` and `overrides`) — invariant I3.3.
+- [ ] T052 [P] Add `test_resolution_performance` in `tests/darnit/test_composition.py`: build a synthetic source with 50 controls, a composite with 5 inline controls plus an `include_all` block, time the `resolve_composition` call, assert `elapsed < 0.2` seconds. Use `pytest.mark.benchmark` or simple `time.perf_counter`.
+- [ ] T053 [P] Update `packages/darnit/src/darnit/core/composition.py` module docstring to reference contracts/resolver-api.md and contracts/toml-schema.md as canonical references for the surface.
+- [ ] T054 Run `uv run python scripts/validate_sync.py --verbose` and address any framework-design spec drift surfaced by the new composition primitives.
+- [ ] T055 Run `uv run python scripts/generate_docs.py` and commit any resulting `docs/generated/` changes.
+- [ ] T056 Lint and type-check: `uv run ruff check . && uv run ruff format --check .`
+- [ ] T057 Full test run: `uv run pytest tests/ --ignore=tests/integration/ -q`. All previously-passing tests must remain green; the new composition tests added in T020–T050 / T051–T052 must pass.
+- [ ] T058 End-to-end quickstart walkthrough: follow [quickstart.md](./quickstart.md) Steps 1–4 verbatim against a locally-installed `acme-baseline` package backed by the real `darnit-baseline` + `darnit-gittuf`. Verify `list-controls`, `audit`, and provenance-tag inspection all behave as documented.
+- [ ] T059 Add a Composition section to `docs/IMPLEMENTATION_GUIDE.md` (or create one if absent) summarizing: when to compose vs. fork, the three conflict-resolution paths, and how provenance flows through audit results. Link to the spec, plan, and quickstart.
+- [ ] T060 Rebase from upstream (`git fetch upstream && git rebase upstream/main`) and verify the workspace still passes T056 + T057 before opening the PR.
+- [ ] T061 [P] Add `test_existing_implementations_unaffected` in `tests/darnit/test_composition.py` covering SC-008 (F-5). Parametrize over the four installed implementations (`darnit-baseline`, `darnit-gittuf`, `darnit-hello`, `darnit-testchecks`); for each, call `darnit.config.merger.load_framework_config(impl.get_framework_config_path())`. Assert `cfg.compose == []`, `cfg.overrides == {}`, `cfg.allow_conflicts is False`, and `len(cfg.controls) > 0`. Snapshot the resolved `controls.keys()` for each implementation against a baseline fixture stored at `tests/darnit/snapshots/<impl>-control-ids.json` (auto-generate the snapshots on first run if missing, with a TODO comment to manually commit them).
+- [ ] T062 [P] Add `test_cli_implementation_flag_with_composite` in `tests/darnit/test_cli.py` covering FR-017 (F-6). Use a temporary composite installed via an entry point (or directly via a TOML file path), invoke `darnit audit --implementation <composite-slug> <tmp_path>` and `darnit list-controls --implementation <composite-slug>` through the CLI's `main([...])` entry point (no subprocess needed), and assert both return exit code 0 and produce output containing the expected control IDs.
+- [ ] T063 [P] Add `test_dual_audit_tool_exposure` in `tests/darnit/test_composition.py` covering the spec's MCP-tool-ownership edge case (F-7). Register a composite alongside its source (both must be discoverable). Inspect the MCP server's tool registry and assert both `audit_<source-slug>` and `audit_<composite-slug>` are present and non-colliding. Invoke each through its handler entry point against a `tmp_path`; assert both return shape-valid result objects without raising.
+
+---
+
+## Dependencies
+
+```text
+Setup (T001–T006)
+        │
+        ▼
+Foundational (T007–T013) ──────── BLOCKS ALL USER STORIES
+        │
+        ├──────────────────────┬──────────────────────┬──────────────────┬──────────────────┐
+        ▼                      ▼                      ▼                  ▼                  ▼
+   US1 (T014–T029)        US4 (T043–T046)        US5 (T047–T050)
+        │                      │                      │
+        ▼                      │                      │
+   US2 (T030–T037)             │                      │
+        │                      │                      │
+        ▼                      │                      │
+   US3 (T038–T042)             │                      │
+        │                      │                      │
+        └──────────────────────┴──────────────────────┴────────────────► Polish (T051–T060)
+```
+
+**Story-level dependencies**:
+
+- **US1** depends only on Foundational. It is the MVP increment.
+- **US2** depends on US1 because the override pass operates on an already-resolved control set.
+- **US3** depends on US2 because the override-resolves-conflict pathway (T038, T042) requires the override application loop from US2.
+- **US4** depends only on Foundational. Cycle protection lives in T011's skeleton; this phase enriches the error and adds the recursive-positive scenario. Can run in parallel with US2/US3.
+- **US5** depends only on Foundational. The version check is independent of conflicts and overrides. Can run in parallel with US2/US3/US4.
+
+**Within-story parallelism**: fixtures and tests marked `[P]` are independent — different fixture files, different test functions. Implementation tasks marked `[P]` operate on distinct helper functions or distinct schema entities and don't share lines. Sequential tasks within a story (no `[P]`) modify the same function body (e.g., the `resolve_composition` body) and must run in listed order.
+
+---
+
+## Implementation Strategy
+
+### MVP (Story 1 only)
+
+Ship T001–T029. Composites can pull slices from non-composite sources, add inline controls, and produce audit results. No overrides, no conflict resolution, no cycle detection beyond the foundational guardrail, no version pinning. This is sufficient for the Story 1 acceptance scenarios (1–4) and unblocks early dogfooding by security architects with simple postures.
+
+### Incremental delivery order
+
+1. **MVP**: Foundational + US1 (29 tasks; the smallest shippable increment).
+2. **Override safety net**: + US2 (5 tasks; adds the "without forking" promise).
+3. **Predictable multi-source composites**: + US3 (5 tasks; unblocks composites that pull from two sources with overlapping IDs, which is realistic the moment composites cross framework families).
+4. **Recursive composition + cycle clarity**: + US4 (4 tasks; necessary the moment one composite becomes another's source).
+5. **Reproducibility for compliance users**: + US5 (4 tasks; needed by regulator-driven users but not by most teams).
+6. **Polish & docs**: + Phase 8 (10 tasks; verify performance, sync docs, walk the quickstart end-to-end).
+
+### Parallel-team strategy
+
+After Foundational (T013) is merged, four developer-pairs can work in parallel:
+
+- Pair A: US1 (T014–T029) — owns the resolver core.
+- Pair B: US4 (T043–T046) — owns cycle messages + recursive positive scenario.
+- Pair C: US5 (T047–T050) — owns version-pin enforcement.
+- Pair D: starts on Phase 8 doc tasks (T053, T059) that don't depend on resolver internals.
+
+US2 and US3 must wait for US1 to land (they extend `resolve_composition`'s body in-place); they can run sequentially by a single pair after US1 merges.
+
+### Suggested PR boundaries
+
+- **PR 1**: Setup + Foundational (T001–T013). All-green tests, no behavior change for non-composite frameworks.
+- **PR 2**: US1 (T014–T029). MVP increment.
+- **PR 3**: US2 (T030–T037).
+- **PR 4**: US3 (T038–T042). This PR closes the spec's two main composition footguns (silent conflicts and orphan overrides).
+- **PR 5**: US4 + US5 (T043–T050). Can be bundled because both are P3 guardrails with small surface area.
+- **PR 6**: Polish (T051–T060).
+
+---
+
+## Format validation summary
+
+- ✅ Every task starts with `- [ ]`.
+- ✅ Every task has a sequential `T###` ID.
+- ✅ Every task names an exact file path or directory (in tasks that don't, like T054/T055/T056/T057/T060, the description is a single command — no path applies).
+- ✅ Setup, Foundational, and Polish tasks carry NO `[Story]` label.
+- ✅ Every US1–US5 phase task carries the correct `[US#]` label.
+- ✅ `[P]` markers gate strictly on file-disjointness AND no incomplete dependencies.
+- ✅ Total task count: 64. Setup: 6. Foundational: 7. US1: 16. US2: 8. US3: 5. US4: 5 (T043, T044, T045, T046, T046b — the last is the F-1 loader-path cycle regression). US5: 4. Polish: 13 (T051–T060 plus T061/T062/T063 for F-5/F-6/F-7).

--- a/tests/darnit/conftest.py
+++ b/tests/darnit/conftest.py
@@ -1,0 +1,57 @@
+"""Pytest fixtures shared across tests in ``tests/darnit/``.
+
+Currently scoped to the composition feature (013-plugin-composition).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from darnit.config.framework_schema import FrameworkConfig
+
+
+@pytest.fixture
+def composite_fixtures_dir() -> Path:
+    """Absolute path to the per-test composite-fixture sources directory.
+
+    Tests load source TOMLs from ``tests/darnit/fixtures/composite/_sources/``
+    and composite TOMLs from ``tests/darnit/fixtures/composite/``.
+    """
+    return Path(__file__).parent / "fixtures" / "composite"
+
+
+@pytest.fixture
+def fixture_source_loader(
+    composite_fixtures_dir: Path,
+) -> Callable[[str], FrameworkConfig | None]:
+    """Return a parse-only ``source_loader`` for composition tests.
+
+    The loader maps a source slug (e.g. ``"mock-source-a"``) to the TOML
+    file at ``_sources/<slug>.toml`` and parses it via
+    :func:`darnit.config.merger._parse_framework_only`.
+
+    IMPORTANT — the loader MUST be parse-only (F-1 fix). It is intentionally
+    routed through ``_parse_framework_only`` rather than
+    ``load_framework_config`` so that recursive composite-of-composite source
+    loads do NOT re-enter composition with a fresh ``_resolution_stack``.
+    Cycle detection (FR-012) and recursive composition (FR-018) both depend
+    on the resolver owning the single shared stack.
+
+    Do not switch this back to a resolving loader without explicitly
+    documenting why; the F-1 regression test (T046b) relies on parse-only
+    semantics here.
+    """
+    from darnit.config.merger import _parse_framework_only
+
+    sources_dir = composite_fixtures_dir / "_sources"
+
+    def _load(slug: str) -> FrameworkConfig | None:
+        path = sources_dir / f"{slug}.toml"
+        if not path.exists():
+            return None
+        return _parse_framework_only(path)
+
+    return _load

--- a/tests/darnit/fixtures/composite/README.md
+++ b/tests/darnit/fixtures/composite/README.md
@@ -1,0 +1,23 @@
+# Composite-implementation test fixtures
+
+This directory holds the hand-authored TOML fixtures used by
+`tests/darnit/test_composition.py`. The fixture-driven approach follows
+research decision R-010 in `specs/013-plugin-composition/research.md`:
+
+- Tests load each fixture through the **production** loader
+  (`darnit.config.merger.load_framework_config` for end-to-end coverage,
+  or `darnit.config.merger._parse_framework_only` for resolver-isolated
+  tests via the `fixture_source_loader` conftest helper). Catching
+  schema-binding bugs is part of the test surface, not just resolver
+  correctness.
+- Hand-authored TOML matches the actual composite-author experience and
+  doubles as concrete documentation for the contract.
+- Each scenario gets its own fixture; we avoid mega-fixtures with toggles.
+
+Subdirectories:
+
+- `_sources/` — non-composite framework TOMLs that composites pull from
+  (`mock-source-a.toml`, `mock-source-b.toml`, leaf/middle layers for
+  recursive scenarios, cycle pairs for the F-1 regression test, etc.).
+- The composite fixtures themselves live at the root of this directory
+  (e.g., `basic-include-all.toml`, `strict-conflict.toml`, ...).

--- a/tests/darnit/fixtures/composite/_sources/mock-source-a.toml
+++ b/tests/darnit/fixtures/composite/_sources/mock-source-a.toml
@@ -1,0 +1,66 @@
+# Mock source-A: a minimal non-composite framework used as the primary
+# source in composition tests. 5 controls across levels 1/2/3 and domains
+# AC/VM/QA, version 1.5.0. Pass logic is intentionally unsatisfiable
+# (DOES_NOT_EXIST.fixture) so any audit always returns FAIL — tests are
+# SHAPE-only per F-3, not status-dependent.
+
+[metadata]
+name = "mock-source-a"
+display_name = "Mock Source A (test fixture)"
+version = "1.5.0"
+spec_version = "mock v1"
+
+[defaults]
+check_adapter = "builtin"
+remediation_adapter = "builtin"
+
+[controls."MOCK-AC-01.01"]
+name = "MockAccessControlOne"
+description = "Mock AC control at level 1, domain AC. Sources tests."
+level = 1
+domain = "AC"
+
+[[controls."MOCK-AC-01.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]
+description = "Unsatisfiable by design — fixture only."
+
+[controls."MOCK-AC-02.01"]
+name = "MockAccessControlTwo"
+description = "Mock AC control at level 1, domain AC."
+level = 1
+domain = "AC"
+
+[[controls."MOCK-AC-02.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]
+
+[controls."MOCK-VM-01.01"]
+name = "MockVulnMgmtOne"
+description = "Mock VM control at level 2, domain VM."
+level = 2
+domain = "VM"
+
+[[controls."MOCK-VM-01.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]
+
+[controls."MOCK-VM-02.01"]
+name = "MockVulnMgmtTwo"
+description = "Mock VM control at level 3, domain VM."
+level = 3
+domain = "VM"
+
+[[controls."MOCK-VM-02.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]
+
+[controls."MOCK-QA-01.01"]
+name = "MockQualityOne"
+description = "Mock QA control at level 2, domain QA."
+level = 2
+domain = "QA"
+
+[[controls."MOCK-QA-01.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]

--- a/tests/darnit/fixtures/composite/_sources/mock-source-b.toml
+++ b/tests/darnit/fixtures/composite/_sources/mock-source-b.toml
@@ -1,0 +1,43 @@
+# Mock source-B: minimal non-composite framework with 3 level-1 controls.
+# Version 0.9.0 (for version-pin tests). Uses the same unsatisfiable
+# file_must_exist pattern as source-A.
+
+[metadata]
+name = "mock-source-b"
+display_name = "Mock Source B (test fixture)"
+version = "0.9.0"
+spec_version = "mock v1"
+
+[defaults]
+check_adapter = "builtin"
+remediation_adapter = "builtin"
+
+[controls."MOCK-B-01.01"]
+name = "MockBOne"
+description = "Mock B control at level 1."
+level = 1
+domain = "B"
+
+[[controls."MOCK-B-01.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]
+
+[controls."MOCK-B-02.01"]
+name = "MockBTwo"
+description = "Mock B control at level 1."
+level = 1
+domain = "B"
+
+[[controls."MOCK-B-02.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]
+
+[controls."MOCK-B-03.01"]
+name = "MockBThree"
+description = "Mock B control at level 1."
+level = 1
+domain = "B"
+
+[[controls."MOCK-B-03.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]

--- a/tests/darnit/fixtures/composite/_sources/mock-source-c-leaf.toml
+++ b/tests/darnit/fixtures/composite/_sources/mock-source-c-leaf.toml
@@ -1,0 +1,32 @@
+# Mock source-C-leaf: the ultimate non-composite source for the three-level
+# recursive scenario (mock-source-mid-composite → this).
+
+[metadata]
+name = "mock-source-c-leaf"
+display_name = "Mock Source C (leaf, test fixture)"
+version = "1.0.0"
+spec_version = "mock v1"
+
+[defaults]
+check_adapter = "builtin"
+remediation_adapter = "builtin"
+
+[controls."LEAF-01.01"]
+name = "MockLeafOne"
+description = "Leaf control 1 — the ultimate non-composite origin."
+level = 1
+domain = "LEAF"
+
+[[controls."LEAF-01.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]
+
+[controls."LEAF-02.01"]
+name = "MockLeafTwo"
+description = "Leaf control 2."
+level = 1
+domain = "LEAF"
+
+[[controls."LEAF-02.01".passes]]
+handler = "file_must_exist"
+paths = ["DOES_NOT_EXIST.fixture"]

--- a/tests/darnit/fixtures/composite/_sources/mock-source-mid-composite.toml
+++ b/tests/darnit/fixtures/composite/_sources/mock-source-mid-composite.toml
@@ -1,0 +1,17 @@
+# Mock source-mid-composite: a composite source that pulls every control
+# from mock-source-c-leaf. Used as the middle layer in the three-level
+# recursive-composition scenario (FR-018).
+
+[metadata]
+name = "mock-source-mid-composite"
+display_name = "Mock Mid Composite (test fixture)"
+version = "1.0.0"
+spec_version = "mock v1"
+
+[defaults]
+check_adapter = "builtin"
+remediation_adapter = "builtin"
+
+[[compose]]
+source = "mock-source-c-leaf"
+include_all = true


### PR DESCRIPTION
## Summary

PR 1 of 6 for feature **013-plugin-composition** — a TOML-only primitive that lets a darnit implementation declare its control set as the union of (a) named slices of other installed implementations and (b) its own inline controls, without inheritance or forking. Tracks issue #233.

This PR is **purely scaffolding** — schema additions, resolver skeleton, and fixture infrastructure. **Zero behavior change for non-composite frameworks** (existing test suite: 2074 passed / 6 skipped / 0 failed). Compose-block iteration (US1), override application (US2), strict-conflict detection (US3), cycle-error messages + recursive scenarios (US4), and version pinning (US5) land in subsequent PRs. The resolver intentionally raises `NotImplementedError` when those branches are hit, so partial-composition is impossible until each user story merges.

## What's in this PR

- **New core module** `darnit.core.composition` (~230 lines)
  - `CompositionError` base + 5 named subclasses: `Missing`, `Conflict`, `OrphanOverride`, `UnknownField`, `Cycle`, `VersionMismatch`
  - `resolve_composition` skeleton with idempotence (I3.3), shared `_resolution_stack` cycle detection (FR-012), and the "clear composition state on return" pattern (I3.2)
- **New pydantic models** in `framework_schema.py`
  - `ComposeBlock` (V1.1 at-least-one-include, V1.2 `include_all` exclusivity, V1.3 PEP 440 `version_constraint` validation)
  - `OverrideBlock` (V2.3 at-least-one-field) with `extra="allow"` so the resolver can validate field names against the real `ControlConfig.model_fields` at resolution time (FR-008 / F-2 alias rejection)
  - Three new `FrameworkConfig` fields: `compose`, `overrides`, `allow_conflicts`
- **Loader refactor** in `merger.py`
  - Extracts parse-only `_parse_framework_only(path)` helper
  - `load_framework_config(path)` is now a thin wrapper that conditionally invokes `resolve_composition` exactly once at the top of the call chain
  - The resolver's default `source_loader` routes through `_parse_framework_only` so cycle detection holds across composite-of-composite recursion (the **F-1 fix** from speckit.analyze)
- **Test fixtures + conftest helper**
  - `tests/darnit/conftest.py` exposes `composite_fixtures_dir` + a parse-only `fixture_source_loader`
  - Four mock source TOMLs: `mock-source-a` (5 controls / levels 1-3 / v1.5.0), `mock-source-b` (3 L1 controls / v0.9.0), `mock-source-c-leaf` (2 controls / v1.0.0), `mock-source-mid-composite` (composes from c-leaf — for recursive scenarios)
- **Complete spec dossier** under `specs/013-plugin-composition/`
  - spec.md (18 FRs, 8 SCs, 5 user stories P1–P3, 8 edge cases)
  - plan.md, research.md (11 design decisions R-001..R-011), data-model.md, contracts/{toml-schema,resolver-api}.md, quickstart.md, tasks.md (64 tasks across 8 phases)
  - Requirements checklist: 16/16 PASS
  - Three rounds of /speckit.analyze applied; final state: 0 CRITICAL / 0 HIGH / 0 MEDIUM blocking findings before /speckit.implement was invoked

## Subsequent PRs (preview)

| PR | Tasks | Story |
|---|---|---|
| **2** | T014–T029 | US1 — Org assembles baseline (P1, MVP) |
| 3 | T030–T037 | US2 — Override single control (P2) |
| 4 | T038–T042 | US3 — Conflicts resolve predictably (P2) |
| 5 | T043–T050 + T046b | US4 — Cycles / recursive (P3) + US5 — Version pinning (P3) |
| 6 | T051–T063 | Polish (perf, doc sync, dual-tool exposure, quickstart smoke) |

## Test plan

- [x] `uv run ruff check .` — zero errors on touched files
- [x] `uv run pytest tests/ --ignore=tests/integration/ -q` — **2074 passed, 6 skipped, 0 failed** (zero regression for non-composite frameworks)
- [x] Smoke: `openssf-baseline.toml` loads identically via both `load_framework_config` (62 controls) and `_parse_framework_only` (62 controls); `compose==[]`, `overrides=={}`, `allow_conflicts is False` on both
- [x] Resolver short-circuits idempotently on non-composite configs (returns input unchanged)
- [x] Schema validators reject: empty compose blocks, `include_all` + `include_levels`, malformed PEP 440 specifier, empty override blocks
- [x] Resolver raises `NotImplementedError` (not silent miss) on composite configs hitting US1/US2 placeholders
- [ ] PR 2 will add the first 10 composite-fixture tests exercising real compose-block resolution end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)