### PR TITLE
fix(baseline): wire up SARIF output and attestation in audit tools

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/tools.py
+++ b/packages/darnit-baseline/src/darnit_baseline/tools.py
@@ -35,6 +35,34 @@ OSPS_REMEDIATION_MAP: dict = {
 }
 
 
+def _build_audit_result(
+    owner: str,
+    repo: str,
+    repo_path: Path,
+    level: int,
+    default_branch: str,
+    results: list[dict],
+    summary: dict[str, int],
+    level_compliance: dict[int, bool],
+):
+    """Assemble an AuditResult from sieve audit output for SARIF/attestation."""
+    from darnit.core.models import AuditResult
+    from darnit_baseline.attestation import get_git_commit, get_git_ref
+
+    return AuditResult(
+        owner=owner,
+        repo=repo,
+        local_path=str(repo_path),
+        level=level,
+        default_branch=default_branch,
+        all_results=results,
+        summary=summary,
+        level_compliance=level_compliance,
+        commit=get_git_commit(str(repo_path)),
+        ref=get_git_ref(str(repo_path)),
+    )
+
+
 def audit_openssf_baseline(
     owner: str | None = None,
     repo: str | None = None,
@@ -172,7 +200,7 @@ def audit_openssf_baseline(
             }
             for r in results
         ]
-        return json.dumps({
+        output = json.dumps({
             "owner": owner,
             "repo": repo,
             "level": level,
@@ -180,16 +208,25 @@ def audit_openssf_baseline(
             "results": compact_results,
         }, indent=2)
     elif output_format == "json":
-        return json.dumps({
+        output = json.dumps({
             "owner": owner,
             "repo": repo,
             "level": level,
             "summary": summary,
             "results": results,
         }, indent=2)
+    elif output_format == "sarif":
+        from darnit_baseline.formatters.sarif import generate_sarif_audit
+
+        compliance = calculate_compliance(results, level)
+        audit_result = _build_audit_result(
+            owner or "", repo or "", repo_path, level,
+            default_branch, results, summary, compliance,
+        )
+        output = json.dumps(generate_sarif_audit(audit_result), indent=2)
     else:
         compliance = calculate_compliance(results, level)
-        return format_results_markdown(
+        output = format_results_markdown(
             owner=owner,
             repo=repo,
             results=results,
@@ -200,6 +237,55 @@ def audit_openssf_baseline(
             report_title="OpenSSF Baseline Audit Report",
             remediation_map=OSPS_REMEDIATION_MAP,
         )
+
+    if attest:
+        attest_note = _attest_audit(
+            owner, repo, repo_path, level, default_branch,
+            results, summary, sign=sign_attestation, staging=staging,
+        )
+        # Only markdown output can carry the note without breaking the
+        # format; for JSON/SARIF the attestation file is still written.
+        if output_format not in ("summary", "json", "sarif"):
+            output += f"\n\n## Attestation\n\n{attest_note}\n"
+
+    return output
+
+
+def _attest_audit(
+    owner: str | None,
+    repo: str | None,
+    repo_path: Path,
+    level: int,
+    default_branch: str,
+    results: list[dict],
+    summary: dict[str, int],
+    *,
+    sign: bool,
+    staging: bool,
+) -> str:
+    """Generate an attestation from completed audit results.
+
+    Returns a one-line status message suitable for embedding in a report.
+    """
+    if not owner or not repo:
+        return "❌ Attestation skipped: owner/repo could not be determined."
+
+    try:
+        from darnit.tools.audit import calculate_compliance
+        from darnit_baseline.attestation import generate_attestation_from_results
+
+        compliance = calculate_compliance(results, level)
+        audit_result = _build_audit_result(
+            owner, repo, repo_path, level, default_branch,
+            results, summary, compliance,
+        )
+        message = generate_attestation_from_results(
+            audit_result, sign=sign, staging=staging,
+        )
+        first_line = message.splitlines()[0] if message else ""
+        return first_line if first_line.startswith("✅") else message
+    except Exception as e:
+        return f"❌ Attestation failed: {e}"
 
 
 def list_available_checks(profile: str | None = None) -> str:
@@ -1006,8 +1092,6 @@ def generate_attestation(
     Returns:
         JSON attestation and path to saved file
     """
-    from darnit_baseline.attestation import generate_attestation as _generate
-
     repo_path = Path(local_path).resolve()
     if not repo_path.exists():
         return f"❌ Error: Repository path not found: {repo_path}"
@@ -1018,18 +1102,34 @@ def generate_attestation(
     owner = owner or detected_owner
     repo = repo or detected_repo
 
+    if not owner or not repo:
+        return "❌ Error: owner/repo could not be determined. Pass them explicitly."
+
     try:
-        result = _generate(
+        from darnit.tools.audit import calculate_compliance, run_sieve_audit
+        from darnit_baseline.attestation import generate_attestation_from_results
+
+        default_branch = _detect_default_branch(repo_path)
+        results, summary = run_sieve_audit(
             owner=owner,
             repo=repo,
             local_path=str(repo_path),
+            default_branch=default_branch,
             level=level,
+            framework_name="openssf-baseline",
+        )
+        compliance = calculate_compliance(results, level)
+        audit_result = _build_audit_result(
+            owner, repo, repo_path, level, default_branch,
+            results, summary, compliance,
+        )
+        return generate_attestation_from_results(
+            audit_result,
             sign=sign,
             staging=staging,
             output_path=output_path,
             output_dir=output_dir,
         )
-        return result
     except Exception as e:
         return f"❌ Error generating attestation: {e}"
 

--- a/tests/darnit_baseline/test_tools_output_wiring.py
+++ b/tests/darnit_baseline/test_tools_output_wiring.py
@@ -1,0 +1,141 @@
+"""Regression tests for audit_openssf_baseline output/attestation wiring.
+
+These guard two previously-silent failures:
+- output_format="sarif" was advertised but fell through to markdown
+- the generate_attestation tool imported a function that does not exist
+"""
+
+import json
+
+import pytest
+
+FAKE_RESULTS = [
+    {"id": "OSPS-LE-02.01", "status": "FAIL", "level": 1, "details": "no license"},
+    {"id": "OSPS-AC-01.01", "status": "PASS", "level": 1, "details": "MFA enforced"},
+]
+FAKE_SUMMARY = {"PASS": 1, "FAIL": 1, "WARN": 0, "N/A": 0, "ERROR": 0, "total": 2}
+
+
+@pytest.fixture
+def fake_audit(monkeypatch):
+    import darnit.tools.audit as audit_mod
+
+    def _fake_run_sieve_audit(*args, **kwargs):
+        return FAKE_RESULTS, FAKE_SUMMARY
+
+    monkeypatch.setattr(audit_mod, "run_sieve_audit", _fake_run_sieve_audit)
+
+
+class TestSarifOutputFormat:
+    def test_sarif_format_returns_sarif_document(self, fake_audit, tmp_path):
+        from darnit_baseline.tools import audit_openssf_baseline
+
+        output = audit_openssf_baseline(
+            owner="acme",
+            repo="widget",
+            local_path=str(tmp_path),
+            level=1,
+            output_format="sarif",
+        )
+
+        doc = json.loads(output)
+        assert doc["version"] == "2.1.0"
+        assert "sarif" in doc["$schema"]
+        run = doc["runs"][0]
+        rule_ids = {r["id"] for r in run["tool"]["driver"]["rules"]}
+        assert "OSPS-LE-02.01" in rule_ids
+        assert run["properties"]["owner"] == "acme"
+        # PASS results are excluded by default; the FAIL must be present
+        result_rules = {r["ruleId"] for r in run["results"]}
+        assert result_rules == {"OSPS-LE-02.01"}
+
+    def test_sarif_format_is_not_markdown(self, fake_audit, tmp_path):
+        from darnit_baseline.tools import audit_openssf_baseline
+
+        output = audit_openssf_baseline(
+            owner="acme",
+            repo="widget",
+            local_path=str(tmp_path),
+            level=1,
+            output_format="sarif",
+        )
+        assert not output.startswith("#")
+
+
+class TestAttestWiring:
+    def test_attest_appends_section_to_markdown(self, fake_audit, tmp_path, monkeypatch):
+        import darnit_baseline.attestation as attestation_pkg
+        from darnit_baseline.tools import audit_openssf_baseline
+
+        captured = {}
+
+        def _fake_generate(audit_result, sign=True, staging=False, **kwargs):
+            captured["audit_result"] = audit_result
+            captured["sign"] = sign
+            return "✅ Attestation saved to: /tmp/fake.intoto.json\n\n{}"
+
+        monkeypatch.setattr(attestation_pkg, "generate_attestation_from_results", _fake_generate)
+
+        output = audit_openssf_baseline(
+            owner="acme",
+            repo="widget",
+            local_path=str(tmp_path),
+            level=1,
+            attest=True,
+            sign_attestation=False,
+        )
+
+        assert "## Attestation" in output
+        assert "✅ Attestation saved to:" in output
+        assert captured["sign"] is False
+        assert captured["audit_result"].owner == "acme"
+        assert captured["audit_result"].all_results == FAKE_RESULTS
+
+    def test_attest_skipped_without_owner_repo(self, fake_audit, tmp_path):
+        from darnit_baseline.tools import audit_openssf_baseline
+
+        output = audit_openssf_baseline(
+            local_path=str(tmp_path),
+            level=1,
+            attest=True,
+        )
+        assert "Attestation skipped" in output
+
+    def test_no_attest_section_by_default(self, fake_audit, tmp_path):
+        from darnit_baseline.tools import audit_openssf_baseline
+
+        output = audit_openssf_baseline(
+            owner="acme",
+            repo="widget",
+            local_path=str(tmp_path),
+            level=1,
+        )
+        assert "## Attestation" not in output
+
+
+class TestGenerateAttestationToolImports:
+    def test_generate_attestation_from_results_importable(self):
+        # The tool previously imported `generate_attestation`, which does
+        # not exist in the attestation package and raised ImportError at
+        # call time.
+        from darnit_baseline.attestation import (
+            generate_attestation_from_results,  # noqa: F401
+        )
+
+    def test_tool_uses_existing_attestation_api(self, fake_audit, tmp_path, monkeypatch):
+        import darnit_baseline.attestation as attestation_pkg
+        from darnit_baseline.tools import generate_attestation
+
+        def _fake_generate(audit_result, **kwargs):
+            return "✅ Attestation saved to: /tmp/fake.intoto.json"
+
+        monkeypatch.setattr(attestation_pkg, "generate_attestation_from_results", _fake_generate)
+
+        output = generate_attestation(
+            owner="acme",
+            repo="widget",
+            local_path=str(tmp_path),
+            level=1,
+            sign=False,
+        )
+        assert output.startswith("✅")


### PR DESCRIPTION
## Summary
- `audit_openssf_baseline(output_format="sarif")` was advertised in the docstring but silently fell through to markdown — it now routes to `generate_sarif_audit()` (the existing, tested SARIF 2.1.0 formatter that was never wired in)
- The `attest` / `sign_attestation` / `staging` parameters were accepted but never used — `attest=True` now generates an in-toto attestation via `generate_attestation_from_results()`, appending an `## Attestation` section to markdown output (JSON/SARIF outputs stay valid JSON; the attestation file is still written either way)
- The `generate_attestation` MCP tool was completely broken on main: it imported `darnit_baseline.attestation.generate_attestation`, which does not exist, so every call raised `ImportError`. It now runs the sieve audit and calls the real `generate_attestation_from_results()` API
- Shared `_build_audit_result()` helper assembles `AuditResult` (incl. git commit/ref) for both the SARIF and attestation paths

## Test plan
- [x] New regression tests in `tests/darnit_baseline/test_tools_output_wiring.py` (7 tests): SARIF format returns a valid SARIF 2.1.0 document (not markdown), attestation section is appended with correct sign flag and AuditResult contents, attestation is skipped without owner/repo, no section by default, and the `generate_attestation` tool imports/uses the real API
- [x] Full baseline suite: 730 passed, 6 skipped
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)