### PR TITLE
release: rename PyPI distribution darnit -> darnit-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Build packages
         run: |
-          uv build --package darnit
+          uv build --package darnit-core
           uv build --package darnit-baseline
 
       - name: Verify package contents

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build packages
         run: |
-          uv build --package darnit
+          uv build --package darnit-core
           uv build --package darnit-baseline
 
       - name: Upload build artifacts
@@ -49,8 +49,8 @@ jobs:
           name: dist
           path: dist/
 
-  publish-darnit:
-    name: Publish darnit
+  publish-darnit-core:
+    name: Publish darnit-core
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
@@ -66,7 +66,7 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Publish darnit to PyPI
+      - name: Publish darnit-core to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist/
@@ -75,7 +75,7 @@ jobs:
 
   publish-darnit-baseline:
     name: Publish darnit-baseline
-    needs: publish-darnit
+    needs: publish-darnit-core
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -132,13 +132,14 @@ jobs:
           case "$PKG" in
             "darnit-mcp")
               # darnit-mcp installs the `darnit` console script via its
-              # darnit dependency. Confirm the CLI is reachable and reports
-              # the expected version.
+              # darnit-core dependency. Confirm the CLI is reachable and
+              # reports the expected version.
               actual=$("$venv/bin/darnit" --version 2>&1 | tail -n1)
               echo "darnit --version → $actual"
               echo "$actual" | grep -F "$VERSION"
               ;;
-            "darnit")
+            "darnit-core")
+              # Distribution is darnit-core; import name is still `darnit`.
               "$venv/bin/python" -c "import darnit; print('darnit imports OK')"
               ;;
             "darnit-baseline")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,11 +237,12 @@ jobs:
 
   # T013 + T014: per-package publish. Sequenced via `needs:` because
   # `darnit-baseline`, `darnit-gittuf`, and `darnit-mcp` declare
-  # `darnit>=...` runtime dependencies — publishing them before darnit
-  # is on the target index would briefly produce unresolvable wheels.
-  # `darnit-mcp` depends on all three other packages, so it publishes last.
-  publish-darnit:
-    name: Publish darnit to ${{ needs.preflight.outputs.is_prerelease == 'true' && 'TestPyPI' || 'PyPI' }}
+  # `darnit-core>=...` runtime dependencies — publishing them before
+  # darnit-core is on the target index would briefly produce unresolvable
+  # wheels. `darnit-mcp` depends on all three other packages, so it
+  # publishes last.
+  publish-darnit-core:
+    name: Publish darnit-core to ${{ needs.preflight.outputs.is_prerelease == 'true' && 'TestPyPI' || 'PyPI' }}
     needs: [preflight, build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -257,10 +258,10 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Publish darnit
+      - name: Publish darnit-core
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          packages-dir: dist/darnit/
+          packages-dir: dist/darnit-core/
           repository-url: ${{ needs.preflight.outputs.is_prerelease == 'true' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           attestations: true
           # We refuse to overwrite published artifacts. If a re-attempt is
@@ -269,7 +270,7 @@ jobs:
 
   publish-darnit-baseline:
     name: Publish darnit-baseline to ${{ needs.preflight.outputs.is_prerelease == 'true' && 'TestPyPI' || 'PyPI' }}
-    needs: [preflight, build, publish-darnit]
+    needs: [preflight, build, publish-darnit-core]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: release
@@ -294,7 +295,7 @@ jobs:
 
   publish-darnit-gittuf:
     name: Publish darnit-gittuf to ${{ needs.preflight.outputs.is_prerelease == 'true' && 'TestPyPI' || 'PyPI' }}
-    needs: [preflight, build, publish-darnit]
+    needs: [preflight, build, publish-darnit-core]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: release
@@ -948,7 +949,7 @@ jobs:
     if: always()
     needs:
       - preflight
-      - publish-darnit
+      - publish-darnit-core
       - publish-darnit-baseline
       - publish-darnit-gittuf
       - publish-darnit-mcp
@@ -974,7 +975,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_PRERELEASE: ${{ needs.preflight.outputs.is_prerelease }}
           VERSION: ${{ needs.preflight.outputs.version }}
-          PYPI_DARNIT: ${{ needs.publish-darnit.result }}
+          PYPI_DARNIT: ${{ needs.publish-darnit-core.result }}
           PYPI_BASELINE: ${{ needs.publish-darnit-baseline.result }}
           PYPI_GITTUF: ${{ needs.publish-darnit-gittuf.result }}
           PYPI_MCP: ${{ needs.publish-darnit-mcp.result }}

--- a/docs/generated/USAGE_GUIDE.md
+++ b/docs/generated/USAGE_GUIDE.md
@@ -11,7 +11,7 @@ This guide explains how to use the Darnit framework for compliance auditing.
 
 1. Install darnit and a compliance framework:
    ```bash
-   pip install darnit darnit-baseline
+   pip install darnit-core darnit-baseline
    ```
 
 2. Run an audit:

--- a/packages/darnit-baseline/pyproject.toml
+++ b/packages/darnit-baseline/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "darnit>=0.1.0",
+    "darnit-core>=0.1.0",
     "tree-sitter>=0.25",
     "tree-sitter-language-pack>=1.5",
 ]

--- a/packages/darnit-example/pyproject.toml
+++ b/packages/darnit-example/pyproject.toml
@@ -5,7 +5,7 @@ description = "Example 'Project Hygiene Standard' implementation for darnit"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "darnit>=0.1.0",
+    "darnit-core>=0.1.0",
 ]
 
 [project.entry-points."darnit.implementations"]

--- a/packages/darnit-gittuf/pyproject.toml
+++ b/packages/darnit-gittuf/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "darnit>=0.1.0",
+    "darnit-core>=0.1.0",
 ]
 
 [project.urls]

--- a/packages/darnit-hello/pyproject.toml
+++ b/packages/darnit-hello/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Documentation",
 ]
 dependencies = [
-    "darnit>=0.1.0",
+    "darnit-core>=0.1.0",
 ]
 
 [project.urls]

--- a/packages/darnit-plugins/pyproject.toml
+++ b/packages/darnit-plugins/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 keywords = [
     "compliance",
     "security",
-    "darnit",
+    "darnit-core",
     "plugins",
     "adapters",
 ]
@@ -32,7 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "darnit>=0.1.0",
+    "darnit-core>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/darnit-testchecks/pyproject.toml
+++ b/packages/darnit-testchecks/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 keywords = [
     "compliance",
     "testing",
-    "darnit",
+    "darnit-core",
     "framework",
 ]
 classifiers = [
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 dependencies = [
-    "darnit>=0.1.0",
+    "darnit-core>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/darnit/pyproject.toml
+++ b/packages/darnit/pyproject.toml
@@ -1,5 +1,9 @@
 [project]
-name = "darnit"
+# PyPI distribution name. The Python import path is still `darnit` (under
+# packages/darnit/src/darnit/) and the CLI command is still `darnit`. Only
+# the PyPI distribution name is `darnit-core`, to avoid a conflict with a
+# similarly-named project on PyPI.
+name = "darnit-core"
 version = "0.1.0"
 description = "Generic compliance audit framework with plugin architecture"
 readme = "README.md"

--- a/packages/darnit/src/darnit/cli.py
+++ b/packages/darnit/src/darnit/cli.py
@@ -35,6 +35,23 @@ from darnit.core.logging import configure_logging, get_logger
 logger = get_logger("cli")
 
 
+def _resolve_version() -> str:
+    """Return the installed `darnit-core` version, or `"dev"` if unresolved.
+
+    The PyPI distribution name is `darnit-core` (the import name and CLI
+    command both remain `darnit`). When darnit is run from a source
+    checkout without an editable install — or when a stale binary on
+    PATH outside the workspace venv is invoked — the distribution
+    metadata isn't on the import path. Fall back to `"dev"` so
+    `darnit --version` never crashes on what is effectively a "no
+    metadata available" condition.
+    """
+    try:
+        return importlib.metadata.version("darnit-core")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
 # Output Formatters
 
 
@@ -671,7 +688,11 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-V", "--version",
         action="version",
-        version=f"%(prog)s {importlib.metadata.version('darnit')}",
+        # PyPI distribution name is `darnit-core` (the CLI command stays `darnit`).
+        # Fall back to "dev" when running from a non-installed source checkout
+        # so the CLI never crashes on `--version` just because the package
+        # metadata isn't on the import path.
+        version=f"%(prog)s {_resolve_version()}",
     )
     parser.add_argument(
         "-v", "--verbose",

--- a/packages/darnit/src/darnit/core/verification.py
+++ b/packages/darnit/src/darnit/core/verification.py
@@ -342,7 +342,7 @@ class PluginVerifier:
         except ImportError:
             self._sigstore_available = False
             logger.info(
-                "Sigstore not available. Install with: pip install darnit[attestation]"
+                "Sigstore not available. Install with: pip install darnit-core[attestation]"
             )
 
         return self._sigstore_available

--- a/packaging/pypi/public-packages.txt
+++ b/packaging/pypi/public-packages.txt
@@ -1,4 +1,4 @@
-darnit
+darnit-core
 darnit-baseline
 darnit-gittuf
 darnit-mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Topic :: Security",
 ]
 dependencies = [
-    "darnit",
+    "darnit-core",
     "darnit-baseline",
     "darnit-gittuf",
 ]
@@ -30,7 +30,7 @@ Issues = "https://github.com/kusari-oss/darnit/issues"
 
 [project.optional-dependencies]
 attestation = [
-    "darnit[attestation]",
+    "darnit-core[attestation]",
 ]
 dev = [
     "pytest>=8.0.0",
@@ -44,7 +44,7 @@ dev = [
 members = ["packages/*"]
 
 [tool.uv.sources]
-darnit = { workspace = true }
+darnit-core = { workspace = true }
 darnit-baseline = { workspace = true }
 darnit-example = { workspace = true }
 darnit-gittuf = { workspace = true }

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -425,7 +425,7 @@ This guide explains how to use the Darnit framework for compliance auditing.
 
 1. Install darnit and a compliance framework:
    ```bash
-   pip install darnit darnit-baseline
+   pip install darnit-core darnit-baseline
    ```
 
 2. Run an audit:

--- a/tests/darnit/core/test_verification.py
+++ b/tests/darnit/core/test_verification.py
@@ -379,11 +379,16 @@ class TestVerificationIntegration:
         assert result.verified is True
 
     def test_verify_darnit_core(self) -> None:
-        """Test verifying darnit core package."""
+        """Test verifying darnit core package.
+
+        The PyPI distribution name is `darnit-core`; the import name and
+        CLI command stay `darnit`. PluginVerifier looks up the
+        distribution name to find package metadata.
+        """
         config = VerificationConfig(allow_unsigned=True, verify_online=False)
         verifier = PluginVerifier(config)
 
-        result = verifier.verify_plugin("darnit")
+        result = verifier.verify_plugin("darnit-core")
 
         assert result.verified is True
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,8 +8,8 @@ resolution-markers = [
 
 [manifest]
 members = [
-    "darnit",
     "darnit-baseline",
+    "darnit-core",
     "darnit-example",
     "darnit-gittuf",
     "darnit-hello",
@@ -427,7 +427,24 @@ wheels = [
 ]
 
 [[package]]
-name = "darnit"
+name = "darnit-baseline"
+version = "0.1.0"
+source = { editable = "packages/darnit-baseline" }
+dependencies = [
+    { name = "darnit-core" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-language-pack" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "darnit-core", editable = "packages/darnit" },
+    { name = "tree-sitter", specifier = ">=0.25" },
+    { name = "tree-sitter-language-pack", specifier = ">=1.5" },
+]
+
+[[package]]
+name = "darnit-core"
 version = "0.1.0"
 source = { editable = "packages/darnit" }
 dependencies = [
@@ -466,68 +483,51 @@ requires-dist = [
 provides-extras = ["attestation"]
 
 [[package]]
-name = "darnit-baseline"
-version = "0.1.0"
-source = { editable = "packages/darnit-baseline" }
-dependencies = [
-    { name = "darnit" },
-    { name = "tree-sitter" },
-    { name = "tree-sitter-language-pack" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "darnit", editable = "packages/darnit" },
-    { name = "tree-sitter", specifier = ">=0.25" },
-    { name = "tree-sitter-language-pack", specifier = ">=1.5" },
-]
-
-[[package]]
 name = "darnit-example"
 version = "0.1.0"
 source = { editable = "packages/darnit-example" }
 dependencies = [
-    { name = "darnit" },
+    { name = "darnit-core" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "darnit", editable = "packages/darnit" }]
+requires-dist = [{ name = "darnit-core", editable = "packages/darnit" }]
 
 [[package]]
 name = "darnit-gittuf"
 version = "0.1.0"
 source = { editable = "packages/darnit-gittuf" }
 dependencies = [
-    { name = "darnit" },
+    { name = "darnit-core" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "darnit", editable = "packages/darnit" }]
+requires-dist = [{ name = "darnit-core", editable = "packages/darnit" }]
 
 [[package]]
 name = "darnit-hello"
 version = "0.1.0"
 source = { editable = "packages/darnit-hello" }
 dependencies = [
-    { name = "darnit" },
+    { name = "darnit-core" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "darnit", editable = "packages/darnit" }]
+requires-dist = [{ name = "darnit-core", editable = "packages/darnit" }]
 
 [[package]]
 name = "darnit-mcp"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "darnit" },
     { name = "darnit-baseline" },
+    { name = "darnit-core" },
     { name = "darnit-gittuf" },
 ]
 
 [package.optional-dependencies]
 attestation = [
-    { name = "darnit", extra = ["attestation"] },
+    { name = "darnit-core", extra = ["attestation"] },
 ]
 dev = [
     { name = "pre-commit" },
@@ -550,9 +550,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "darnit", editable = "packages/darnit" },
-    { name = "darnit", extras = ["attestation"], marker = "extra == 'attestation'", editable = "packages/darnit" },
     { name = "darnit-baseline", editable = "packages/darnit-baseline" },
+    { name = "darnit-core", editable = "packages/darnit" },
+    { name = "darnit-core", extras = ["attestation"], marker = "extra == 'attestation'", editable = "packages/darnit" },
     { name = "darnit-gittuf", editable = "packages/darnit-gittuf" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -578,7 +578,7 @@ name = "darnit-plugins"
 version = "0.1.0"
 source = { editable = "packages/darnit-plugins" }
 dependencies = [
-    { name = "darnit" },
+    { name = "darnit-core" },
 ]
 
 [package.optional-dependencies]
@@ -589,7 +589,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "darnit", editable = "packages/darnit" },
+    { name = "darnit-core", editable = "packages/darnit" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
 ]
@@ -600,7 +600,7 @@ name = "darnit-testchecks"
 version = "0.1.0"
 source = { editable = "packages/darnit-testchecks" }
 dependencies = [
-    { name = "darnit" },
+    { name = "darnit-core" },
 ]
 
 [package.optional-dependencies]
@@ -611,7 +611,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "darnit", editable = "packages/darnit" },
+    { name = "darnit-core", editable = "packages/darnit" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
 ]


### PR DESCRIPTION
## Summary

The bare \`darnit\` name on PyPI conflicts with a similarly-named existing project. Renames the PyPI distribution to \`darnit-core\` to avoid the conflict before reserving names for v0.1.0.

**Deliberately scoped to ONLY the PyPI distribution name.** Three identifiers exist independently:

| Identifier | Before | After |
|---|---|---|
| **PyPI distribution name** | \`darnit\` | **\`darnit-core\`** |
| Python import name (\`import darnit\`, \`packages/darnit/src/darnit/\` on disk) | \`darnit\` | unchanged |
| CLI command name (\`darnit audit ...\`) | \`darnit\` | unchanged |

Users still type \`darnit audit\` and write \`import darnit\` — the only visible change is \`pip install darnit-core\` instead of \`pip install darnit\`, and most users won't see that because they install \`darnit-mcp\` (the meta-package) which pulls the core in transitively.

## What changed (15 files)

### Distribution / dependency declarations
- \`packages/darnit/pyproject.toml\` — \`name\` field
- 6 dependents — \`"darnit>=0.1.0"\` → \`"darnit-core>=0.1.0"\` (baseline, gittuf, example, hello, plugins, testchecks)
- \`pyproject.toml\` (root) — workspace mapping, dependency list, \`attestation\` extras dep
- \`packaging/pypi/public-packages.txt\` — first line

### Documentation
- \`scripts/generate_docs.py\` — install hint
- \`docs/generated/USAGE_GUIDE.md\` — regenerated from the script

### Runtime metadata lookups
- \`packages/darnit/src/darnit/cli.py\` — \`importlib.metadata.version()\` call updated, AND wrapped in a new \`_resolve_version()\` helper that falls back to \`"dev"\` if metadata isn't on the import path. This was a **latent crash** before; the pre-rename code only worked locally because of an unrelated stale install on the contributor's machine. Defensive handling is overdue.
- \`packages/darnit/src/darnit/core/verification.py\` — sigstore install hint message

### Test
- \`tests/darnit/core/test_verification.py::test_verify_darnit_core\` — the test ironically named for the new package now verifies the new distribution name, with a docstring explaining the import vs distribution split.

### Intentionally NOT changed (these are import names, not distribution names)
- \`pyproject.toml:110\` — mypy \`packages = ["darnit", ...]\`
- \`pyproject.toml:161\` — ruff \`known-first-party = ["darnit", ...]\`

Confirmed by their siblings (\`darnit_baseline\` with **underscore** = import name; distinct from \`darnit-baseline\` with hyphen = distribution name).

## Test plan

- [x] \`uv run ruff check .\` — clean
- [x] \`uv run pytest tests/ --ignore=tests/integration/ -q\` — **2122 passed / 6 skipped / 0 failed**
- [x] \`uv run python scripts/validate_sync.py --verbose\` — PASS
- [x] \`uv run python scripts/generate_docs.py\` — regenerated docs committed; no remaining diff
- [x] No bare \`darnit\` distribution-name references remain in any pyproject.toml file

## Next step

After this merges, the v0.1.0 release prereqs become: reserve \`darnit-core\` (instead of \`darnit\`) on PyPI + TestPyPI as Trusted Publisher, then continue with the rest of the runbook in [\`packaging/README.md\`](packaging/README.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)