### PR TITLE
feat(baseline): AC-01.01 — fall back to user-account 2FA for user-owned repos

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -443,15 +443,30 @@ description = "Require multi-factor authentication for organization members"
 tags = { level = 1, domain = "AC", security_severity = 9.0, access-control = true, authentication = true }
 when = { platform = "github" }
 docs_url = "https://baseline.openssf.org/versions/2025-10-10#OSPS-AC-01.01"
-help_md = """Enable MFA for all organization members with elevated permissions.
+help_md = """Enable MFA for all organization members (or for a solo-maintainer user account).
 
-**Remediation:**
-1. Go to Organization Settings → Security
-2. Enable 'Require two-factor authentication for everyone'
-3. Set a grace period for existing members to enable MFA
+**Two valid paths depending on repository ownership:**
+
+- **Organization-owned repo (canonical):** the org enforces 2FA for every
+  member. Check via `gh api /orgs/<owner>` → `two_factor_requirement_enabled`.
+  Remediate: Organization Settings → Authentication security → enable
+  'Require two-factor authentication for everyone in the organization',
+  with a grace period for existing members.
+- **User-owned repo (fallback):** the maintainer running the audit has 2FA
+  enabled on their personal account. Check via `gh api /user` →
+  `two_factor_authentication` (requires the `gh` token to have the
+  `read:user` scope: run `gh auth refresh -s read:user`). Remediate: the
+  account owner's GitHub Settings → Password and authentication →
+  'Two-factor authentication'.
+
+The user-owned fallback is a liberal interpretation of the OpenSSF Baseline
+control (which is org-scoped by design). It covers the common case of a
+solo maintainer on a personal account; it does NOT substitute for org-wide
+enforcement when the repository sits inside an organization.
 
 **References:**
 - [GitHub MFA Documentation](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa)
+- [GitHub Org 2FA Requirements](https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-two-factor-authentication-for-your-organization)
 """
 
 # ExecPass: Use gh CLI to check MFA requirement
@@ -466,11 +481,33 @@ output_format = "json"
 expr = 'has(output.json.two_factor_requirement_enabled) && output.json.two_factor_requirement_enabled == true'
 timeout = 30
 
+# Fallback for user-owned repos: org enforcement isn't possible (the owner
+# isn't an org), so check whether the authenticated maintainer has 2FA
+# enabled on their personal account. Requires `gh auth refresh -s read:user`
+# so the token can read the `two_factor_authentication` field on /user.
+#
+# This is a deliberately liberal interpretation: the canonical spec is
+# org-scoped, and this fallback can produce a false positive on an
+# *org*-owned repo where the org doesn't enforce 2FA but the maintainer
+# running the audit happens to. Tolerable for solo-maintainer / user-owned
+# repos (the common case it's intended to cover); narrowing the trigger
+# to user-owned repos is tracked separately and will move when darnit
+# auto-detects owner type.
+[[controls."OSPS-AC-01.01".passes]]
+handler = "exec"
+command = ["gh", "api", "/user"]
+pass_exit_codes = [0]
+fail_exit_codes = [1]
+output_format = "json"
+expr = 'has(output.json.two_factor_authentication) && output.json.two_factor_authentication == true'
+timeout = 30
+
 [[controls."OSPS-AC-01.01".passes]]
 handler = "manual"
 steps = [
     "Navigate to Organization Settings → Security",
     "Verify 'Require two-factor authentication' is enabled",
+    "(For user-owned repos) Verify the maintainer has 2FA enabled on their account: Settings → Password and authentication",
 ]
 
 [controls."OSPS-AC-01.01".remediation]


### PR DESCRIPTION
## Summary

`OSPS-AC-01.01` is canonically org-scoped: it asks whether an organization enforces 2FA for all members. On a user-owned repo (solo maintainer, personal account), the existing exec pass calls `gh api /orgs/<user>`, gets a 404, and the control fails — even when the maintainer's account itself has 2FA enabled.

This PR adds a second exec pass that runs *after* the org check: if `gh api /user` shows `two_factor_authentication: true`, the control passes. The original org check still wins when applicable; the user-account fallback only fires when the org check returned nothing useful.

Discovered during the demo dry-run against `mlieberman85/darnit-gittuf-demo` (context: feature 014 / #262).

## Behavior

Sieve passes in order; pipeline stops at first conclusive result.

| Repo owner | gh has read:user? | Pass 1 (org) | Pass 2 (user) | Result |
|---|---|---|---|---|
| Org enforces 2FA | any | ✓ PASS | (skipped) | PASS |
| Org doesn't enforce 2FA, maintainer 2FA on | yes | ✗ | ✓ PASS | PASS *(see caveat below)* |
| Org doesn't enforce 2FA, maintainer 2FA on | no | ✗ | ✗ (no scope) | falls to manual |
| User owns repo, maintainer 2FA on | yes | ✗ (404) | ✓ PASS | PASS |
| User owns repo, maintainer 2FA off | yes | ✗ (404) | ✗ | falls to manual |
| User owns repo | no | ✗ (404) | ✗ (no scope) | falls to manual |

## Known caveat (documented in help_md)

The fallback is liberal. On an org-owned repo where the org does **not** enforce 2FA but the auditing maintainer happens to have 2FA on their own account, this fallback produces a false-positive PASS. Tolerable for the solo-maintainer / user-owned case it's intended to cover; tightening the fallback to fire only when the owner is detected as a User is its own follow-up (requires darnit to auto-detect owner type, which it doesn't today).

The help_md text spells out both paths and the caveat verbatim so audit consumers see the limitation.

## User-facing prerequisite

For the user-account fallback to actually evaluate, the `gh` token needs the `read:user` scope:

```bash
gh auth refresh -s read:user
```

Without that scope, `gh api /user` returns the public profile and `two_factor_authentication` is absent. The pass then fails cleanly and falls through to the manual step — no harm, just no benefit.

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run python scripts/validate_sync.py --verbose` → PASSED
- [x] `uv run python scripts/generate_docs.py` → no diff in `docs/generated/`
- [x] `uv run pytest tests/darnit_baseline -q` → 661 passed, 6 skipped

## Follow-up tracked elsewhere

- Auto-detect owner type so this fallback only fires for user-owned repos (avoids the org false-positive case). Will file a separate issue once this lands.
- darnit's `enable_branch_protection` and similar remediation paths surface terse "Executed N handlers" messages instead of per-control API response bodies — discovered during the same demo dry-run. Worth its own bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)