### PR TITLE
fix(baseline): BR-02.02 — replace broken `gh release list --json assets` with `gh api`

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -2794,11 +2794,21 @@ help_md = """Ensure release assets are properly versioned.
 3. Use consistent naming conventions
 """
 
+# `gh release list --json …` only exposes list-level metadata fields
+# (tagName, name, publishedAt, …); it does NOT expose per-release `assets`.
+# An earlier version of this pass invoked `gh release list --json tagName,assets`,
+# which always exited 1 with "Unknown JSON field: assets" — meaning the
+# control could never PASS on any repo. The right shape uses the underlying
+# REST endpoint, which DOES return per-release `assets` on each item.
 [[controls."OSPS-BR-02.02".passes]]
 handler = "exec"
-command = ["gh", "release", "list", "--json", "tagName,assets", "--limit", "5"]
+command = ["gh", "api", "/repos/$OWNER/$REPO/releases?per_page=5"]
 pass_exit_codes = [0]
 output_format = "json"
+# Each release in the response array has an `assets` array (objects with
+# name, browser_download_url, …). The control's intent is "release assets
+# are clearly associated with release IDs" — satisfied when at least one
+# release has ≥1 asset listed beneath its tag.
 expr = 'output.json.exists(r, size(r.assets) > 0)'
 timeout = 30
 


### PR DESCRIPTION
## Summary

`OSPS-BR-02.02` (ClearAssetAssociation) invoked `gh release list --json tagName,assets`, but `gh release list --json` doesn't expose an `assets` field. The command always exited with code 1 and the error message:

```
Unknown JSON field: "assets"
Available fields:
  createdAt
  isDraft
  isImmutable
  isLatest
  isPrerelease
  name
  publishedAt
  tagName
```

That meant the control could never PASS on any repo — even one with explicit per-release assets clearly tagged with version IDs.

Closes #274.

## Fix

Swap to the REST API endpoint that DOES return per-release assets:

```diff
- command = ["gh", "release", "list", "--json", "tagName,assets", "--limit", "5"]
+ command = ["gh", "api", "/repos/$OWNER/$REPO/releases?per_page=5"]
```

The existing CEL expression — `output.json.exists(r, size(r.assets) > 0)` — works against the new response shape unchanged. Each release object in the array carries an `assets` array (asset objects with `name`, `browser_download_url`, etc.).

## Smoke test (against `mlieberman85/darnit-gittuf-demo` — feature 014 demo repo)

```bash
$ gh api '/repos/mlieberman85/darnit-gittuf-demo/releases?per_page=5' \
    --jq 'map({tag: .tag_name, asset_count: (.assets | length)})'
[{"asset_count":1,"tag":"v0.14.1"}]
```

CEL eval: `size(r.assets) > 0 → true` → BR-02.02 PASSES.

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run python scripts/validate_sync.py --verbose` → PASSED
- [x] `uv run python scripts/generate_docs.py` → no diff in `docs/generated/`
- [x] `uv run pytest tests/darnit_baseline -q` → 661 passed, 6 skipped
- [x] Smoke test confirms CEL evaluates `true` against a repo with assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)