### PR TITLE
fix(skills): darnit-remediate honors the verification-prompt-block for threat-model drafts

### DIFF
--- a/packages/darnit/src/darnit/skills/darnit-remediate/SKILL.md
+++ b/packages/darnit/src/darnit/skills/darnit-remediate/SKILL.md
@@ -36,7 +36,24 @@ This single call creates the branch, applies all remediations, and commits. Do N
 
 ### 3. Review generated files (quality check)
 
-Read the generated files. The templates are designed to produce correct output — trust them.
+Most generated files are template-based and finished as-emitted — trust them and apply only mechanical fixes. A small set is intentionally a DRAFT that asks for human/agent triage; those carry an explicit marker.
+
+#### 3a. Files that contain `<!-- darnit:verification-prompt-block -->`
+
+These are review-required drafts (today: `THREAT_MODEL.md` / `docs/threatmodel/SUMMARY.md` produced by `generate_threat_model`). The marker block embeds the canonical instructions for triaging the file's findings — open the marker block, follow what it says.
+
+**Workflow:**
+
+1. Read the marker block and surface its instructions to the user along with a quick tally (how many findings, of what kinds, in which files).
+2. **Ask the user before any extensive triage.** Large outputs (10+ findings) imply a long edit pass; the user should opt in. Offer to: (a) triage everything per the embedded prompt, (b) triage just a specific subset (e.g., one finding class), or (c) leave the draft as-emitted.
+3. With consent: read each finding, judge true-positive vs false-positive against the actual source, and either enrich it with project-specific reasoning or remove it. Collapse repetitive same-cause findings into a single explanatory entry where it improves the document.
+4. Preserve the marker block itself — its presence signals that the draft has gone through review. (You may remove the CLI-specific paragraph inside the block once you've triaged the CLI section per its own instructions.)
+
+This is the ONE category of generated file where the rules in §3b about not enhancing do NOT apply.
+
+#### 3b. All other generated files (templates)
+
+Read them. The templates are designed to produce correct output — trust them.
 
 **Fix ONLY these issues:**
 - Broken syntax (malformed YAML, unclosed brackets, invalid workflow expressions)
@@ -70,6 +87,7 @@ Show: branch name, controls fixed, files changed, PR URL (if created), and remai
 - If `remediate_audit_findings` fails mid-way, report which files were already changed so the user can review.
 - The tool respects the `safe` flag on remediations — only safe remediations are auto-applied. Unsafe ones are listed but excluded.
 - If there are unresolved data questions, the remediation tool will block and tell you. Suggest running `/darnit-data` first.
+- The §3a verification-prompt-block files (today: `THREAT_MODEL.md` / `docs/threatmodel/SUMMARY.md`) are the ONE exception to §3b's "trust the template" stance. Always ask the user before doing a large triage pass on these — don't silently rewrite dozens of findings, and don't silently skip them either. The default "skip enhancement" rule from §3b is wrong for these files.
 
 ## Error handling
 


### PR DESCRIPTION
## Summary

The `darnit-remediate` skill's §3 "Review generated files" guidance was authored for the template-based remediations darnit emits (SECURITY.md, CONTRIBUTING.md, GOVERNANCE.md, …) — files that are intentionally project-agnostic and *should* be left generic. That blanket "do NOT enhance" rule is wrong for one specific case: the threat-model generator's output, which is explicitly emitted as a **DRAFT** and embeds a `<!-- darnit:verification-prompt-block -->` instructing the calling agent to triage findings.

## Observed failure

During the demo dry-run against `mlieberman85/darnit-gittuf-demo` (feature 014 / #262), `generate_threat_model` wrote `docs/threatmodel/SUMMARY.md` with **88 raw cobra-CLI findings** ("Unauthenticated cli command (cobra)" × every Cobra subcommand). 

`OSPS-SA-03.02` passed its `file_exists` check, so the audit *looked* green, but the findings were **untouched** because the Claude session running `darnit-remediate` honored the §3 "do NOT 'enhance' by injecting specific names ... details from the repo" rule and skipped triage entirely. The embedded verification prompt — which explicitly asks the agent to read each finding, judge true-positive vs false-positive, and either enrich or remove — sat unread.

## Fix

Split §3 into two cases:

- **§3a** — files containing `<!-- darnit:verification-prompt-block -->`. Read the embedded prompt. Prompt the user before doing extensive triage (offer: triage everything / triage a subset / leave as-emitted). With consent: read each finding against actual source, enrich or remove, collapse repetitive same-cause findings. Preserve the marker.
- **§3b** — other generated files (templates). Existing "don't enhance" rules unchanged.

Plus a Gotchas-section note flagging §3a as the exception to §3b's trust-the-template stance.

## Why this matters

The threat-model output's value is in its triage, not its existence. A file with 88 untouched raw findings is *worse* than a smaller curated set:

- Reviewers tune out
- Real signal gets buried
- The "OSPS-SA-03.02 passed" report is misleading — the file exists but the audit nature it represents (a working threat model) doesn't

The CLI-specific verification paragraph this PR's predecessor (#276 + cobra feature 014) embeds in the output is *specifically* an instruction to the calling agent — but only a calling agent following these instructions can act on it. The skill is what tells the agent how to follow embedded instructions.

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run pytest tests/darnit_baseline -q` → 661 passed, 6 skipped
- [ ] Live re-test on `mlieberman85/darnit-gittuf-demo`: with the updated skill, the next `darnit-remediate` run should prompt the user about the 88 findings rather than silently leaving them raw

## Related

- Feature spec 014 (#262 / `specs/014-cobra-threat-model/`) added the CLI-specific verification-prompt paragraph that this skill should now honor.
- #277 tracks the related need for a more concrete AC-04.02 remediation handler that emits its own structured prompt to the agent (similar shape, different control).
- Discovered during demo dry-run; see [mlieberman85/darnit-gittuf-demo](https://github.com/mlieberman85/darnit-gittuf-demo) for the observed 88-findings state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)