### PR TITLE
feat(cli): add --show-all to list every check in audit output

### DIFF
--- a/packages/darnit/src/darnit/cli.py
+++ b/packages/darnit/src/darnit/cli.py
@@ -74,7 +74,7 @@ def format_result_text(result: dict) -> str:
     return f"  {icon} {control_id}: {status} - {details}"
 
 
-def format_results_text(results: list[dict], framework_name: str) -> str:
+def format_results_text(results: list[dict], framework_name: str, show_all: bool = False) -> str:
     """Format all results for text output."""
     lines = [f"\n=== {framework_name} Audit Results ===\n"]
 
@@ -105,13 +105,27 @@ def format_results_text(results: list[dict], framework_name: str) -> str:
         for r in by_status["WARN"]:
             lines.append(format_result_text(r))
 
-    # Show passes (optional, can be verbose)
+    # Show passes
     if "PASS" in by_status:
         lines.append(f"\n--- Passed ({len(by_status['PASS'])}) ---")
-        for r in by_status["PASS"][:10]:  # Limit to 10
+        passes = by_status["PASS"] if show_all else by_status["PASS"][:10]
+        for r in passes:
             lines.append(format_result_text(r))
-        if len(by_status["PASS"]) > 10:
-            lines.append(f"  ... and {len(by_status['PASS']) - 10} more")
+        if not show_all and len(by_status["PASS"]) > 10:
+            lines.append(
+                f"  ... and {len(by_status['PASS']) - 10} more "
+                "(use --show-all to list every check)"
+            )
+
+    # With --show-all, list every remaining status (e.g. N/A) so the output
+    # documents every check for conformance evidence.
+    if show_all:
+        for status, group in by_status.items():
+            if status in ("FAIL", "WARN", "PASS"):
+                continue
+            lines.append(f"\n--- {status} ({len(group)}) ---")
+            for r in group:
+                lines.append(format_result_text(r))
 
     return "\n".join(lines)
 
@@ -221,7 +235,9 @@ def cmd_audit(args: argparse.Namespace) -> int:
     if args.output == "json":
         sys.stdout.write(format_results_json(results, config.framework_name) + "\n")
     else:
-        sys.stdout.write(format_results_text(results, config.framework_name) + "\n")
+        sys.stdout.write(
+            format_results_text(results, config.framework_name, show_all=args.show_all) + "\n"
+        )
 
     # Return non-zero if any failures
     failures = [r for r in results if r.get("status") == "FAIL"]
@@ -773,6 +789,12 @@ def create_parser() -> argparse.ArgumentParser:
         "--no-fail",
         action="store_true",
         help="Don't exit with error code on failures",
+    )
+    audit_parser.add_argument(
+        "--show-all",
+        action="store_true",
+        help="List every check in text output: show all passed checks (no truncation) "
+             "and include N/A checks. Useful for documenting full OSPS Baseline conformance.",
     )
     audit_parser.add_argument(
         "--profile", "-p",

--- a/tests/darnit/test_cli.py
+++ b/tests/darnit/test_cli.py
@@ -4,7 +4,13 @@ import json
 
 import pytest
 
-from darnit.cli import create_parser, format_result_text, format_results_json, main
+from darnit.cli import (
+    create_parser,
+    format_result_text,
+    format_results_json,
+    format_results_text,
+    main,
+)
 
 
 def test_install_claude_creates_settings(tmp_path, monkeypatch, caplog):
@@ -223,3 +229,39 @@ class TestFormatting:
             "warn": 1,
             "na": 1,
         }
+
+
+@pytest.mark.unit
+def test_audit_command_parses_show_all():
+    """The audit command accepts --show-all."""
+    args = create_parser().parse_args(["audit", "--show-all", "."])
+    assert args.command == "audit"
+    assert args.show_all is True
+
+
+@pytest.mark.unit
+def test_audit_show_all_defaults_false():
+    """--show-all defaults to False."""
+    args = create_parser().parse_args(["audit", "."])
+    assert args.show_all is False
+
+
+@pytest.mark.unit
+def test_format_results_text_truncates_passes_by_default():
+    """By default the passed section truncates past 10 with a hint."""
+    results = [{"id": f"OSPS-X-{i:02d}", "status": "PASS", "details": "ok"} for i in range(15)]
+    rendered = format_results_text(results, "openssf-baseline")
+    assert "... and 5 more" in rendered
+    assert "--show-all" in rendered
+
+
+@pytest.mark.unit
+def test_format_results_text_show_all_lists_every_check():
+    """--show-all lists all passes (no truncation) and includes N/A checks."""
+    results = [{"id": f"OSPS-X-{i:02d}", "status": "PASS", "details": "ok"} for i in range(15)]
+    results.append({"id": "OSPS-NA-01.01", "status": "NA", "details": "not applicable"})
+    rendered = format_results_text(results, "openssf-baseline", show_all=True)
+    assert "... and" not in rendered
+    for i in range(15):
+        assert f"OSPS-X-{i:02d}" in rendered
+    assert "OSPS-NA-01.01" in rendered


### PR DESCRIPTION
Closes #293. Default text output truncates the passed section to 10 ("... and N more"), --show-all lists every passed check and includes N/A, so maintainers can document full OSPS Baseline conformance. Default output is unchanged.

## Summary

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist

If this PR modifies the darnit framework (`packages/darnit/`):

- [ ] Updated framework spec (`openspec/specs/framework-design/spec.md`) if behavior changed
- [ ] Ran `uv run python scripts/validate_sync.py --verbose` and it passes
- [ ] Ran `uv run python scripts/generate_docs.py` and committed any doc changes
- [x] N/A — CLI output only; no spec/control/doc changes.

## Control/TOML Changes Checklist

If this PR modifies controls or TOML configuration:

- [ ] Control metadata defined in TOML (not Python code)
- [ ] SARIF fields (description, severity, help_url) included where appropriate
- [ ] Ran validation to confirm TOML schema compliance
- [x] N/A — no controls or TOML modified.

## Testing

- [x] Tests pass locally (`uv run pytest tests/ -v`)
- [x] Added tests for new functionality (if applicable)
- [x] Linting passes (`uv run ruff check .`)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
