### PR TITLE
fix: decouple remediation enhancer from private LLM helper

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/remediation/enhancer.py
+++ b/packages/darnit-baseline/src/darnit_baseline/remediation/enhancer.py
@@ -119,25 +119,16 @@ def _enhance_architecture(content: str, local_path: str, *, llm_fn: object | Non
         "Return the enhanced ARCHITECTURE.md content."
     )
 
-    if llm_fn is not None:
-        try:
-            result = llm_fn(prompt)
-            if isinstance(result, str) and result.strip():
-                return result
-        except Exception as e:
-            logger.warning("LLM enhancement failed: %s", e)
-            return None
-    else:
-        # Try using the framework's LLM evaluation
-        try:
-            from darnit.sieve.builtin_handlers import _call_llm
+    if llm_fn is None:
+        logger.debug("No LLM callable provided for enhancement")
+        return None
 
-            result = _call_llm(prompt)
-            if isinstance(result, str) and result.strip():
-                return result
-        except Exception:
-            logger.debug("No LLM available for enhancement")
-            return None
+    try:
+        result = llm_fn(prompt)
+        if isinstance(result, str) and result.strip():
+            return result
+    except Exception as e:
+        logger.warning("LLM enhancement failed: %s", e)
 
     return None
 

--- a/tests/darnit_baseline/remediation/test_enhancer.py
+++ b/tests/darnit_baseline/remediation/test_enhancer.py
@@ -1,0 +1,107 @@
+# from unittest.mock import patch
+
+from darnit_baseline.remediation.enhancer import (
+    _enhance_architecture,
+    enhance_generated_file,
+    get_enhancement_type,
+    is_enhanceable,
+)
+
+
+def test_is_enhanceable_architecture_file():
+    assert is_enhanceable("ARCHITECTURE.md") is True
+    assert is_enhanceable("/tmp/project/ARCHITECTURE.md") is True
+
+
+def test_get_enhancement_type_architecture_file():
+    assert get_enhancement_type("ARCHITECTURE.md") == "architecture"
+    assert get_enhancement_type("/tmp/project/ARCHITECTURE.md") == "architecture"
+
+
+def test_enhance_architecture_uses_provided_llm_fn(tmp_path):
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "app.py").write_text(
+        '"""Application entrypoint."""\n\n'
+        "def main():\n"
+        "    return None\n",
+        encoding="utf-8",
+    )
+
+    prompts: list[str] = []
+
+    def fake_llm(prompt: str) -> str:
+        prompts.append(prompt)
+        return "# Enhanced Architecture\n\nAdded component descriptions."
+
+    result = _enhance_architecture(
+        "# Architecture\n\n| Component | Path |\n| --- | --- |\n| App | src/app.py |\n",
+        str(tmp_path),
+        llm_fn=fake_llm,
+    )
+
+    assert result == "# Enhanced Architecture\n\nAdded component descriptions."
+    assert len(prompts) == 1
+    assert "Application entrypoint." in prompts[0]
+    assert "Current ARCHITECTURE.md" in prompts[0]
+
+
+def test_enhance_architecture_without_llm_fn_returns_none(tmp_path):
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "app.py").write_text(
+        '"""Application entrypoint."""\n\n'
+        "def main():\n"
+        "    return None\n",
+        encoding="utf-8",
+    )
+
+    result = _enhance_architecture(
+        "# Architecture\n\n| Component | Path |\n| --- | --- |\n| App | src/app.py |\n",
+        str(tmp_path),
+    )
+
+    assert result is None
+
+
+def test_enhance_generated_file_uses_injected_llm_fn(tmp_path):
+    architecture_file = tmp_path / "ARCHITECTURE.md"
+    architecture_file.write_text(
+        "# Architecture\n\n| Component | Path |\n| --- | --- |\n| App | src/app.py |\n",
+        encoding="utf-8",
+    )
+
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "app.py").write_text(
+        '"""Application entrypoint."""\n\n'
+        "def main():\n"
+        "    return None\n",
+        encoding="utf-8",
+    )
+
+    def fake_llm(_prompt: str) -> str:
+        return "# Enhanced Architecture\n\nAdded component descriptions."
+
+    result = enhance_generated_file(
+        str(architecture_file),
+        str(tmp_path),
+        "architecture",
+        llm_fn=fake_llm,
+    )
+
+    assert result == "# Enhanced Architecture\n\nAdded component descriptions."
+
+
+def test_enhance_generated_file_returns_none_for_unknown_type(tmp_path):
+    generated_file = tmp_path / "README.md"
+    generated_file.write_text("# README\n", encoding="utf-8")
+
+    result = enhance_generated_file(
+        str(generated_file),
+        str(tmp_path),
+        "unknown",
+    )
+
+    assert result is None
+


### PR DESCRIPTION
## Summary

Fixes #167.

This PR removes the private `_call_llm` fallback import from the baseline remediation enhancer. LLM-based enhancement now relies only on an injected `llm_fn` callable, and gracefully returns `None` when no LLM callable is provided.

Added tests covering:
- enhancement using a provided `llm_fn`
- graceful fallback when no `llm_fn` is provided
- public enhancer behavior through `enhance_generated_file`

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist

If this PR modifies the darnit framework (`packages/darnit/`):

- [ ] Updated framework spec (`openspec/specs/framework-design/spec.md`) if behavior changed
- [ ] Ran `uv run python scripts/validate_sync.py --verbose` and it passes
- [ ] Ran `uv run python scripts/generate_docs.py` and committed any doc changes

## Control/TOML Changes Checklist

If this PR modifies controls or TOML configuration:

- [ ] Control metadata defined in TOML (not Python code)
- [ ] SARIF fields (description, severity, help_url) included where appropriate
- [ ] Ran validation to confirm TOML schema compliance

## Testing

- [x] Tests pass locally (`uv run pytest tests/ -v`)
- [x] Added tests for new functionality (if applicable)
- [x] Linting passes (`uv run ruff check .`)

## Additional Notes

Local test run:

```bash
uv run pytest tests/darnit_baseline/remediation/test_enhancer.py