### PR TITLE
Add files via upload

### DIFF
--- a/parsing.py
+++ b/parsing.py
@@ -1,0 +1,199 @@
+"""Tree-sitter wrappers and query execution helpers.
+
+This module isolates every interaction with the tree-sitter 0.25 API so the
+rest of the discovery pipeline stays ergonomic. Queries are constructed as
+module-level constants in `queries/<language>.py` and re-used across files.
+
+Thread-safety notes:
+
+* ``tree_sitter.Language`` is thread-safe and can be shared.
+* ``tree_sitter.Parser`` is NOT thread-safe. Create one per worker.
+* ``tree_sitter.QueryCursor`` is NOT thread-safe. Create one per call.
+
+Error recovery:
+
+Tree-sitter never raises on malformed input; ``parser.parse()`` returns a tree
+with ``ERROR`` / ``MISSING`` nodes and queries still work on recoverable parts.
+The wrappers below never wrap ``parse()`` in a ``try`` block.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+try:
+    import tree_sitter as ts
+    from tree_sitter_language_pack import get_language, get_parser
+
+    TREE_SITTER_AVAILABLE = True
+except ImportError:  # pragma: no cover — dependency is required in pyproject.toml
+    TREE_SITTER_AVAILABLE = False
+    ts = None  # type: ignore[assignment]
+
+    def get_language(name: str) -> Any:  # type: ignore[misc]
+        raise ImportError("tree-sitter-language-pack is not installed")
+
+    def get_parser(name: str) -> Any:  # type: ignore[misc]
+        raise ImportError("tree-sitter-language-pack is not installed")
+
+
+logger = logging.getLogger("darnit_baseline.threat_model.parsing")
+
+
+# ---------------------------------------------------------------------------
+# Supported languages
+# ---------------------------------------------------------------------------
+
+
+#: Languages the discovery pipeline understands structurally. TOML is not in
+#: this list — see FR-005 in spec.md.
+SUPPORTED_LANGUAGES: frozenset[str] = frozenset(
+    {"python", "javascript", "typescript", "tsx", "go", "yaml"}
+)
+
+
+#: Map file extensions to the tree-sitter grammar name. Every entry here must
+#: resolve via ``get_language`` in ``tree-sitter-language-pack``.
+_EXTENSION_TO_LANGUAGE: dict[str, str] = {
+    ".py": "python",
+    ".pyi": "python",
+    ".js": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".go": "go",
+    ".yml": "yaml",
+    ".yaml": "yaml",
+}
+
+
+def detect_language_from_path(path: str | Path) -> str | None:
+    """Return the tree-sitter grammar name for a file path, or None.
+
+    Unknown extensions return None; callers should skip such files silently
+    (they count toward `FileScanStats.total_files_seen` but not
+    `in_scope_files`).
+    """
+
+    suffix = Path(path).suffix.lower()
+    return _EXTENSION_TO_LANGUAGE.get(suffix)
+
+
+# ---------------------------------------------------------------------------
+# Parser / query helpers
+# ---------------------------------------------------------------------------
+
+def get_root_node(tree):
+    """Compat: tree-sitter-language-pack 1.8+ made root_node a method."""
+    rn = tree.root_node
+    return rn() if callable(rn) else rn
+
+
+def get_tree_sitter_parser(language_name: str) -> Any:
+    """Return a ready-to-use ``tree_sitter.Parser`` for the given language.
+
+    Wraps ``tree_sitter_language_pack.get_parser`` so future caching /
+    pooling can be introduced in one place without touching call sites.
+    """
+    if language_name not in SUPPORTED_LANGUAGES:
+        raise ValueError(
+            f"Unsupported language: {language_name!r}. "
+            f"Supported: {sorted(SUPPORTED_LANGUAGES)}"
+        )
+    return get_parser(language_name)
+
+
+def parse_source(language_name: str, content: bytes) -> Any:
+    """Parse source bytes into a tree-sitter Tree.
+
+    Never raises on malformed input; tree-sitter recovers and returns a tree
+    with ``ERROR`` nodes for the broken portions. Callers can inspect
+    ``tree.root_node.has_error`` for diagnostic logging but the remaining
+    captures are still valid.
+
+    Compatibility: the ``parser.parse()`` argument type changed between
+    ``tree-sitter-language-pack`` releases — 1.5.x accepts ``bytes``,
+    1.8.x accepts only ``str``. We try ``bytes`` first (the historical
+    contract and what the rest of darnit's pipeline carries around) and
+    fall back to a UTF-8 decode on TypeError. Bytes that aren't valid
+    UTF-8 are decoded with ``errors="replace"`` so a single odd file
+    doesn't sink the whole audit.
+    """
+
+    if not isinstance(content, (bytes, bytearray)):
+        raise TypeError(
+            f"parse_source expected bytes, got {type(content).__name__}"
+        )
+    parser = get_tree_sitter_parser(language_name)
+    try:
+        if hasattr(parser, "parse_bytes"):
+            tree = parser.parse_bytes(bytes(content))
+        else:
+            tree = parser.parse(bytes(content))
+    except TypeError:
+        # Fallback for intermediate string-only versions if necessary
+        tree = parser.parse(bytes(content).decode("utf-8", errors="replace"))
+    if get_root_node(tree).has_error:
+        logger.debug(
+            "tree-sitter reported parse errors for %s (recoverable)", language_name
+        )
+    return tree
+
+
+def make_query(language_name: str, sexpr: str) -> Any:
+    """Compile an S-expression query against the grammar for the given language.
+
+    Queries should be constructed once at module load time and cached as
+    module-level constants; query construction is significantly more expensive
+    than execution.
+    """
+
+    if language_name not in SUPPORTED_LANGUAGES:
+        raise ValueError(
+            f"Unsupported language: {language_name!r}. "
+            f"Supported: {sorted(SUPPORTED_LANGUAGES)}"
+        )
+    language = get_language(language_name)
+    return ts.Query(language, sexpr)
+
+
+def run_query(query: Any, root_node: Any) -> Iterator[dict[str, list[Any]]]:
+    """Execute a compiled query and yield one capture dict per match.
+
+    Each yielded dict maps capture names to lists of ``tree_sitter.Node``.
+    Note that every capture name maps to a *list* even when only one node
+    matched — always index ``[0]`` or iterate.
+    """
+
+    cursor = ts.QueryCursor(query)
+    for _pattern_index, captures in cursor.matches(root_node):
+        yield captures
+
+
+def node_text(node: Any, source: bytes) -> str:
+    """Return the UTF-8 decoded text of a tree-sitter node.
+
+    Handles the common failure mode where callers pass a ``str`` source by
+    decoding lazily via ``node.text`` when the source is not available.
+    """
+
+    if source is not None:
+        return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+    return node.text.decode("utf-8", errors="replace")
+
+
+__all__ = [
+    "SUPPORTED_LANGUAGES",
+    "detect_language_from_path",
+    "get_tree_sitter_parser",
+    "parse_source",
+    "make_query",
+    "run_query",
+    "node_text",
+    "TREE_SITTER_AVAILABLE",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,27 +1,35 @@
 [project]
-name = "darnit-mcp"
+name = "darnit-baseline"
 version = "0.1.0"
-description = "MCP server for compliance auditing using the darnit framework"
+description = "OpenSSF Baseline (OSPS v2025.10.10) compliance checks for darnit"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 authors = [
-    { name = "Michael Lieberman" }
+    { name = "Kusari", email = "info@kusari.dev" },
 ]
-keywords = ["security", "compliance", "mcp", "openssf", "baseline", "osps"]
+keywords = ["security", "compliance", "openssf", "baseline", "osps"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Security",
+    "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "darnit-core",
-    "darnit-baseline",
-    "darnit-gittuf",
-    "darnit-reproducibility",
+    "darnit-core>=0.1.0",
+    "tree-sitter>=0.25",
+    # tree-sitter-language-pack 1.8+ changed two APIs the threat-model
+    # pipeline depends on:
+    #   1. parser.parse() now wants str only (not bytes) and exposes a
+    #      separate parse_bytes() for the old contract.
+    #   2. tree.root_node became a callable method instead of a property.
+    # Cap at <1.8 until darnit's parsing layer supports both shapes. See #268.
+    "tree-sitter-language-pack>=1.5",
 ]
 
 [project.urls]
@@ -29,140 +37,21 @@ Homepage = "https://github.com/kusari-oss/darnit"
 Repository = "https://github.com/kusari-oss/darnit"
 Issues = "https://github.com/kusari-oss/darnit/issues"
 
-[project.optional-dependencies]
-attestation = [
-    "darnit-core[attestation]",
-]
-dev = [
-    "pytest>=8.0.0",
-    "pytest-cov>=4.0.0",
-    "ruff>=0.8.0",
-    "pre-commit>=4.0.0",
-    "vulture>=2.11",
-]
+[project.entry-points."darnit.implementations"]
+openssf-baseline = "darnit_baseline:register"
 
-[tool.uv.workspace]
-members = ["packages/*"]
+[project.entry-points."darnit.frameworks"]
+openssf-baseline = "darnit_baseline:get_framework_path"
 
-[tool.uv.sources]
-darnit-core = { workspace = true }
-darnit-baseline = { workspace = true }
-darnit-example = { workspace = true }
-darnit-gittuf = { workspace = true }
-darnit-reproducibility = { workspace = true }
-darnit-hello = { workspace = true }
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-python_files = ["test_*.py"]
-python_functions = ["test_*"]
-addopts = [
-    "-v",
-    "--tb=short",
-    "--strict-markers",
-]
-markers = [
-    "unit: Unit tests (no external dependencies)",
-    "integration: Integration tests (may require git/gh)",
-    "slow: Slow tests",
-    "upstream: Upstream spec sync tests (run nightly, excluded by default)",
-]
-filterwarnings = [
-    "ignore::DeprecationWarning:darnit_baseline.rules",
-]
+[tool.hatch.build.targets.wheel]
+packages = ["src/darnit_baseline"]
 
-[tool.coverage.run]
-source = ["packages/darnit/src", "packages/darnit-baseline/src"]
-omit = ["*/tests/*", "*/__pycache__/*"]
-
-[tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
-    "if TYPE_CHECKING:",
-    "raise NotImplementedError",
-]
-
-[dependency-groups]
-dev = [
-    "pytest-asyncio>=1.3.0",
-    "mypy>=1.8.0",
-    "ruff>=0.8.0",
-    "skills-ref>=0.1.1",
-    "jsonschema>=4.26.0",
-    "syrupy>=4.0.0",  # snapshot testing for threat-model rendering (014-cobra-threat-model R8)
-    # Internal/test-only workspace packages — not published to PyPI. Pinned here
-    # so they install for development and tests via `uv sync`, but do not become
-    # runtime dependencies of any published wheel.
-    "darnit-example",
-    "darnit-hello",
-]
-
-[tool.mypy]
-python_version = "3.11"
-warn_return_any = true
-warn_unused_ignores = true
-disallow_untyped_calls = true
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
-check_untyped_defs = true
-no_implicit_optional = true
-warn_redundant_casts = true
-strict_equality = true
-# Gradually enable stricter checks
-packages = [
-    "darnit",
-    "darnit_baseline",
-]
-
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_defs = false
-
-[tool.ruff]
-target-version = "py311"
-line-length = 120
-exclude = [
-    ".git",
-    ".venv",
-    "__pycache__",
-    "build",
-    "dist",
-    ".eggs",
-    # Intentionally broken syntax fixture for FR-019 (parser error recovery test)
-    "tests/darnit_baseline/threat_model/fixtures/red_herrings/broken_syntax.py",
-]
-
-[tool.ruff.lint]
-select = [
-    "F",      # Pyflakes (includes F401 unused imports, F841 unused variables)
-    "E",      # pycodestyle errors
-    "W",      # pycodestyle warnings
-    "I",      # isort (import sorting)
-    "UP",     # pyupgrade (Python version upgrades)
-    "B",      # flake8-bugbear (common bugs)
-    "C4",     # flake8-comprehensions
-    "SIM",    # flake8-simplify
-]
-ignore = [
-    "E501",   # line too long (handled by formatter)
-    "E731",   # lambda assignment (sometimes useful)
-    "B008",   # function call in default argument (needed for FastAPI/MCP)
-    "SIM102", # nested if (sometimes more readable than combined)
-    "SIM105", # contextlib.suppress (explicit try-except often clearer)
-    "SIM108", # ternary operator (readability preference)
-    "SIM110", # any() suggestion (explicit loop often clearer)
-    "SIM116", # dict comprehension (sometimes explicit is clearer)
-    "UP042",  # StrEnum suggestion (pre-existing, not introduced by this PR)
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/*" = ["B", "SIM", "E402"]  # Less strict for tests, allow late imports
-"scripts/*" = ["E402"]  # Allow late imports in scripts
-"docs/examples/*" = ["B", "SIM", "E402"]  # Less strict for examples
-
-[tool.ruff.lint.isort]
-known-first-party = ["darnit", "darnit_baseline", "darnit_example"]
-
-[tool.bandit]
-exclude_dirs = ["tests", "docs/examples"]
-skips = ["B101"]  # Allow assert statements
+[tool.hatch.build.targets.wheel.force-include]
+"templates" = "darnit_baseline/templates"
+# opengrep_rules/ lives under src/darnit_baseline/threat_model/ and is already
+# packaged by the `packages` entry above. Re-adding it here caused hatch to fail
+# with "A second file is being added to the wheel archive at the same path".


### PR DESCRIPTION
## Summary
tree-sitter-language-pack 1.8 changed root_node from a property to a callable method, and parser.parse() now expects str instead of bytes.

- Added a get_root_node() helper in parsing.py that checks if root_node is callable and handles both cases. Updated all call sites in parsing.py and ts_discovery.py to use it instead of tree.root_node directly.
- Updated parse_source to try parser.parse_bytes() first if it exists, and fall back to parser.parse() for older versions.

Also lifted the version cap in pyproject.toml from >=1.5,<1.8 to >=1.5 so the new version can actually get installed.

Checked grouping.py and ranking.py too, neither one touches root_node so I left them alone.

Closes #268

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist
If this PR modifies the darnit framework (`packages/darnit/`):
- [ ] Updated framework spec (`docs/architecture/framework-design.md`) if behavior changed
- [ ] Ran `uv run python scripts/validate_sync.py --verbose` and it passes

## Control/TOML Changes Checklist
If this PR modifies controls or TOML configuration:
- [ ] Control metadata defined in TOML (not Python code)
- [ ] SARIF fields (description, severity, help_url) included where appropriate
- [ ] Ran validation to confirm TOML schema compliance

## Testing
- [ ] Tests pass locally (`uv run pytest tests/ -v`)
- [ ] Added tests for new functionality (if applicable)
- [ ] Linting passes (`uv run ruff check .`)

## Additional Notes
This PR doesn't touch any other frameworks, so those checklists don't apply here. 