### PR TITLE
fix(baseline): wrap CEL expressions with has() guards (closes #220)

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -463,7 +463,7 @@ command = ["gh", "api", "/orgs/$OWNER"]
 pass_exit_codes = [0]
 fail_exit_codes = [1]
 output_format = "json"
-expr = 'output.json.two_factor_requirement_enabled == true'
+expr = 'has(output.json.two_factor_requirement_enabled) && output.json.two_factor_requirement_enabled == true'
 timeout = 30
 
 [[controls."OSPS-AC-01.01".passes]]
@@ -625,7 +625,7 @@ command = ["gh", "api", "/repos/$OWNER/$REPO/branches/$BRANCH/protection"]
 pass_exit_codes = [0]
 fail_exit_codes = [1]
 output_format = "json"
-expr = 'output.json.allow_deletions.enabled == false'
+expr = 'has(output.json.allow_deletions) && has(output.json.allow_deletions.enabled) && output.json.allow_deletions.enabled == false'
 timeout = 30
 
 [[controls."OSPS-AC-03.02".passes]]

--- a/tests/darnit/sieve/test_cel_evaluator.py
+++ b/tests/darnit/sieve/test_cel_evaluator.py
@@ -580,3 +580,68 @@ class TestWarnControlCELExpressions:
         result = evaluator.evaluate(program, context)
         assert result.success is True
         assert result.value is False
+
+
+class TestIssue220HasGuards:
+    """Regression tests for issue #220.
+
+    The openssf-baseline.toml CEL expressions for
+    ``two_factor_requirement_enabled`` (OSPS-AC-01.01) and
+    ``allow_deletions.enabled`` (OSPS-AC-03.02) used to crash with KeyError
+    whenever the ``gh api`` response omitted those fields — which happens
+    routinely for non-admin tokens or orgs that hide 2FA settings. The fix
+    wraps each access with ``has()`` so missing fields cleanly evaluate
+    to ``false`` (INCONCLUSIVE → fall through to the next pass) rather than
+    raising.
+    """
+
+    # OSPS-AC-01.01 — two_factor_requirement_enabled
+    OSPS_AC_01_01_EXPR = (
+        "has(output.json.two_factor_requirement_enabled) && "
+        "output.json.two_factor_requirement_enabled == true"
+    )
+
+    # OSPS-AC-03.02 — allow_deletions.enabled. Chained has() because the
+    # outer key (`allow_deletions`) may itself be missing.
+    OSPS_AC_03_02_EXPR = (
+        "has(output.json.allow_deletions) && "
+        "has(output.json.allow_deletions.enabled) && "
+        "output.json.allow_deletions.enabled == false"
+    )
+
+    def _eval(self, expr: str, context: dict) -> object:
+        evaluator = CELEvaluator()
+        result = evaluator.evaluate(evaluator.compile(expr), context)
+        assert result.success is True, f"CEL failed: {result.error}"
+        return result.value
+
+    def test_ac_01_01_2fa_enabled_passes(self) -> None:
+        ctx = {"output": {"json": {"two_factor_requirement_enabled": True}}}
+        assert self._eval(self.OSPS_AC_01_01_EXPR, ctx) is True
+
+    def test_ac_01_01_2fa_disabled_fails(self) -> None:
+        ctx = {"output": {"json": {"two_factor_requirement_enabled": False}}}
+        assert self._eval(self.OSPS_AC_01_01_EXPR, ctx) is False
+
+    def test_ac_01_01_2fa_missing_does_not_crash(self) -> None:
+        """The original bug: missing key used to raise KeyError. Now → false."""
+        ctx = {"output": {"json": {}}}
+        assert self._eval(self.OSPS_AC_01_01_EXPR, ctx) is False
+
+    def test_ac_03_02_deletions_locked_passes(self) -> None:
+        ctx = {"output": {"json": {"allow_deletions": {"enabled": False}}}}
+        assert self._eval(self.OSPS_AC_03_02_EXPR, ctx) is True
+
+    def test_ac_03_02_deletions_allowed_fails(self) -> None:
+        ctx = {"output": {"json": {"allow_deletions": {"enabled": True}}}}
+        assert self._eval(self.OSPS_AC_03_02_EXPR, ctx) is False
+
+    def test_ac_03_02_outer_key_missing_does_not_crash(self) -> None:
+        """The original bug, outer key form: API omits `allow_deletions`."""
+        ctx = {"output": {"json": {}}}
+        assert self._eval(self.OSPS_AC_03_02_EXPR, ctx) is False
+
+    def test_ac_03_02_inner_key_missing_does_not_crash(self) -> None:
+        """The chained-has() case: outer present, leaf missing."""
+        ctx = {"output": {"json": {"allow_deletions": {}}}}
+        assert self._eval(self.OSPS_AC_03_02_EXPR, ctx) is False


### PR DESCRIPTION
## Summary

Closes #220. Two CEL expressions in \`openssf-baseline.toml\` accessed GitHub API fields without checking for their presence first, and crashed with \`KeyError\` whenever the API response omitted them — which happens routinely for non-admin tokens or orgs that hide 2FA settings.

| Control | API endpoint | Field | Old expression | New expression |
|---|---|---|---|---|
| OSPS-AC-01.01 (\`RequireMFA\`) | \`/orgs/\$OWNER\` | \`two_factor_requirement_enabled\` | direct access | wrapped with \`has(...)\` |
| OSPS-AC-03.02 (\`PreventBranchDeletion\`) | \`/repos/\$OWNER/\$REPO/branches/\$BRANCH/protection\` | \`allow_deletions.enabled\` | direct nested access | chained \`has()\` on both outer + leaf keys |

The pattern matches an existing one in the same TOML (OSPS-AC-03.01 at line 2563): \`has(output.json.enabled) && output.json.enabled == true\`. Both affected controls already have a \`manual\` pass as their second-phase fallback, so missing fields now produce INCONCLUSIVE → fall through → WARN, rather than a hard crash. Conservative-by-default (Constitution Principle II) holds: nothing pretends to PASS without a verified-positive signal.

## Test plan

- [x] 7 new regression tests in \`TestIssue220HasGuards\` covering: pass / fail / outer-key-missing / inner-key-missing / value-missing for both expressions. The \`*_does_not_crash\` tests are the canonical guards against this regressing.
- [x] \`uv run ruff check .\` — clean on touched files
- [x] \`uv run pytest tests/ --ignore=tests/integration/ -q\` — **2115 passed (7 new) / 6 skipped / 0 failed**
- [x] \`uv run python scripts/validate_sync.py --verbose\` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)