### PR TITLE
fix(baseline): pin tree-sitter-language-pack<1.8 (closes audit-time crash)

### DIFF
--- a/packages/darnit-baseline/pyproject.toml
+++ b/packages/darnit-baseline/pyproject.toml
@@ -23,7 +23,13 @@ classifiers = [
 dependencies = [
     "darnit-core>=0.1.0",
     "tree-sitter>=0.25",
-    "tree-sitter-language-pack>=1.5",
+    # tree-sitter-language-pack 1.8+ changed two APIs the threat-model
+    # pipeline depends on:
+    #   1. parser.parse() now wants str only (not bytes) and exposes a
+    #      separate parse_bytes() for the old contract.
+    #   2. tree.root_node became a callable method instead of a property.
+    # Cap at <1.8 until darnit's parsing layer supports both shapes. See #268.
+    "tree-sitter-language-pack>=1.5,<1.8",
 ]
 
 [project.urls]

--- a/packages/darnit-baseline/src/darnit_baseline/threat_model/parsing.py
+++ b/packages/darnit-baseline/src/darnit_baseline/threat_model/parsing.py
@@ -111,6 +111,14 @@ def parse_source(language_name: str, content: bytes) -> Any:
     with ``ERROR`` nodes for the broken portions. Callers can inspect
     ``tree.root_node.has_error`` for diagnostic logging but the remaining
     captures are still valid.
+
+    Compatibility: the ``parser.parse()`` argument type changed between
+    ``tree-sitter-language-pack`` releases — 1.5.x accepts ``bytes``,
+    1.8.x accepts only ``str``. We try ``bytes`` first (the historical
+    contract and what the rest of darnit's pipeline carries around) and
+    fall back to a UTF-8 decode on TypeError. Bytes that aren't valid
+    UTF-8 are decoded with ``errors="replace"`` so a single odd file
+    doesn't sink the whole audit.
     """
 
     if not isinstance(content, (bytes, bytearray)):
@@ -118,7 +126,12 @@ def parse_source(language_name: str, content: bytes) -> Any:
             f"parse_source expected bytes, got {type(content).__name__}"
         )
     parser = get_tree_sitter_parser(language_name)
-    tree = parser.parse(bytes(content))
+    try:
+        tree = parser.parse(bytes(content))
+    except TypeError:
+        # tree-sitter-language-pack >= 1.8 binding wants str, not bytes.
+        # Decode and retry.
+        tree = parser.parse(bytes(content).decode("utf-8", errors="replace"))
     if tree.root_node.has_error:
         logger.debug(
             "tree-sitter reported parse errors for %s (recoverable)", language_name

--- a/tests/darnit_baseline/threat_model/test_parsing.py
+++ b/tests/darnit_baseline/threat_model/test_parsing.py
@@ -100,3 +100,70 @@ def test_parse_source_recovers_from_syntax_errors() -> None:
 def test_unsupported_language_raises() -> None:
     with pytest.raises(ValueError, match="Unsupported language"):
         parse_source("rust", b"fn main() {}")
+
+
+def test_parse_source_handles_both_language_pack_apis(monkeypatch) -> None:
+    """Regression: tree-sitter-language-pack changed parser.parse() arg
+    type between releases — 1.5.x took bytes, 1.8.x takes str only.
+    parse_source() must work against either by trying bytes first and
+    falling back to a UTF-8 decode on TypeError.
+
+    Simulates the 1.8.x binding by monkeypatching the parser to reject
+    bytes and only accept str.
+    """
+    from darnit_baseline.threat_model import parsing
+
+    real_parser = parsing.get_tree_sitter_parser("python")
+
+    class StrOnlyParserWrapper:
+        """Mimics the tree-sitter-language-pack 1.8 binding's parse()
+        which raises TypeError unless given a str."""
+
+        def parse(self, source):
+            if not isinstance(source, str):
+                raise TypeError(
+                    "argument 'source': 'bytes' object is not an instance of 'str'"
+                )
+            return real_parser.parse(source.encode("utf-8"))
+
+    monkeypatch.setattr(
+        parsing, "get_tree_sitter_parser", lambda _lang: StrOnlyParserWrapper()
+    )
+
+    # Even though the underlying parser rejects bytes, parse_source must
+    # still succeed by transparently falling back to the str path.
+    tree = parse_source("python", b"def foo(): pass\n")
+    assert tree is not None
+    query = make_query("python", "(identifier) @id")
+    matches = list(run_query(query, tree.root_node))
+    assert any(
+        match[1].get("id", []) and parsing.node_text(match[1]["id"][0], b"def foo(): pass\n") == "foo"
+        if isinstance(match, tuple) and len(match) >= 2
+        else False
+        for match in matches
+    ) or len(matches) >= 1  # at least one identifier captured
+
+
+def test_parse_source_handles_non_utf8_bytes_under_str_binding(monkeypatch) -> None:
+    """Regression: when the binding requires str, parse_source must decode
+    bytes safely even if they contain invalid UTF-8 sequences. The decode
+    uses errors='replace' so a single bad byte doesn't tank the audit.
+    """
+    from darnit_baseline.threat_model import parsing
+
+    real_parser = parsing.get_tree_sitter_parser("python")
+
+    class StrOnlyParserWrapper:
+        def parse(self, source):
+            if not isinstance(source, str):
+                raise TypeError("source must be str")
+            return real_parser.parse(source.encode("utf-8"))
+
+    monkeypatch.setattr(
+        parsing, "get_tree_sitter_parser", lambda _lang: StrOnlyParserWrapper()
+    )
+
+    # Embed a bare 0xFF byte (invalid UTF-8 start) into otherwise-valid Python.
+    naughty = b"def foo():\n    return '\xff'\n"
+    tree = parse_source("python", naughty)
+    assert tree is not None  # didn't raise UnicodeDecodeError


### PR DESCRIPTION
## Summary

Pins `tree-sitter-language-pack>=1.5,<1.8` in `darnit-baseline`'s `pyproject.toml`. Newer versions broke two APIs the threat-model pipeline depends on and were silently being picked up by fresh `uv tool install` runs.

Bug repro: `parsing.py:121` raises `TypeError: argument 'source': 'bytes' object is not an instance of 'str'` because 1.8 switched `parser.parse()` to accept only `str` (with a separate `parse_bytes()` for the old contract). `discover_all()` bails on the first parsed file and OSPS-SA-03.02 surfaces a generic "Executed 1 remediation handler(s)" with no traceback.

There's also a deeper API change in 1.8: `tree.root_node` became a callable method instead of a property. 23 production call sites would need shim updates to support both shapes. That's tracked separately in **#268**; this PR is the stop-gap.

## Changes

- `packages/darnit-baseline/pyproject.toml`: cap `tree-sitter-language-pack<1.8`, with an explanatory comment.
- `packages/darnit-baseline/src/darnit_baseline/threat_model/parsing.py`: defensive `parse()` fallback — try `bytes` first, decode and retry on `TypeError`. Harmless under 1.5.x where the bytes call always succeeds.
- `tests/darnit_baseline/threat_model/test_parsing.py`: two new regression tests monkeypatching the parser to mimic the 1.8 contract and asserting `parse_source()` degrades cleanly. Also covers non-UTF-8 bytes under the str path.

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run pytest tests/darnit_baseline -q` → 661 passed, 6 skipped (was 659 before, +2 new)
- [x] Bug reproduced against `tree-sitter-language-pack 1.8.1` before the fix and confirmed via `parse_source()` smoke test
- [x] Workspace venv (1.5.0) still works end-to-end against the gittuf demo target

## Closes / tracks

- Stop-gap for #268 (full 1.8+ API support — separate scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)