### PR TITLE
docs(install): add from-source install path + remove curl|sh from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,23 @@ The threat model generator can use [Opengrep](https://github.com/opengrep/opengr
 findings with data-flow traces. Without it, the generator uses tree-sitter structural
 analysis only — accurate but without taint confirmation.
 
-```bash
-# Install Opengrep (optional)
-curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
+Install via your platform's package manager (recommended — gets you a signed,
+checksummed artifact rather than piping an unverified script into your shell):
 
-# Verify
+```bash
+# macOS / Linux with Homebrew
+brew install opengrep
+
+# Or pin a specific release directly from GitHub:
+#   https://github.com/opengrep/opengrep/releases
+# Download, verify the SHA-256 against the release notes, then place
+# the binary on your PATH.
+
+# Verify the install succeeded
 opengrep --version
 ```
+
+If you'd rather use Semgrep (also supported by darnit): `pipx install semgrep`.
 
 ### Threat-model coverage scope
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -11,6 +11,7 @@ darnit ships through five channels. Pick the one that matches your situation; ea
 | On macOS arm64 or Linux with Homebrew | **Homebrew** | [homebrew.md](homebrew.md) |
 | Want a self-contained binary, no package manager | **Standalone binary** | [binary.md](binary.md) |
 | A Claude Code user who wants `/darnit:darnit-audit` and the MCP server in one install | **Claude Code plugin** | [claude-code-plugin.md](claude-code-plugin.md) |
+| Want to try an unreleased feature, contribute, or run a specific branch | **From source** (clone + `uv tool install --editable`) | [from-source.md](from-source.md) |
 | Building your own darnit-compatible compliance plugin | (not an install path — see [`docs/packaging-plugins.md`](../packaging-plugins.md)) | — |
 
 If you're not sure: **`pipx install darnit-mcp`** works for most users and is the simplest path. The other channels exist because real-world environments have constraints (no Python, locked-down CI runners, brew-only macOS workflows, agent-first usage).

--- a/docs/install/from-source.md
+++ b/docs/install/from-source.md
@@ -1,0 +1,95 @@
+# Install darnit from source
+
+For users who want to **try an unreleased feature**, contribute to darnit, or run a specific commit/branch before it ships through one of the published channels ([PyPI](pypi.md), [container](container.md), [Homebrew](homebrew.md), [binary](binary.md), [Claude Code plugin](claude-code-plugin.md)).
+
+This path is necessary today because darnit's packages aren't yet on PyPI. After the first stable release (`v0.1.0`), the published channels become the easier path; from-source becomes a contributor-or-feature-preview workflow.
+
+## Quick install
+
+```bash
+# 1. Clone the canonical repository
+git clone https://github.com/kusari-oss/darnit ~/Projects/darnit
+cd ~/Projects/darnit
+
+# 2. Optionally switch to a specific feature branch
+git checkout <branch-name>
+
+# 3. Install as an editable `uv tool` with all three workspace packages
+uv tool install --python 3.12 \
+  --editable packages/darnit \
+  --with-editable packages/darnit-baseline \
+  --with-editable packages/darnit-gittuf
+
+# 4. Verify
+darnit --version
+darnit list        # should show openssf-baseline, 62 controls
+```
+
+That's it — `darnit` is on `PATH`, editable-backed by your clone, ready to run.
+
+## Why three `--with-editable` flags?
+
+darnit is a uv workspace. The user-facing CLI lives in `packages/darnit/` (the `darnit-core` package), but it discovers compliance implementations via Python entry points exposed by sibling packages:
+
+- `packages/darnit/` → the `darnit-core` framework (CLI, sieve, MCP server)
+- `packages/darnit-baseline/` → the OpenSSF Baseline implementation (62 controls)
+- `packages/darnit-gittuf/` → the gittuf plugin
+
+If you install only `packages/darnit/` editable, uv tries to resolve `darnit-baseline` and `darnit-gittuf` from PyPI — and they don't exist on PyPI yet (pre-v0.1.0). The `--with-editable` flags tell uv to add the sibling packages as additional editable members in the same tool venv.
+
+After v0.1.0 ships, this constraint disappears: `uv tool install darnit-mcp` (the workspace root) will resolve everything from PyPI.
+
+## Why `--python 3.12`?
+
+darnit's workspace targets **Python 3.11 and 3.12** (see `requires-python` in each `pyproject.toml`). Newer Python versions (3.13, 3.14) may work but are not yet covered by darnit's CI matrix, and `tree-sitter-language-pack` doesn't ship wheels for them at the time of writing (see [#268](https://github.com/kusari-oss/darnit/issues/268)). Pinning the tool venv to 3.12 avoids surprise build-from-source failures and matches what darnit's own CI runs against.
+
+If your system default is 3.11 or 3.12 already, you can omit the flag.
+
+## Running the MCP server from source
+
+```bash
+darnit serve --framework openssf-baseline
+```
+
+Or configure it as an MCP server in Claude Code:
+
+```bash
+claude mcp add --scope user darnit -- "$(which darnit)" serve --framework openssf-baseline
+```
+
+(The `darnit install` command also writes MCP config, but it writes to Claude Desktop's settings file, not Claude Code's — see [#270](https://github.com/kusari-oss/darnit/issues/270). The direct `claude mcp add` command works around that until the install command is fixed.)
+
+## Switching branches
+
+Because the install is editable, switching branches in `~/Projects/darnit` immediately changes what `darnit` runs — no reinstall needed:
+
+```bash
+cd ~/Projects/darnit
+git checkout feature-branch
+darnit --version   # now runs the feature branch's code
+```
+
+The only time you need to reinstall is when the workspace dependency set itself changes (e.g., a new sibling package gets added to `packages/`, or pinned versions in any `pyproject.toml` change).
+
+## Uninstall
+
+```bash
+uv tool uninstall darnit-core
+```
+
+The clone in `~/Projects/darnit` stays on disk — remove it manually if you no longer want the source tree.
+
+## Why not `uv tool install git+https://…`?
+
+Two reasons this doesn't work today:
+
+1. The **workspace root** (`darnit-mcp`) is a virtual package — it has `[tool.uv.workspace]` but no source of its own. `setuptools` errors out trying to build it directly.
+2. Installing a **single package by `subdirectory=`** works structurally, but its workspace-sibling dependencies (`darnit-baseline`, `darnit-gittuf`) aren't on PyPI yet. uv tries to resolve them from PyPI, gets 404, fails.
+
+After v0.1.0 puts all four packages on PyPI, `uv tool install darnit-mcp` works in one shot — no clone needed.
+
+## See also
+
+- [Installation overview](README.md) — decision tree for the published channels.
+- [PyPI install](pypi.md) — the path after v0.1.0 ships.
+- The [maintainer release runbook](../../packaging/README.md) — how releases get produced.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,6 +1,6 @@
 # Packaging & Release Runbook
 
-Maintainer-facing documentation for the darnit release pipeline. End-user install instructions live in [`docs/install/`](../docs/install/).
+Maintainer-facing documentation for the darnit release pipeline. End-user install instructions live in [`docs/install/`](../docs/install/), including [from-source.md](../docs/install/from-source.md) for users wanting to try unreleased features before they're cut into a published release.
 
 > **Canonical repository home**: `https://github.com/kusari-oss/darnit`
 >


### PR DESCRIPTION
## Summary

Three small doc improvements that surfaced during demo prep:

### 1. New `docs/install/from-source.md`

End-user-facing instructions for installing darnit from a clone of this repo. Necessary today because:

- The workspace root `pyproject.toml` is virtual (no buildable source — `setuptools` errors out)
- The sibling packages (`darnit-baseline`, `darnit-gittuf`) aren't on PyPI yet, so `uv tool install --from "git+...#subdirectory=packages/darnit" darnit-core` fails to resolve workspace deps

The actual working incantation:

```bash
git clone https://github.com/kusari-oss/darnit ~/Projects/darnit
cd ~/Projects/darnit
uv tool install --python 3.12 \
  --editable packages/darnit \
  --with-editable packages/darnit-baseline \
  --with-editable packages/darnit-gittuf
```

The doc covers:
- Why three `--with-editable` flags (workspace explanation)
- Why `--python 3.12` (avoids the `tree-sitter-language-pack` 3.14-wheel gap from #268)
- Running the MCP server from a from-source install + the `claude mcp add` workaround for #270
- Branch-switching without reinstalling (editable-backed)
- Cleanup
- Why the obvious `uv tool install git+...` paths don't work today

This path becomes a contributor-/feature-preview workflow once v0.1.0 lands on PyPI; the doc notes that explicitly.

### 2. `docs/install/README.md` decision tree

Added a new row:

> | Want to try an unreleased feature, contribute, or run a specific branch | **From source** (clone + `uv tool install --editable`) | from-source.md |

So someone reading the install index can find this path.

### 3. Removed `curl | sh` from the top-level README

The "Optional: Opengrep for taint analysis" section was piping an unverified install script straight into bash:

```bash
curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
```

Replaced with `brew install opengrep` (signed/checksummed via the Homebrew formula) + a pointer to the GitHub releases page for users who want to pin a specific SHA-256, plus `pipx install semgrep` as the supported alternative. Includes a one-line explanation of why piping unverified scripts is being avoided.

Plus a one-line cross-reference in `packaging/README.md` so a maintainer reading the runbook discovers the new from-source path.

## Why this matters now

Pre-v0.1.0, the only path for someone wanting to try darnit is the from-source workflow. Without docs, anyone reaching this repo has to derive the multi-`--with-editable` incantation from scratch (which we did during demo prep — see the recent session history). Documenting it unblocks contributors and feature-preview users before the first stable release.

## Test plan

- [x] `uv run ruff check .` → All checks passed!
- [x] `uv run python scripts/validate_sync.py --verbose` → PASSED
- [x] `uv run python scripts/generate_docs.py` → no diff in `docs/generated/`
- [x] No code paths touched; nothing test-runnable to break
- [ ] After merge: try the documented commands on a fresh machine end-to-end (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)