### PR TITLE
fix(sieve): depth-limited file discovery via opt-in max_depth (closes #221)

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -1052,6 +1052,10 @@ help_md = """Use standard package managers and lockfiles.
 
 [[controls."OSPS-BR-05.01".passes]]
 handler = "file_exists"
+# max_depth = 2 lets us find manifests in conventional nested layouts
+# (e.g., `app-code/keys-v2/go.mod`, `backend/pyproject.toml`) without
+# walking deep into massive monorepos. Resolves issue #221.
+max_depth = 2
 files = [
     "package.json",
     "package-lock.json",

--- a/packages/darnit/src/darnit/sieve/builtin_handlers.py
+++ b/packages/darnit/src/darnit/sieve/builtin_handlers.py
@@ -39,12 +39,60 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
+_FILE_DISCOVERY_PRUNE_DIRS = frozenset(
+    {
+        # VCS
+        ".git", ".hg", ".svn",
+        # Python
+        "__pycache__", ".venv", "venv", ".tox", ".mypy_cache",
+        ".pytest_cache", ".ruff_cache", "site-packages",
+        # JS/TS
+        "node_modules",
+        # Rust / Go / Java build outputs
+        "target", "build", "dist", "out",
+        # IDE / OS
+        ".idea", ".vscode", ".DS_Store",
+    }
+)
+
+
+def _walk_depth_limited(root: str, max_depth: int):
+    """Yield directories under ``root`` up to ``max_depth`` levels deep.
+
+    Skips well-known noise directories (``.git``, ``node_modules``,
+    ``__pycache__``, build outputs, etc.) so performance stays sane on
+    real monorepos. ``max_depth=0`` yields only ``root`` itself; ``=1``
+    yields root + its immediate subdirs; etc.
+    """
+    root_abs = os.path.abspath(root)
+    yield root_abs, 0
+    if max_depth <= 0:
+        return
+    for dirpath, dirnames, _files in os.walk(root_abs):
+        depth = dirpath[len(root_abs):].count(os.sep)
+        # Prune in-place so os.walk skips them (matches os.walk's contract)
+        dirnames[:] = [d for d in dirnames if d not in _FILE_DISCOVERY_PRUNE_DIRS]
+        if depth >= max_depth:
+            # Don't descend further; stop yielding deeper dirs
+            dirnames.clear()
+            continue
+        for d in dirnames:
+            yield os.path.join(dirpath, d), depth + 1
+
+
 def file_exists_handler(config: dict[str, Any], context: HandlerContext) -> HandlerResult:
     """Check if any file from a list of paths exists.
 
     Config fields:
         files: list[str] - File paths/patterns to check (any match = pass)
         use_locator: bool - If true, files are populated from locator.discover at load time
+        max_depth: int - When > 0, search subdirectories up to this many levels
+            deep for any non-glob pattern in ``files``. Default 0 (root only,
+            backward-compatible). Glob patterns containing ``*`` are NOT
+            depth-walked — they're still evaluated by ``glob.glob`` exactly as
+            before. Well-known noise directories (``.git``, ``node_modules``,
+            ``__pycache__``, build outputs, etc.) are pruned during the walk
+            so monorepo performance stays bounded. Resolves issue #221.
     """
     files = config.get("files", [])
     if not files:
@@ -52,6 +100,8 @@ def file_exists_handler(config: dict[str, Any], context: HandlerContext) -> Hand
             status=HandlerResultStatus.INCONCLUSIVE,
             message="No files specified for existence check",
         )
+
+    max_depth = int(config.get("max_depth", 0) or 0)
 
     for pattern in files:
         if "*" in pattern:
@@ -67,6 +117,27 @@ def file_exists_handler(config: dict[str, Any], context: HandlerContext) -> Hand
                     confidence=1.0,
                     evidence={"found_file": found, "relative_path": rel_path, "files_checked": files},
                 )
+        elif max_depth > 0:
+            # Depth-limited search for nested manifests (issue #221). Walks up
+            # to `max_depth` levels under `context.local_path`, pruning noise
+            # directories. First hit wins; we report its relative path so
+            # downstream consumers (and audit reviewers) can see where it
+            # actually lives.
+            for dirpath, _depth in _walk_depth_limited(context.local_path, max_depth):
+                candidate = os.path.join(dirpath, pattern)
+                if os.path.exists(candidate):
+                    rel_path = os.path.relpath(candidate, context.local_path)
+                    return HandlerResult(
+                        status=HandlerResultStatus.PASS,
+                        message=f"Required file found: {rel_path}",
+                        confidence=1.0,
+                        evidence={
+                            "found_file": candidate,
+                            "relative_path": rel_path,
+                            "files_checked": files,
+                            "max_depth": max_depth,
+                        },
+                    )
         else:
             path = os.path.join(context.local_path, pattern)
             if os.path.exists(path):
@@ -81,7 +152,7 @@ def file_exists_handler(config: dict[str, Any], context: HandlerContext) -> Hand
         status=HandlerResultStatus.FAIL,
         message=f"None of the required files found: {files}",
         confidence=1.0,
-        evidence={"files_checked": files},
+        evidence={"files_checked": files, "max_depth": max_depth},
     )
 
 

--- a/tests/darnit/sieve/test_builtin_handlers.py
+++ b/tests/darnit/sieve/test_builtin_handlers.py
@@ -97,6 +97,125 @@ class TestFileExistsHandler:
         assert result.status == HandlerResultStatus.FAIL
 
 
+class TestFileExistsHandlerDepthLimited:
+    """Regression tests for issue #221 — depth-limited file discovery.
+
+    The ``max_depth`` config field lets a pass walk subdirectories looking
+    for non-glob patterns, so projects with nested manifests (e.g.,
+    ``app-code/keys-v2/go.mod`` or ``backend/pyproject.toml``) are
+    detected by controls like OSPS-BR-05.01 rather than failing. Default
+    behavior (``max_depth=0``) is unchanged for backward compatibility.
+    """
+
+    def test_default_max_depth_root_only(self, tmp_path, ctx):
+        """Without max_depth, only the repo root is checked (regression: bug)."""
+        nested = tmp_path / "app-code" / "keys-v2"
+        nested.mkdir(parents=True)
+        (nested / "go.mod").write_text("module example")
+
+        result = file_exists_handler({"files": ["go.mod"]}, ctx)
+
+        # This is the bug from issue #221: file is present but not at root,
+        # so the default-depth check misses it.
+        assert result.status == HandlerResultStatus.FAIL
+
+    def test_max_depth_2_finds_nested_manifest(self, tmp_path, ctx):
+        """With max_depth=2, a manifest 2 levels deep is found."""
+        nested = tmp_path / "app-code" / "keys-v2"
+        nested.mkdir(parents=True)
+        (nested / "go.mod").write_text("module example")
+
+        result = file_exists_handler(
+            {"files": ["go.mod"], "max_depth": 2}, ctx
+        )
+
+        assert result.status == HandlerResultStatus.PASS
+        assert result.evidence["relative_path"] == "app-code/keys-v2/go.mod"
+        assert result.evidence["max_depth"] == 2
+
+    def test_max_depth_finds_root_first(self, tmp_path, ctx):
+        """Root match is preferred over nested when max_depth is set."""
+        (tmp_path / "go.mod").write_text("root")
+        nested = tmp_path / "app-code" / "keys-v2"
+        nested.mkdir(parents=True)
+        (nested / "go.mod").write_text("nested")
+
+        result = file_exists_handler(
+            {"files": ["go.mod"], "max_depth": 3}, ctx
+        )
+
+        assert result.status == HandlerResultStatus.PASS
+        assert result.evidence["relative_path"] == "go.mod"
+
+    def test_max_depth_skips_noise_directories(self, tmp_path, ctx):
+        """node_modules / __pycache__ / .git etc. are pruned during the walk.
+
+        Without pruning, a deeply nested package.json inside node_modules
+        would yield false positives.
+        """
+        # Set up: package.json buried inside node_modules at depth 1+
+        nm = tmp_path / "node_modules" / "some-pkg"
+        nm.mkdir(parents=True)
+        (nm / "package.json").write_text('{"name": "noise"}')
+
+        # Real app package.json one level deep but NOT inside node_modules
+        app = tmp_path / "app"
+        app.mkdir()
+        (app / "package.json").write_text('{"name": "real"}')
+
+        result = file_exists_handler(
+            {"files": ["package.json"], "max_depth": 5}, ctx
+        )
+
+        assert result.status == HandlerResultStatus.PASS
+        # The "real" app/ match wins; node_modules/some-pkg/ was pruned
+        assert result.evidence["relative_path"] == "app/package.json"
+
+    def test_max_depth_respects_limit(self, tmp_path, ctx):
+        """A file 3 levels deep is NOT found when max_depth=2."""
+        # depth 3: tmp_path / a / b / c / go.mod
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        (deep / "go.mod").write_text("too deep")
+
+        result = file_exists_handler(
+            {"files": ["go.mod"], "max_depth": 2}, ctx
+        )
+
+        # max_depth=2 means root + 2 subdirs (a, a/b). a/b/c is beyond.
+        assert result.status == HandlerResultStatus.FAIL
+
+    def test_max_depth_zero_explicit_is_root_only(self, tmp_path, ctx):
+        """max_depth=0 explicitly is equivalent to omitting the field."""
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        (nested / "pyproject.toml").write_text("")
+
+        result = file_exists_handler(
+            {"files": ["pyproject.toml"], "max_depth": 0}, ctx
+        )
+
+        assert result.status == HandlerResultStatus.FAIL
+
+    def test_max_depth_with_glob_pattern_unchanged(self, tmp_path, ctx):
+        """Glob patterns are NOT depth-walked; their behavior is unchanged.
+
+        max_depth only affects non-glob patterns. Authors who want
+        recursive glob behavior should use ``**`` in the pattern itself.
+        """
+        nested = tmp_path / "docs" / "subdir"
+        nested.mkdir(parents=True)
+        (nested / "SECURITY.md").write_text("policy")
+
+        # max_depth=5 set but pattern is a glob — depth-walk is skipped
+        result = file_exists_handler(
+            {"files": ["*.md"], "max_depth": 5}, ctx
+        )
+
+        # No top-level *.md files → FAIL (glob doesn't recurse without **)
+        assert result.status == HandlerResultStatus.FAIL
+
+
 # =============================================================================
 # exec_handler
 # =============================================================================


### PR DESCRIPTION
## Summary

Closes #221. Projects with nested manifests — microservices under \`app-code/<service>/\`, \`frontend/\` + \`backend/\` splits, monorepos with distinct components — used to fail dependency-detection controls like OSPS-BR-05.01 even when standard manifests were clearly present one or two directories deep. The handler only checked the repo root.

## What changed

### Handler (\`packages/darnit/src/darnit/sieve/builtin_handlers.py\`)

New opt-in config field on \`file_exists\` handler:

\`\`\`toml
[[controls.\"OSPS-BR-05.01\".passes]]
handler = \"file_exists\"
max_depth = 2  # NEW — walks up to N levels deep for non-glob patterns
files = [\"go.mod\", \"pyproject.toml\", \"package.json\", ...]
\`\`\`

- **Default \`max_depth = 0\`** preserves backward compatibility for every other control that doesn't opt in.
- **Glob patterns are unchanged** — they're still evaluated by \`glob.glob\` exactly as before. \`max_depth\` applies only to non-glob patterns.
- **Noise-directory pruning** during the walk: \`.git\`, \`node_modules\`, \`__pycache__\`, \`.venv\`, \`venv\`, \`.tox\`, \`.mypy_cache\`, \`.ruff_cache\`, \`.pytest_cache\`, \`target\`, \`build\`, \`dist\`, \`out\`, \`.idea\`, \`.vscode\`, etc. A misconfigured deep walk through a 50k-file \`node_modules\` tree was the biggest \"make this the default\" risk; explicit opt-in + pruning sidesteps that.
- **First match wins**; root match is naturally preferred over deeper matches because \`os.walk\` yields breadth-first by depth.

### TOML (\`packages/darnit-baseline/openssf-baseline.toml\`)

OSPS-BR-05.01 (\`StandardizedDependencyTools\`) opts in with \`max_depth = 2\`. No other control's behavior changes.

## Issue #226 still open

#226 (\"Evaluate making depth-limited file discovery the default in sieve handlers\") remains a separate discussion. This PR is deliberately the smallest change that fixes the user-reported bug: opt-in only, conservative default. Flipping the global default would change behavior for every control in every implementation and deserves its own evaluation.

## Test plan

7 new regression tests in \`TestFileExistsHandlerDepthLimited\`:

- \`test_default_max_depth_root_only\` — without \`max_depth\`, nested files are still missed (regression: this is the bug from #221)
- \`test_max_depth_2_finds_nested_manifest\` — \`app-code/keys-v2/go.mod\` is found with \`max_depth = 2\`
- \`test_max_depth_finds_root_first\` — root match preferred over nested when both exist
- \`test_max_depth_skips_noise_directories\` — \`node_modules/some-pkg/package.json\` is pruned; real \`app/package.json\` wins
- \`test_max_depth_respects_limit\` — file 3 levels deep is NOT found with \`max_depth = 2\`
- \`test_max_depth_zero_explicit_is_root_only\` — explicit \`= 0\` equivalent to default
- \`test_max_depth_with_glob_pattern_unchanged\` — globs are not depth-walked

Verification:
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run pytest tests/ --ignore=tests/integration/ -q\` — **2115 passed (7 new) / 6 skipped / 0 failed**
- [x] \`uv run python scripts/validate_sync.py --verbose\` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)