### PR TITLE
fix(baseline): AC-01.01 — drop fail_exit_codes so /user fallback actually runs

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -476,7 +476,13 @@ location_hint = ".github/settings.yml"
 handler = "exec"
 command = ["gh", "api", "/orgs/$OWNER"]
 pass_exit_codes = [0]
-fail_exit_codes = [1]
+# Intentionally NOT setting fail_exit_codes: when the repo owner isn't an
+# org (user-owned repos), `gh api /orgs/<user>` returns 404 and gh exits
+# non-zero. We want that case to be INCONCLUSIVE so the sieve falls
+# through to the /user pass below, not a definitive FAIL. The CEL expr
+# below evaluates only when the command succeeded (exit 0); a real org
+# without 2FA enforcement returns exit 0 with the field present-and-false,
+# which still flips this pass to FAIL via the expr.
 output_format = "json"
 expr = 'has(output.json.two_factor_requirement_enabled) && output.json.two_factor_requirement_enabled == true'
 timeout = 30
@@ -493,11 +499,14 @@ timeout = 30
 # repos (the common case it's intended to cover); narrowing the trigger
 # to user-owned repos is tracked separately and will move when darnit
 # auto-detects owner type.
+#
+# Same fail_exit_codes omission as above: if /user fails (no read:user
+# scope, auth error), fall through to the manual handler instead of
+# marking the control FAIL outright.
 [[controls."OSPS-AC-01.01".passes]]
 handler = "exec"
 command = ["gh", "api", "/user"]
 pass_exit_codes = [0]
-fail_exit_codes = [1]
 output_format = "json"
 expr = 'has(output.json.two_factor_authentication) && output.json.two_factor_authentication == true'
 timeout = 30


### PR DESCRIPTION
## Summary

PR #271 added a `/user`-account 2FA fallback pass to `OSPS-AC-01.01` for user-owned repos, but missed that the first (org) pass set `fail_exit_codes = [1]`. On a user-owned repo, `gh api /orgs/<user>` returns 404 → gh exits 1 → that matches `fail_exit_codes` → the sieve marks the control **FAIL definitively** and stops before the `/user` fallback ever fires.

## Repro

```bash
# Fresh clone of mlieberman85/darnit-gittuf-demo, gh authed with read:user scope:
gh api /user --jq '{login, two_factor_authentication}'
# → {"login":"mlieberman85","two_factor_authentication":true}

darnit audit
# → OSPS-AC-01.01 still reports FAIL even though the maintainer's account 2FA is on
```

## Fix

Remove `fail_exit_codes = [1]` from both AC-01.01 passes.

### New pass semantics

| Exit code | CEL expr | Result |
|---|---|---|
| 0 | true | PASS |
| 0 | false | FAIL *(real signal: org with 2FA off, or user-account with 2FA off)* |
| non-zero | n/a | **INCONCLUSIVE**, pipeline continues to next pass |

Concretely:

- Org repo, org enforces 2FA → org pass: exit 0, expr true → PASS ✓
- Org repo, org does not enforce 2FA → org pass: exit 0, expr false → FAIL ✓
- User repo → org pass: exit 1 (404) → INCONCLUSIVE → /user pass evaluates
- User repo + read:user scope + 2FA on → /user pass: exit 0, expr true → PASS ✓
- User repo + read:user scope + 2FA off → /user pass: exit 0, expr false → FAIL ✓
- User repo without read:user scope → /user pass: exit 0, expr false (field absent) → FAIL → falls to manual
- /user API itself errors → /user pass: exit non-zero → INCONCLUSIVE → falls to manual

This is the behaviour PR #271's help_md promised; it just didn't land because of this short-circuit.

## Discovery context

Found by a second Claude session auditing `mlieberman85/darnit-gittuf-demo` after PR #271 merged. The audit kept reporting FAIL despite the `/user` fallback being in place. Tracing through the sieve passes surfaced the `fail_exit_codes = [1]` short-circuit on pass 0.

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run python scripts/validate_sync.py --verbose` → PASSED
- [x] `uv run python scripts/generate_docs.py` → no diff in `docs/generated/`
- [x] `uv run pytest tests/darnit_baseline -q` → 661 passed, 6 skipped
- [ ] Manual: re-run `darnit audit` against `mlieberman85/darnit-gittuf-demo` after this lands → AC-01.01 lands as PASS via the `/user` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)