### PR TITLE
fix(packaging): add [build-system] to darnit-mcp root so it builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,3 +163,10 @@ known-first-party = ["darnit", "darnit_baseline", "darnit_example"]
 [tool.bandit]
 exclude_dirs = ["tests", "docs/examples"]
 skips = ["B101"]  # Allow assert statements
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+bypass-selection = true


### PR DESCRIPTION
release.yml runs uv build --package darnit-mcp, which fails because the root pyproject (name = darnit-mcp) has no build-system. hatchling with bypass-selection = true builds the dependency-only wheel correctly.

## Summary

<!-- Brief description of changes -->

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist

If this PR modifies the darnit framework (`packages/darnit/`):

- [ ] Updated framework spec (`openspec/specs/framework-design/spec.md`) if behavior changed
- [ ] Ran `uv run python scripts/validate_sync.py --verbose` and it passes
- [ ] Ran `uv run python scripts/generate_docs.py` and committed any doc changes

## Control/TOML Changes Checklist

If this PR modifies controls or TOML configuration:

- [ ] Control metadata defined in TOML (not Python code)
- [ ] SARIF fields (description, severity, help_url) included where appropriate
- [ ] Ran validation to confirm TOML schema compliance

## Testing

- [ ] Tests pass locally (`uv run pytest tests/ -v`)
- [ ] Added tests for new functionality (if applicable)
- [ ] Linting passes (`uv run ruff check .`)

## Additional Notes

<!-- Any additional context, screenshots, or information -->

Per @mlieberman85's request on #261.