### PR TITLE
fix: cache framework config by mtime, remove broken ad-hoc caches

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/tools.py
+++ b/packages/darnit-baseline/src/darnit_baseline/tools.py
@@ -199,6 +199,7 @@ def audit_openssf_baseline(
             local_path=str(repo_path),
             report_title="OpenSSF Baseline Audit Report",
             remediation_map=OSPS_REMEDIATION_MAP,
+            framework_name="openssf-baseline",
         )
 
 
@@ -1437,6 +1438,7 @@ def audit_org(
         summary=summary,
         compliance=compliance,
         level=level,
+        framework_name="openssf-baseline",
     )
 
 

--- a/packages/darnit/src/darnit/config/context_storage.py
+++ b/packages/darnit/src/darnit/config/context_storage.py
@@ -515,25 +515,12 @@ def get_pending_context(
     # Load auto_accept_confidence threshold from framework config
     auto_accept_threshold = 0.8
     try:
-        from darnit.config.control_loader import load_framework_config
-        from darnit.config.merger import resolve_framework_path
+        from darnit.config.merger import load_effective_config_auto
 
-        # Try .baseline.toml extends, then fall back to "openssf-baseline"
-        fw_name = None
-        try:
-            from darnit.config import load_user_config
-
-            user_cfg = load_user_config(Path(local_path))
-            if user_cfg and user_cfg.extends:
-                fw_name = user_cfg.extends
-        except Exception:
-            pass
-        fw_name = fw_name or "openssf-baseline"
-
-        config_path = resolve_framework_path(fw_name)
-        if config_path and config_path.exists():
-            fw_config = load_framework_config(config_path)
-            auto_accept_threshold = fw_config.context.auto_accept_confidence
+        effective_config = load_effective_config_auto(Path(local_path))
+        framework = effective_config._framework_config
+        if framework is not None:
+            auto_accept_threshold = framework.context.auto_accept_confidence
     except Exception:
         pass  # Use default threshold
 

--- a/packages/darnit/src/darnit/config/merger.py
+++ b/packages/darnit/src/darnit/config/merger.py
@@ -473,8 +473,20 @@ def _parse_framework_only(path: Path) -> FrameworkConfig:
     return config
 
 
+# Parsed framework configs are large (the baseline TOML is 4000+ lines) and
+# were previously re-parsed several times per audit. Keyed by resolved path,
+# invalidated on mtime change so .toml edits are picked up even in a
+# long-running MCP server. Composed frameworks are keyed on the top-level
+# file's mtime only; editing a composition *source* without touching the
+# top file serves stale until the next mtime change.
+_framework_config_cache: dict[Path, tuple[int, FrameworkConfig]] = {}
+
+
 def load_framework_config(path: Path) -> FrameworkConfig:
     """Load framework configuration from TOML file.
+
+    Results are cached per resolved path and invalidated when the file's
+    mtime changes. Callers MUST treat the returned config as read-only.
 
     If the parsed config has any ``[[compose]]`` blocks or
     ``[overrides."…"]`` blocks, this function resolves composition exactly
@@ -497,6 +509,16 @@ def load_framework_config(path: Path) -> FrameworkConfig:
         CompositionError: Any composition-resolution failure (missing
             source, cycle, conflict, orphan override, etc.).
     """
+    resolved = path.resolve()
+    try:
+        mtime_ns = resolved.stat().st_mtime_ns
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Framework config not found: {path}") from None
+
+    cached = _framework_config_cache.get(resolved)
+    if cached is not None and cached[0] == mtime_ns:
+        return cached[1]
+
     config = _parse_framework_only(path)
 
     # Composition resolution runs EXACTLY ONCE at the top of this call chain.
@@ -508,6 +530,7 @@ def load_framework_config(path: Path) -> FrameworkConfig:
 
         config = resolve_composition(config)
 
+    _framework_config_cache[resolved] = (mtime_ns, config)
     return config
 
 

--- a/packages/darnit/src/darnit/server/tools/builtin_audit.py
+++ b/packages/darnit/src/darnit/server/tools/builtin_audit.py
@@ -140,6 +140,7 @@ async def builtin_audit(
         level=level,
         local_path=str(repo_path),
         report_title=report_title,
+        framework_name=_framework_name,
     )
 
 

--- a/packages/darnit/src/darnit/tools/audit.py
+++ b/packages/darnit/src/darnit/tools/audit.py
@@ -22,7 +22,7 @@ logger = get_logger("tools.audit")
 
 # Sieve system imports - lazy loaded
 _sieve_components = None
-_toml_controls_registered = False
+_toml_controls_registered: set[Path] = set()
 
 
 def _get_sieve_components():
@@ -59,13 +59,13 @@ def _register_toml_controls(framework_name: str | None = None) -> int:
     Returns:
         Number of controls registered from TOML
     """
-    global _toml_controls_registered
-    if _toml_controls_registered:
-        return 0
-
     framework_path = _get_framework_config_path(framework_name)
     if not framework_path:
         logger.debug("No framework TOML found, skipping TOML control registration")
+        return 0
+
+    resolved_path = framework_path.resolve()
+    if resolved_path in _toml_controls_registered:
         return 0
 
     try:
@@ -85,7 +85,7 @@ def _register_toml_controls(framework_name: str | None = None) -> int:
                 registered += 1
                 logger.debug(f"Registered TOML control: {control.control_id}")
 
-        _toml_controls_registered = True
+        _toml_controls_registered.add(resolved_path)
         if registered > 0:
             logger.info(f"Registered {registered} controls from {framework_path.name}")
         return registered
@@ -101,8 +101,6 @@ def _register_toml_controls(framework_name: str | None = None) -> int:
 # =============================================================================
 # User Configuration Loading
 # =============================================================================
-
-_effective_config_cache: dict[str, Any] = {}
 
 
 def _get_framework_config_path(framework_name: str | None = None) -> Path | None:
@@ -159,28 +157,14 @@ def load_effective_audit_config(local_path: str, framework_name: str | None = No
     Returns:
         EffectiveConfig if successful, None otherwise
     """
-    # Check cache first
-    abs_path = str(Path(local_path).resolve())
-    if abs_path in _effective_config_cache:
-        return _effective_config_cache[abs_path]
-
     try:
         from darnit.config import load_effective_config_auto
 
-        effective = load_effective_config_auto(Path(local_path), framework_name=framework_name)
-
-        # Cache the result
-        _effective_config_cache[abs_path] = effective
-        return effective
+        return load_effective_config_auto(Path(local_path), framework_name=framework_name)
 
     except Exception as e:
         logger.warning(f"Error loading effective config: {e}")
         return None
-
-
-def clear_effective_config_cache():
-    """Clear the effective config cache."""
-    _effective_config_cache.clear()
 
 
 def get_excluded_control_ids(local_path: str) -> dict[str, str]:
@@ -652,6 +636,7 @@ def format_results_markdown(
     local_path: str | None = None,
     report_title: str = "Compliance Audit Report",
     remediation_map: dict[str, Any] | None = None,
+    framework_name: str | None = None,
 ) -> str:
     """Format audit results as Markdown.
 
@@ -664,6 +649,8 @@ def format_results_markdown(
         level: Maximum level checked
         local_path: Path to the repository (for pending context)
         report_title: Title for the report H1 heading.
+        framework_name: Framework name used to resolve the framework TOML
+            for per-control help text on failures.
         remediation_map: Implementation-provided mapping of control IDs to
             remediation tools. Structure:
             {
@@ -802,7 +789,7 @@ def format_results_markdown(
 
                 # Include help_md for failed controls to explain remediation options
                 if status == "FAIL":
-                    help_md = _get_control_help(control_id)
+                    help_md = _get_control_help(control_id, framework_name)
                     if help_md:
                         # Indent help text and add as a sub-item
                         help_lines = help_md.strip().split("\n")
@@ -1168,7 +1155,6 @@ __all__ = [
     "load_effective_audit_config",
     "get_excluded_control_ids",
     "get_adapter_for_control",
-    "clear_effective_config_cache",
     # TOML framework support
     "_register_toml_controls",  # Internal but useful for testing
 ]


### PR DESCRIPTION
## Summary
- `load_framework_config` now caches the parsed `FrameworkConfig` per resolved path, invalidated on mtime change — the 4,375-line baseline TOML was being parsed + Pydantic-validated 3–4× per audit run
- Removes two broken ad-hoc caches it obsoletes:
  - `_effective_config_cache` (keyed by repo path only — returned the wrong config when `framework_name` differed; never invalidated across MCP server lifetime)
  - `_toml_controls_registered` global bool (a second framework's TOML controls were silently never registered after the first audit; now keyed by framework path)
- Fixes two silently-dead code paths found during the audit:
  - FAIL-control help text never rendered: `_get_control_help` was always called with `framework_name=None` → always `None`. `format_results_markdown` now takes `framework_name` (passed from the baseline tool and builtin audit)
  - `context_storage.get_pending_context` imported `load_framework_config` from `control_loader`, which doesn't export it — the swallowed `ImportError` meant the TOML `auto_accept_confidence` was never read. No behavior change today (TOML value = 0.8 default), but the knob works now

## Test plan
- [x] `uv run pytest tests/` — 2196 passed, 6 skipped
- [x] `uv run ruff check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)