### PR TITLE
docs: state threat-model coverage scope honestly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository includes an MCP (Model Context Protocol) server for AI assistant
 - **Automated Remediation**: Generate fixes for compliance gaps with dry-run support
 - **Project Configuration**: Canonical `.project.yaml` for project metadata and documentation locations
 - **Attestation Generation**: Create cryptographically signed in-toto attestations
-- **STRIDE Threat Modeling**: (Alpha) Built-in security threat analysis. To be only used for basic drafting.
+- **STRIDE Threat Modeling**: (Alpha) Built-in security threat analysis — works best on Python web services (Flask, FastAPI, Django, MCP servers); Go/JavaScript and CLI tools have limited coverage today. See [Coverage scope](#threat-model-coverage-scope) below. To be used for basic drafting only.
 - **CEL Expressions**: Flexible pass logic using Common Expression Language
 - **Plugin Verification**: Sigstore-based plugin signing and verification
 
@@ -80,6 +80,22 @@ curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh |
 # Verify
 opengrep --version
 ```
+
+### Threat-model coverage scope
+
+The tree-sitter discovery pipeline is tuned for **web-service shapes**. What works well today:
+
+| Project shape | Coverage |
+|---|---|
+| Python web service (Flask, FastAPI, Django, MCP server) | Best path — full STRIDE: routes, data stores, sinks, info-disclosure, elevation-of-privilege |
+| JavaScript/Node service (Express-style) | Moderate — route registration + basic sink set |
+| Go HTTP service (`net/http`, chi, gorilla) | Thin — HTTP route registration + `sql.Open` only |
+| YAML / GitHub Actions workflows | Some — overly-broad permissions and similar config issues |
+| CLI tools (cobra, click, argparse, urfave/cli) | Not modeled — produces structurally complete but empty output |
+| Crypto/signing **client** libraries (sigstore-python, in-toto) | Out of scope — these call out rather than receive; entry-point queries don't fire |
+| Systems software, daemons, libraries, ML pipelines | Not modeled |
+
+If your project doesn't match a supported shape, the generator will still write a report — but it will likely show "Total findings: 0" because no entry points were discovered. That's a coverage gap on our side, not a clean bill of health. Expanding the query set is [tracked in our issue tracker](https://github.com/kusari-oss/darnit/issues?q=is%3Aissue+threat-model+coverage).
 
 ## Quick Start
 

--- a/packages/darnit-baseline/README.md
+++ b/packages/darnit-baseline/README.md
@@ -179,7 +179,7 @@ Five templates have `llm_enhance` prompts (marked with \*) that request LLM-base
 | DO-05.01 | `SUPPORT.md` | Production | End-of-support variant (no-op if DO-03.01 ran first) |
 | SA-01.01 | `ARCHITECTURE.md` | Scaffold\* | Components/actors/data flow — all example data. `llm_enhance` |
 | SA-02.01 | `API.md` | Scaffold\* | Interface tables, usage examples — all placeholder. `llm_enhance` |
-| SA-03.02 | `THREAT_MODEL.md` | Production\* | Full STRIDE: 5 assets, 9 threats with mitigations. `llm_enhance`, `project_update` |
+| SA-03.02 | `THREAT_MODEL.md` | Production\* | Full STRIDE on Python web services; thin or empty on Go/CLI/library projects. See [coverage scope](../../README.md#threat-model-coverage-scope). `llm_enhance`, `project_update` |
 
 #### CI Workflows (`.github/workflows/`)
 


### PR DESCRIPTION
## Summary

- Adds a **Threat-model coverage scope** subsection to the top-level README so users don't mistake "Total findings: 0" for a clean bill of health. Lists the project shapes the tree-sitter pipeline targets (Python web services = best path) versus the shapes that produce empty output today (CLIs, client libraries, daemons).
- Updates the bullet for "STRIDE Threat Modeling" in the feature list to mention the coverage caveat inline.
- Tempers the **Production*** rating for the SA-03.02 `THREAT_MODEL.md` remediation in `packages/darnit-baseline/README.md` to reflect the shape dependency.

## Why

A cold audit of a Go CLI (gittuf) showed darnit happily writing a `THREAT_MODEL.md` containing "Total findings: 0" because the Go entry-point queries only match HTTP routing patterns. The file looked complete; the audit gave a misleading impression. Honest docs surface that gap so users (and demo audiences) aren't surprised.

Coverage expansion is tracked in #262.

## Test plan

- [ ] README renders correctly on GitHub (table + anchor link to coverage section work)
- [ ] No `docs/generated/` drift introduced (`uv run python scripts/generate_docs.py` is a no-op)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)