### PR TITLE
docs: surface composition in user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository includes an MCP (Model Context Protocol) server for AI assistant
 ## Features
 
 - **Plugin Architecture**: Implement any compliance standard as a darnit plugin
+- **Composition**: Assemble your organization's posture as a TOML-only mix of slices from other installed implementations — no forking, no Python ([quickstart](specs/013-plugin-composition/quickstart.md))
 - **MCP Server**: Integrates with AI assistants (Claude, etc.) for interactive auditing
 - **Automated Remediation**: Generate fixes for compliance gaps with dry-run support
 - **Project Configuration**: Canonical `.project.yaml` for project metadata and documentation locations
@@ -204,6 +205,8 @@ confirm_project_context(
 To create a new compliance implementation, start with the [**third-party plugin packaging guide**](docs/packaging-plugins.md) — it walks through `pyproject.toml`, entry points, the `ComplianceImplementation` protocol, the TOML control schema, signing, and distribution end-to-end. A minimal worked example lives at [`packages/darnit-hello/`](packages/darnit-hello/); copy it as a starting point.
 
 For implementation-level details (Python control handlers, custom MCP tools, remediation patterns), see the [Implementation Development Guide](docs/getting-started/implementation-development.md) and the [step-by-step tutorial](docs/tutorials/create-new-implementation.md).
+
+**If your "implementation" is really a curated mix of existing ones** — e.g., "OpenSSF Baseline levels 1–2 + three named SLSA controls + four of our own" — see the [composition quickstart](specs/013-plugin-composition/quickstart.md). Composition is TOML-only; you don't write Python composition code, and upstream sources stay upgrade-current automatically.
 
 ## Available MCP Tools
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -33,6 +33,15 @@ Compliance framework plugins — TOML controls, CEL expressions, remediation, cu
 - [Add a New Control](../tutorials/add-new-control.md) — Add a control to the OpenSSF Baseline
 - [Create a New Implementation](../tutorials/create-new-implementation.md) — Build a plugin from scratch
 
+### I want to assemble an org-specific posture from existing implementations
+
+Composition — TOML-only mix of slices from already-installed implementations ("OpenSSF Baseline L1+L2 + three named SLSA controls + our internal controls"). No Python composition code; upstream sources stay upgrade-current.
+
+1. [Environment Setup](environment-setup.md) — Prerequisites, fork, clone, install
+2. [Composition Quickstart](../../specs/013-plugin-composition/quickstart.md) — End-to-end walkthrough for an `acme-baseline` composite
+3. [TOML schema contract](../../specs/013-plugin-composition/contracts/toml-schema.md) — `[[compose]]`, `[overrides."ID"]`, `allow_conflicts` semantics
+4. [Implementation Guide §12](../IMPLEMENTATION_GUIDE.md#12-composition-assembling-implementations-from-other-implementations) — When to compose vs fork, conflict-resolution escape hatches, provenance contract
+
 ## Quick Reference
 
 | Guide | What it covers |

--- a/docs/getting-started/implementation-development.md
+++ b/docs/getting-started/implementation-development.md
@@ -287,4 +287,5 @@ The OpenSSF Baseline implementation (`packages/darnit-baseline/`) is the canonic
 - [Tutorial: Add a New Control](../tutorials/add-new-control.md) — Step-by-step walkthrough
 - [Tutorial: Create a New Implementation](../tutorials/create-new-implementation.md) — Build a plugin from scratch
 - [Testing Guide](testing.md) — Testing your implementation
+- [Composition Quickstart](../../specs/013-plugin-composition/quickstart.md) — Assemble an implementation from slices of other installed implementations in TOML, without writing Python composition code
 - Back to [Getting Started](README.md)

--- a/docs/packaging-plugins.md
+++ b/docs/packaging-plugins.md
@@ -360,6 +360,19 @@ See `CLAUDE.md` "Three-Layer Architecture" for the canonical reference.
 
 ---
 
+## Composition vs forking
+
+If your goal is "OpenSSF Baseline + a few of our own controls + an override or two" rather than a wholly new compliance standard, **don't build a plugin from scratch — compose one in TOML**. A composite implementation declares which controls it pulls from already-installed sources (levels, named IDs, or tag-based slices), adds inline controls of its own, and optionally overrides specific fields without forking. The framework resolves all of that at registration time and the rest of the framework sees a normal flat control set.
+
+- [Composition quickstart](../specs/013-plugin-composition/quickstart.md) — the canonical end-to-end walkthrough
+- [Composition spec](../specs/013-plugin-composition/spec.md) — full requirements (FR-001..FR-018, user stories, edge cases)
+- [TOML schema contract](../specs/013-plugin-composition/contracts/toml-schema.md) — `[[compose]]`, `[overrides."ID"]`, `allow_conflicts`, field-by-field semantics
+- [Implementation Guide §12](IMPLEMENTATION_GUIDE.md#12-composition-assembling-implementations-from-other-implementations) — when-to-compose-vs-fork, conflict-resolution escape hatches, provenance contract
+
+Composition keeps you upgrade-current on upstream changes (their pass logic and remediation flow through automatically); a fork takes upstream code captive. Reach for a fork only if you need to fundamentally re-author pass logic or maintain semantically divergent behavior.
+
+---
+
 ## See also
 
 - [Project constitution](../.specify/memory/constitution.md) — TOML-First Architecture, Plugin Separation rules


### PR DESCRIPTION
## Summary

Post-013 doc catchup. Feature 013-plugin-composition shipped via #251–#256, but only `docs/IMPLEMENTATION_GUIDE.md` (the dev-facing implementation reference) mentioned it. Users coming through README, the getting-started flow, or the third-party plugin packaging guide had no path to discover composition.

Four small surgical edits cross-link to the existing `specs/013-plugin-composition/quickstart.md` — no new user-facing doc page is created. The quickstart already serves as the canonical walkthrough.

## Test plan

- [x] All four edits resolve to existing files (`specs/013-plugin-composition/{quickstart,spec}.md`, `specs/013-plugin-composition/contracts/toml-schema.md`, `docs/IMPLEMENTATION_GUIDE.md#12-...`)
- [x] IMPLEMENTATION_GUIDE.md anchor slug matches the actual `## 12. Composition (assembling implementations from other implementations)` heading
- [x] Full test suite: 2108 passed / 6 skipped / 0 failed (unchanged from post-013 baseline; this PR is docs-only)
- [x] No new dependencies, no schema changes, no behavioral changes

## Changes

| File | What changed |
|---|---|
| `README.md` | Added "Composition" to the Features bullet list; added a paragraph in "Creating a Plugin" pointing composite authors at the quickstart instead of the full plugin-packaging flow |
| `docs/getting-started/README.md` | Added a fourth "Choose Your Path" section for org-specific posture composition |
| `docs/getting-started/implementation-development.md` | Added composition quickstart to "Next Steps" |
| `docs/packaging-plugins.md` | Added a "Composition vs forking" section above "See also" with four canonical links + a one-sentence rule of thumb |

🤖 Generated with [Claude Code](https://claude.com/claude-code)