### PR TITLE
feat(baseline): AC-04.02 — zizmor `excessive-permissions` deep audit (primary)

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -2744,6 +2744,26 @@ help_md = """Minimize CI/CD job permissions.
 4. Avoid using `write-all` or `admin` permissions
 """
 
+# Primary: zizmor's `excessive-permissions` deep audit. zizmor models per-step
+# action requirements and flags workflow- or job-level grants broader than the
+# steps actually exercise — the semantic least-privilege check a regex can't do.
+# Matches BR-01.01's zizmor invocation shape: pass_exit_codes covers zizmor's
+# severity-banded codes (0=clean, 10-14=findings of varying severity). When
+# zizmor isn't installed the exec exits 127 (not in pass_exit_codes) →
+# INCONCLUSIVE → the pipeline falls through to the structural pattern check.
+[[controls."OSPS-AC-04.02".passes]]
+handler = "exec"
+command = ["zizmor", "--format", "json", "--offline", "$PATH"]
+pass_exit_codes = [0, 10, 11, 12, 13, 14]
+output_format = "json"
+expr = '!output.json.exists(f, f.ident == "excessive-permissions")'
+timeout = 60
+
+# Fallback: structural pattern check. Confirms each workflow has SOME form
+# of explicit least-privilege permissions (block form, `read-all`, or `{}`).
+# Less precise than zizmor — can't tell if the declared permissions are
+# *minimal* for what the workflow does — but catches the obvious anti-pattern
+# of omitting permissions entirely or using `write-all`.
 [[controls."OSPS-AC-04.02".passes]]
 handler = "pattern"
 files = [".github/workflows/*.yml", ".github/workflows/*.yaml"]
@@ -2758,6 +2778,7 @@ steps = [
     "Review workflow permissions in .github/workflows/",
     "Verify permissions are scoped to specific resources (contents, issues, etc.)",
     "Confirm read-only access is used where write access isn't needed",
+    "(Optional) Install zizmor and run `zizmor .github/workflows/` for a deep audit",
 ]
 
 [controls."OSPS-AC-04.02".remediation]


### PR DESCRIPTION
## Summary

The structural pattern check on `OSPS-AC-04.02` (ScopedPermissions) only sees workflow *shape* — does each workflow have a `permissions` block? Are the keys legal? It cannot see whether the declared permissions are **minimal for what the workflow actually does**. That requires semantic understanding of each step's API surface, which is exactly what zizmor's `excessive-permissions` audit provides.

Darnit already shells out to zizmor for `OSPS-BR-01.01` (template-injection). This PR adds an identical primary pass to AC-04.02 keyed on the `excessive-permissions` audit.

Related to #273 (read-all shorthand fix to the structural pattern — separate, can land in either order).

## Stacked pass chain

| Order | Handler | Trigger | What it checks |
|---|---|---|---|
| 1 | exec (zizmor) | when zizmor on PATH | semantic least-privilege deep audit |
| 2 | pattern | zizmor exits non-zero (e.g., not installed) → INCONCLUSIVE | structural least-privilege check |
| 3 | manual | both above inconclusive | reviewer guidance (with `zizmor` install hint) |

`pass_exit_codes = [0, 10, 11, 12, 13, 14]` covers zizmor's severity-banded exit codes. When zizmor isn't installed the exec exits 127, which isn't in that list → INCONCLUSIVE → falls through to the existing pattern. Old behaviour preserved for environments without zizmor.

## Smoke test against `mlieberman85/darnit-gittuf-demo` (gittuf @ v0.14.1)

```bash
$ zizmor --format json --offline .github/workflows \
    | jq '[.[] | select(.ident == "excessive-permissions")] | length'
1
```

zizmor catches **1 excessive-permissions finding** in `.github/workflows/ci.yml` (Medium severity) that the structural pattern misses. Under the old check the workflow passed structurally; under the new chain AC-04.02 correctly identifies a real least-privilege remediation target.

This is the kind of "structural check says fine, semantic audit says no" signal that demonstrates darnit's value beyond a regex-based reading.

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run python scripts/validate_sync.py --verbose` → PASSED
- [x] `uv run python scripts/generate_docs.py` → no diff in `docs/generated/`
- [x] `uv run pytest tests/darnit_baseline -q` → 661 passed, 6 skipped
- [x] Smoke test confirms `excessive-permissions` is the correct zizmor `ident` and the CEL expression matches the JSON shape

## Follow-up scope (out of this PR)

zizmor's audit catalog at https://docs.zizmor.sh/audits/ has several other audits that map to existing OSPS controls. Worth tracking:

| zizmor `ident` | candidate OSPS control |
|---|---|
| `impostor-commit` | BR-04.* (release integrity) |
| `unpinned-uses` | BR-06.* (release signing / dep-pinning) |
| `dangerous-triggers` | BR-01.02 (branch name handling) |
| `cache-poisoning` | could be a new control or BR-07.* extension |

Not in scope here; this PR just adds the one audit that directly maps to AC-04.02's existing intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)