### PR TITLE
fix(baseline): AC-04.02 — accept `permissions: read-all` shorthand

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -2749,8 +2749,16 @@ handler = "pattern"
 files = [".github/workflows/*.yml", ".github/workflows/*.yaml"]
 pass_if_any = false
 
+# Accept any of the following least-privilege forms:
+#   1. `permissions: read-all`            — top-level shorthand, all read-only
+#   2. `permissions: {}`                  — explicit no-permissions
+#   3. Indented block keys (`contents: read`, `issues: write`, …)
+#
+# Explicitly NOT accepted: `permissions: write-all` (broad write access, the
+# anti-pattern this control exists to catch) and workflows that omit
+# `permissions` entirely (would inherit GITHUB_TOKEN's repo-wide default).
 [controls."OSPS-AC-04.02".passes.pattern.patterns]
-scoped_permission = '^\s+(contents|issues|pull-requests|packages|actions|security-events|id-token|attestations|deployments|statuses|checks):\s*(read|write|none)'
+scoped_permission = '^\s*permissions:\s*(read-all|\{\s*\})\s*$|^\s+(contents|issues|pull-requests|packages|actions|security-events|id-token|attestations|deployments|statuses|checks):\s*(read|write|none)'
 
 [[controls."OSPS-AC-04.02".passes]]
 handler = "manual"


### PR DESCRIPTION
## Summary

`OSPS-AC-04.02` (ScopedPermissions) checks `.github/workflows/*.{yml,yaml}` for least-privilege permission scoping. The pattern handler runs with `pass_if_any = false`, so **every** workflow file must match the regex.

The old regex only accepted the explicit block form:

```yaml
permissions:
  contents: read
  issues: write
```

But GitHub Actions also supports a top-level shorthand that's *more* restrictive than most block forms:

```yaml
permissions: read-all   # all permissions read-only
permissions: {}         # no permissions at all
```

Workflows using these shorthand forms were misreported as least-privilege failures.

## Impact

Discovered on `mlieberman85/darnit-gittuf-demo` (the demo target for feature 014 / #262). 11 of 12 gittuf workflows use `permissions: read-all`. Under the old regex only **3/12** matched (those that *also* had explicit job-level block permissions); the other 9 were misreported as failures despite being strictly compliant.

## Fix

Widen the regex to ALSO accept `permissions: read-all` and `permissions: {}`. Block form still matches. `permissions: write-all` (the anti-pattern this control exists to catch) is still rejected.

### Before / after

```regex
# Before
^\s+(contents|issues|pull-requests|packages|actions|security-events|id-token|attestations|deployments|statuses|checks):\s*(read|write|none)

# After
^\s*permissions:\s*(read-all|\{\s*\})\s*$|^\s+(contents|issues|pull-requests|packages|actions|security-events|id-token|attestations|deployments|statuses|checks):\s*(read|write|none)
```

Plus a comment block above explaining accepted/rejected forms.

### Smoke-test matrix against gittuf demo workflows

| Workflow | Before | After |
|---|---|---|
| ci-locale.yml | ✗ | ✓ |
| ci.yml | ✗ | ✓ |
| codeql.yml | ✓ | ✓ |
| coverage.yml | ✗ | ✓ |
| docs.yml | ✗ | ✓ |
| gittuf-verify.yml | ✗ | ✓ |
| lint.yml | ✗ | ✓ |
| release.yml | ✓ | ✓ |
| run-demo.yml | ✗ | ✓ |
| sca.yml | ✓ | ✓ |
| scorecard.yml | ✓ | ✓ |
| ubuntu-2204.yml | ✗ | ✓ |
| **3/12 → 12/12** | | |

### Anti-pattern still caught

- `permissions: write-all` → still rejected (broad write access)
- Workflows omitting `permissions:` entirely → still rejected (inherits GITHUB_TOKEN's repo-wide default)

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run python scripts/validate_sync.py --verbose` → PASSED
- [x] `uv run python scripts/generate_docs.py` → no diff in `docs/generated/`
- [x] `uv run pytest tests/darnit_baseline -q` → 661 passed, 6 skipped
- [x] Smoke test against `mlieberman85/darnit-gittuf-demo` workflows (12/12 pass; `write-all` still rejected; missing-permissions still rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)