### PR TITLE
fix(baseline): AC-03 help_md now surfaces programmatic remediation

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -558,13 +558,25 @@ when = { platform = "github" }
 docs_url = "https://baseline.openssf.org/versions/2025-10-10#OSPS-AC-03.01"
 help_md = """Enable branch protection to require pull requests.
 
-**Remediation:**
+**Auto-remediation (recommended):**
+Darnit can configure this for you via the GitHub Branch Protection API.
+
+- MCP tool: `enable_branch_protection` — accepts `owner`, `repo`, `branch`,
+  `required_approvals`, `enforce_admins`, and related flags. The defaults
+  satisfy OSPS-AC-03.01 + OSPS-AC-03.02 + OSPS-QA-07.01 in a single call.
+- TOML remediation: the control's `[remediation]` block uses an `api_call`
+  handler against `PUT /repos/{owner}/{repo}/branches/{branch}/protection`.
+
+Requires the `gh` CLI to be authenticated with a token holding `repo` scope.
+
+**Manual fallback:**
 1. Go to Repository Settings → Branches
-2. Add branch protection rule for main/master
+2. Add a branch protection rule for main/master
 3. Enable 'Require a pull request before merging'
 
 **References:**
-- [GitHub Branch Protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [GitHub Branch Protection (UI)](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [REST API: branch protection](https://docs.github.com/en/rest/branches/branch-protection)
 """
 
 # ExecPass: Use gh CLI to check branch protection
@@ -610,13 +622,25 @@ docs_url = "https://baseline.openssf.org/versions/2025-10-10#OSPS-AC-03.02"
 location_hint = ".github/settings.yml"
 help_md = """Protect primary branch from deletion.
 
-**Remediation:**
+**Auto-remediation (recommended):**
+Darnit can configure this for you via the GitHub Branch Protection API.
+A protected branch automatically disallows deletion.
+
+- MCP tool: `enable_branch_protection` (same tool that satisfies
+  OSPS-AC-03.01; the API call sets `allow_deletions=false` by default).
+- TOML remediation: the control's `[remediation]` block uses an `api_call`
+  handler against `PUT /repos/{owner}/{repo}/branches/{branch}/protection`.
+
+Requires the `gh` CLI to be authenticated with a token holding `repo` scope.
+
+**Manual fallback:**
 1. Go to Repository Settings → Branches
-2. Add branch protection rule for main/master
-3. The rule automatically prevents branch deletion
+2. Add a branch protection rule for main/master
+3. Confirm 'Allow deletions' is unchecked (default for new rules)
 
 **References:**
-- [GitHub Branch Protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [GitHub Branch Protection (UI)](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [REST API: branch protection](https://docs.github.com/en/rest/branches/branch-protection)
 """
 
 [[controls."OSPS-AC-03.02".passes]]


### PR DESCRIPTION
## Summary

Both `OSPS-AC-03.01` (PreventDirectCommits) and `OSPS-AC-03.02` (PreventBranchDeletion) already have:

- An `[api_call]` remediation handler in `openssf-baseline.toml` targeting `PUT /repos/{owner}/{repo}/branches/{branch}/protection`.
- A corresponding MCP tool `enable_branch_protection` in `darnit-baseline/src/darnit_baseline/tools.py` that wraps the same endpoint.

But the `help_md` text shown to users in the audit output described only **manual** steps ("Go to Repository Settings → Branches"). The text predates the programmatic remediation work and was never updated, so users running an audit conclude darnit cannot fix the issue — even though it can.

This PR rewrites `help_md` for both controls to surface the automated path first, with the manual instructions preserved as a clearly-labelled fallback.

## Before / after

Before:

```markdown
**Remediation:**
1. Go to Repository Settings → Branches
2. Add branch protection rule for main/master
3. Enable 'Require a pull request before merging'
```

After:

```markdown
**Auto-remediation (recommended):**
Darnit can configure this for you via the GitHub Branch Protection API.

- MCP tool: `enable_branch_protection` — accepts `owner`, `repo`, …
- TOML remediation: …api_call against PUT …/branch-protection

**Manual fallback:**
1. Go to Repository Settings → Branches
…
```

## Scope

Only AC-03.01 and AC-03.02. Other controls (QA-01.02, GV-03.01, several others touching repo Settings) likely have the same staleness — those are tracked separately in #266 for a systematic audit.

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run python scripts/validate_sync.py --verbose` → PASSED
- [x] `uv run python scripts/generate_docs.py` → no diff in `docs/generated/`
- [x] `uv run pytest tests/darnit_baseline -q` → 659 passed, 6 skipped

Tracks #266 (partial — AC-03 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)