### PR TITLE
docs(packaging): HOMEBREW_TAP_TOKEN can be a fine-grained PAT or a GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -766,8 +766,11 @@ jobs:
   # GH Release's binary assets by URL + SHA-256; the assets must exist on
   # the release before we compute hashes and dispatch.
   #
-  # Authentication: HOMEBREW_TAP_TOKEN is a GitHub App installation token
-  # scoped to `contents: write` on kusari-oss/homebrew-tap ONLY. See
+  # Authentication: HOMEBREW_TAP_TOKEN is a fine-grained PAT scoped to
+  # kusari-oss/homebrew-tap ONLY, with `contents: write` permission. A
+  # GitHub App installation token works identically at the HTTP layer
+  # (both pass as `Authorization: Bearer <token>` against the dispatches
+  # endpoint) — swap to an App at any time without code changes. See
   # packaging/README.md "External setup" for the maintainer-side steps.
   homebrew_dispatch:
     name: Dispatch formula bump to kusari-oss/homebrew-tap

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -45,9 +45,17 @@ Mirror the four configurations above on `test.pypi.org`. Used for pre-release (`
 
 ### Homebrew tap (T040–T041)
 
-1. Create `kusari-oss/homebrew-tap` as a public repo with the default branch `main` and a stub README.
-2. Create a GitHub App (or reuse the org's release App) with `contents: write` on `kusari-oss/homebrew-tap` only.
-3. Store the App's installation token as the `HOMEBREW_TAP_TOKEN` secret on `kusari-oss/darnit`.
+1. Create `kusari-oss/homebrew-tap` as a public repo with the default branch `main` and a stub README. Copy `packaging/homebrew/tap-workflows/{bump-formula.yml,ci.yml}` into the tap repo's `.github/workflows/`.
+2. Provide a credential the release pipeline can use to fire a `repository_dispatch` against the tap repo. Two options, simplest first:
+   - **Fine-grained PAT** (recommended for low-cadence projects). Create at https://github.com/settings/personal-access-tokens/new with **Repository access → Only select repositories → `kusari-oss/homebrew-tap`** and **Repository permissions → Contents: Read and write**. Trade-off: tied to your user account; rotates when you re-issue the PAT.
+   - **GitHub App** (recommended once release cadence justifies the polish). Create an App with `contents: write` on `kusari-oss/homebrew-tap` only; install on the tap repo; store the App-issued installation token (or app-id + private-key pair the workflow exchanges for one) as the secret. Trade-off: more setup; rotatable; not tied to a user account.
+
+   The dispatch step in `release.yml` uses bearer auth (`Authorization: Bearer ${HOMEBREW_TAP_TOKEN}`), which works identically for both options. Swap between them at any time without touching the workflow.
+
+3. Store the credential as the `HOMEBREW_TAP_TOKEN` secret on the `release` environment of `kusari-oss/darnit`:
+   ```bash
+   gh secret set HOMEBREW_TAP_TOKEN --repo kusari-oss/darnit --env release
+   ```
 
 ## Doing a release
 


### PR DESCRIPTION
## Summary

Two stale doc/comment spots assumed the only auth path for the homebrew-tap dispatch was a GitHub App installation token:

1. `release.yml:769-771` — comment claimed the secret **is** an App installation token
2. `packaging/README.md` § "Homebrew tap" — instructed maintainers to "Create a GitHub App (or reuse the org's release App)" as the single auth path

In practice the dispatch step is just bearer auth:

```yaml
-H "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}"
```

…and GitHub's `repository_dispatch` endpoint accepts that same shape for either a fine-grained PAT scoped to one repo OR an App-issued installation token. Either credential drops in; no code change.

## What this PR changes

- **Documents both auth paths** — fine-grained PAT (recommended for low cadence; one secret, no App setup) and GitHub App (recommended once cadence justifies it; rotatable, not tied to a user).
- **Spells out the field values** for the PAT path (Personal access tokens (fine-grained) → Only select repositories → kusari-oss/homebrew-tap → Contents: Read and write), so maintainers don't have to derive them.
- **Adds the `gh secret set` invocation** for storing the credential on the `release` environment, since that's the actual store of record.
- **Cross-references** the tap-workflows copy step so it's discoverable from the auth section.
- **Makes clear** the App is still the right long-term answer — this is just acknowledging the PAT path also exists and is what `kusari-oss/darnit` is using as of v0.1.0 prep.

## What this PR does NOT change

- No workflow code changes. `release.yml`'s dispatch step is auth-agnostic by design.
- No change to `packaging/homebrew/tap-workflows/`. Those workflows are unchanged.
- Not switching the project's recommendation — both paths are first-class; the App is recommended once a higher release cadence exists.

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run python scripts/validate_sync.py --verbose` → PASSED
- [x] `uv run python scripts/generate_docs.py` → no diff in `docs/generated/`
- [x] No code paths touched; nothing test-runnable to break

🤖 Generated with [Claude Code](https://claude.com/claude-code)