### PR TITLE
fix(baseline): wheel-build duplicate-file error (unblocks #285 + v0.1.0)

### DIFF
--- a/packages/darnit-baseline/pyproject.toml
+++ b/packages/darnit-baseline/pyproject.toml
@@ -52,4 +52,6 @@ packages = ["src/darnit_baseline"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "templates" = "darnit_baseline/templates"
-"src/darnit_baseline/threat_model/opengrep_rules" = "darnit_baseline/threat_model/opengrep_rules"
+# opengrep_rules/ lives under src/darnit_baseline/threat_model/ and is already
+# packaged by the `packages` entry above. Re-adding it here caused hatch to fail
+# with "A second file is being added to the wheel archive at the same path".


### PR DESCRIPTION
## Summary

The wheel-build CI job is failing on every PR with:

\`\`\`
ValueError: A second file is being added to the wheel archive at the same path:
\`darnit_baseline/threat_model/opengrep_rules/config_loaders.yaml\`.
\`\`\`

**Root cause:** \`tool.hatch.build.targets.wheel.packages = [\"src/darnit_baseline\"]\` already recursively includes every file under that tree — including the 4 YAMLs in \`src/darnit_baseline/threat_model/opengrep_rules/\`. The \`force-include\` entry below was re-adding the same files at the same destination path, and hatchling errors out on duplicates as of recent versions.

**Fix:** drop the redundant \`force-include\` line. The remaining \`templates\` entry is still needed because that directory lives at the package root, *outside* \`src/\`.

## Why this wasn't caught earlier

The wheel-build CI job (\`ci.yml::build\`) only triggers on PRs. Recently most main-branch updates landed via PR but the workflow had a path filter or a stale trigger configuration that didn't fire on these specific changes — so the bug accumulated. Repro on plain main:

\`\`\`
git clone --depth 1 https://github.com/kusari-oss/darnit /tmp/test
cd /tmp/test
uv build --package darnit-baseline   # same hatch dup-file error
\`\`\`

So this is a **pre-existing build bug, not a regression from #285**. #285 just surfaced it because it was the first PR to hit Build CI in a while.

## Why dropping the entry is safe

The 4 YAML rule files (\`config_loaders.yaml\`, \`data_stores.yaml\`, \`entry_points.yaml\`, \`taint_external_input.yaml\`) live under \`src/darnit_baseline/threat_model/opengrep_rules/\`, which is inside the \`packages\` directory. Hatchling automatically ships all files inside the package tree (not just \`.py\` files). Confirmed locally:

\`\`\`
$ unzip -l dist/darnit_baseline-0.1.0-py3-none-any.whl | grep opengrep_rules
   1131  darnit_baseline/threat_model/opengrep_rules/config_loaders.yaml
   1394  darnit_baseline/threat_model/opengrep_rules/data_stores.yaml
   1628  darnit_baseline/threat_model/opengrep_rules/entry_points.yaml
   1738  darnit_baseline/threat_model/opengrep_rules/taint_external_input.yaml
\`\`\`

Same 4 files, same paths, same coverage. No runtime impact.

## Blast radius

- Unblocks #285 (cobra threat-model) — same Build job will now go green.
- Unblocks v0.1.0 release pipeline — the rc0 \`uv build\` step would otherwise fail identically.
- No code changes; one TOML deletion + a comment explaining why.

## Test plan

- [x] \`rm -rf dist/ && uv build --package darnit-baseline\` → success (was: hatch dup-file error)
- [x] \`uv build --package darnit-core\` → success (sanity, was already working)
- [x] All 4 opengrep YAML files present in built wheel
- [ ] CI Build job goes green on this PR (will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)