### PR TITLE
fix(baseline): GH license API as primary signal for LE-02.02 / LE-03.02

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -1682,6 +1682,7 @@ name = "ReleaseLicense"
 description = "Releases include license information"
 tags = { level = 1, domain = "LE", legal = true, license = true }
 when = { platform = "github" }
+inferred_from = "OSPS-LE-03.01"  # GitHub auto-generates source archives that include the repo's LICENSE for every release; if LE-03.01 passes, the release contains license info by construction.
 
 # Check that releases have license info (via release notes or included files)
 docs_url = "https://baseline.openssf.org/versions/2025-10-10#OSPS-LE-02.02"
@@ -1693,6 +1694,16 @@ help_md = """Include OSI-approved license with releases.
 2. Ensure license is compatible with dependencies
 3. Document license in package metadata
 """
+
+# Primary: GitHub's own license detector (licensee server-side) returns an SPDX id.
+# Nonzero exit falls through to the next pass so auth/network failures don't masquerade as FAIL.
+[[controls."OSPS-LE-02.02".passes]]
+handler = "exec"
+command = ["gh", "api", "/repos/$OWNER/$REPO/license"]
+pass_exit_codes = [0]
+output_format = "json"
+expr = 'has(output.json.license) && output.json.license.spdx_id != "" && output.json.license.spdx_id != "NOASSERTION"'
+timeout = 30
 
 [[controls."OSPS-LE-02.02".passes]]
 handler = "exec"
@@ -1791,6 +1802,17 @@ help_md = """Include license file in release artifacts.
 2. Include license in package metadata
 3. Automate license inclusion in release workflow
 """
+
+# Primary: GitHub's own license detector. A PASS here means GitHub has identified a
+# recognized SPDX license in the repo, and every auto-generated source archive for a
+# release therefore includes it. Falls through on nonzero exit (auth/network/no-detection).
+[[controls."OSPS-LE-03.02".passes]]
+handler = "exec"
+command = ["gh", "api", "/repos/$OWNER/$REPO/license"]
+pass_exit_codes = [0]
+output_format = "json"
+expr = 'has(output.json.license) && output.json.license.spdx_id != "" && output.json.license.spdx_id != "NOASSERTION"'
+timeout = 30
 
 [[controls."OSPS-LE-03.02".passes]]
 handler = "exec"

--- a/tests/darnit/sieve/test_cel_evaluator.py
+++ b/tests/darnit/sieve/test_cel_evaluator.py
@@ -441,6 +441,62 @@ class TestWarnControlCELExpressions:
     that replace weak "existence-only" checks with meaningful validation.
     """
 
+    # -- OSPS-LE-02.02 / LE-03.02: GH license endpoint (primary pass) --
+
+    def test_gh_license_endpoint_pass_with_spdx(self) -> None:
+        """GitHub returns a recognized SPDX id → PASS."""
+        evaluator = CELEvaluator()
+        expr = (
+            'has(output.json.license) && output.json.license.spdx_id != ""'
+            ' && output.json.license.spdx_id != "NOASSERTION"'
+        )
+        program = evaluator.compile(expr)
+        context = {
+            "output": {
+                "json": {
+                    "name": "LICENSE",
+                    "path": "LICENSE",
+                    "license": {"spdx_id": "Apache-2.0", "key": "apache-2.0"},
+                }
+            }
+        }
+        result = evaluator.evaluate(program, context)
+        assert result.success is True
+        assert result.value is True
+
+    def test_gh_license_endpoint_fail_noassertion(self) -> None:
+        """GitHub found a LICENSE file but couldn't classify it → not a PASS."""
+        evaluator = CELEvaluator()
+        expr = (
+            'has(output.json.license) && output.json.license.spdx_id != ""'
+            ' && output.json.license.spdx_id != "NOASSERTION"'
+        )
+        program = evaluator.compile(expr)
+        context = {
+            "output": {
+                "json": {
+                    "name": "LICENSE",
+                    "license": {"spdx_id": "NOASSERTION", "key": "other"},
+                }
+            }
+        }
+        result = evaluator.evaluate(program, context)
+        assert result.success is True
+        assert result.value is False
+
+    def test_gh_license_endpoint_fail_no_license_field(self) -> None:
+        """Response missing the license field → not a PASS (handled by has() guard)."""
+        evaluator = CELEvaluator()
+        expr = (
+            'has(output.json.license) && output.json.license.spdx_id != ""'
+            ' && output.json.license.spdx_id != "NOASSERTION"'
+        )
+        program = evaluator.compile(expr)
+        context = {"output": {"json": {"name": "LICENSE"}}}
+        result = evaluator.evaluate(program, context)
+        assert result.success is True
+        assert result.value is False
+
     # -- OSPS-LE-02.02: ReleaseLicense --
 
     def test_release_license_pass_body_keyword(self) -> None:


### PR DESCRIPTION
## Summary

Both LE-02.02 (`ReleaseLicense`) and LE-03.02 (`LicenseInReleases`) currently fall through to manual on common repo shapes:

- **LE-02.02** only checks `gh release view --json body,assets`, grepping the release body for license keywords and asset names matching `^(license|copying|notice)`. A release titled "v0.1.0" with body "Bug fixes" and an asset named `darnit-v0.1.0.tar.gz` is INCONCLUSIVE even when the project unambiguously has an MIT license.
- **LE-03.02** only matches LICENSE-shaped asset names. Misses every repo that ships a `LICENSE` at root but doesn't separately attach it as a release asset (i.e. most repos — GitHub already includes LICENSE inside the auto-generated source archive).

Per `CLAUDE.md`'s conservative-by-default principle, INCONCLUSIVE rolls up the same as FAIL. So clearly-compliant projects get flagged as "Needs Verification" on two controls that should be cheap to verify.

## Change

Add a higher-confidence primary pass to both controls that calls `gh api /repos/$OWNER/$REPO/license`. GitHub runs `licensee` server-side and returns `license.spdx_id` for recognized licenses; PASS when SPDX is set and not `NOASSERTION`.

`fail_exit_codes` deliberately omitted — nonzero falls through to the existing release-view pass so 404/auth/network errors don't masquerade as FAIL. Same pattern PR #272 established for AC-01.01.

LE-02.02 also gains `inferred_from = "OSPS-LE-03.01"` (LE-03.02 already had it). Rationale: GitHub auto-generates a source archive for every release that includes the repo's LICENSE.

## Why not askalono/licensee locally or an LLM stage?

Both were on the table. The GH endpoint is highest-ROI as a first step since darnit already has a GitHub context for these controls. Local classification + LLM fallback earn their keep on controls where per-file SPDX header scanning matters (REUSE, per-file tagging) — LE-02 / LE-03 only ask about the LICENSE-at-root, which GitHub already classifies.

## Test plan

- [x] `uv run pytest tests/darnit/sieve/test_cel_evaluator.py -k 'gh_license_endpoint or release_license'` → 6 passed (3 new + 3 existing)
- [x] `uv run python scripts/validate_sync.py --verbose` → PASSED (62 controls, schema valid)
- [x] `uv run ruff check .` → All checks passed
- [x] Full baseline + sieve suite (942 tests) → all pass
- [ ] Smoke-test against a real repo with a recognized SPDX license (manual)
- [ ] Smoke-test against a repo with `LICENSE` but no `gh` auth (verify the fall-through to release-view pass actually happens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)