### PR TITLE
release: v0.0.0rc0 (dry-run pre-release)

### DIFF
--- a/packages/darnit-baseline/pyproject.toml
+++ b/packages/darnit-baseline/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnit-baseline"
-version = "0.1.0"
+version = "0.0.0rc0"
 description = "OpenSSF Baseline (OSPS v2025.10.10) compliance checks for darnit"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/darnit-gittuf/pyproject.toml
+++ b/packages/darnit-gittuf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnit-gittuf"
-version = "0.1.0"
+version = "0.0.0rc0"
 description = "Gittuf policy checks plugin for darnit"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/darnit/pyproject.toml
+++ b/packages/darnit/pyproject.toml
@@ -4,7 +4,7 @@
 # the PyPI distribution name is `darnit-core`, to avoid a conflict with a
 # similarly-named project on PyPI.
 name = "darnit-core"
-version = "0.1.0"
+version = "0.0.0rc0"
 description = "Generic compliance audit framework with plugin architecture"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,3 +163,10 @@ known-first-party = ["darnit", "darnit_baseline", "darnit_example"]
 [tool.bandit]
 exclude_dirs = ["tests", "docs/examples"]
 skips = ["B101"]  # Allow assert statements
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+bypass-selection = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnit-mcp"
-version = "0.1.0"
+version = "0.0.0rc0"
 description = "MCP server for compliance auditing using the darnit framework"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "darnit-baseline"
-version = "0.1.0"
+version = "0.0.0rc0"
 source = { editable = "packages/darnit-baseline" }
 dependencies = [
     { name = "darnit-core" },
@@ -445,7 +445,7 @@ requires-dist = [
 
 [[package]]
 name = "darnit-core"
-version = "0.1.0"
+version = "0.0.0rc0"
 source = { editable = "packages/darnit" }
 dependencies = [
     { name = "cel-python" },
@@ -495,7 +495,7 @@ requires-dist = [{ name = "darnit-core", editable = "packages/darnit" }]
 
 [[package]]
 name = "darnit-gittuf"
-version = "0.1.0"
+version = "0.0.0rc0"
 source = { editable = "packages/darnit-gittuf" }
 dependencies = [
     { name = "darnit-core" },
@@ -517,7 +517,7 @@ requires-dist = [{ name = "darnit-core", editable = "packages/darnit" }]
 
 [[package]]
 name = "darnit-mcp"
-version = "0.1.0"
+version = "0.0.0rc0"
 source = { virtual = "." }
 dependencies = [
     { name = "darnit-baseline" },


### PR DESCRIPTION
## Summary

- Bumps all 4 public packages (`darnit-mcp`, `darnit-core`, `darnit-baseline`, `darnit-gittuf`) to `0.0.0rc0`.
- This is the pre-release that exercises the new tag-driven pipeline end-to-end against TestPyPI + GHCR + GitHub Release before cutting `v0.1.0`.
- Pre-release `rcN` tags **skip** the Homebrew formula bump and Claude Code plugin jobs by design — those run on stable tags only.

## Pre-flight (already verified locally on this branch)

- `uv sync --all-extras` — clean
- `uv run ruff check .` — All checks passed!
- `uv run pytest tests/ --ignore=tests/integration/ -q` — 2122 passed, 6 skipped
- `uv run python scripts/validate_sync.py --verbose` — all validations successful
- `uv run python scripts/generate_docs.py` then `git diff --exit-code docs/generated/` — no diff

## External setup still required before tagging

- [ ] `release` environment on `kusari-oss/darnit` — **done** (id `15434148958`)
- [ ] 4× TestPyPI Trusted Publishers (`darnit-core`, `darnit-baseline`, `darnit-gittuf`, `darnit-mcp` — owner `kusari-oss`, repo `darnit`, workflow `release.yml`, env `release`)
- [ ] Merge this PR
- [ ] Tag: `git tag v0.0.0rc0 && git push origin v0.0.0rc0`

Homebrew tap setup (`kusari-oss/homebrew-tap` + GitHub App + `HOMEBREW_TAP_TOKEN`) is **not** required for rc0 — it's tracked separately as a v0.1.0 blocker.

## Test plan

- [ ] CI green on this PR
- [ ] After tag push: `release.yml` `preflight` job passes (verifies tag == pyproject version, working tree clean, lint, tests, sync, docs)
- [ ] All 4 `pypi_publish_*` jobs upload to TestPyPI (not PyPI)
- [ ] `container_build_push` pushes `ghcr.io/kusari-oss/darnit:v0.0.0rc0` (+ `-rc`)
- [ ] `binary_matrix` produces signed shiv binaries for 4 platforms
- [ ] `release_attach_binaries` creates GitHub Release marked pre-release
- [ ] `homebrew_dispatch` and `plugin_package` skip cleanly (stable-only `if:` guards)
- [ ] `finalize` posts timing table to release notes
- [ ] Release Smoke Tests workflow triggers and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)