### PR TITLE
fix(baseline): OSPS-DO-02.01 fallback to WARN when defect reporting guide not auto-detected

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -1258,6 +1258,7 @@ look_for_urls = false
 [[controls."OSPS-DO-02.01".passes]]
 handler = "file_exists"
 use_locator = true
+expr = 'has(output.found_file)'
 
 [[controls."OSPS-DO-02.01".passes]]
 handler = "pattern"
@@ -1270,11 +1271,19 @@ files = [
   "CONTRIBUTING.md",
 ]
 pass_if_any = true
+expr = 'output.any_match'
 
 [controls."OSPS-DO-02.01".passes.pattern.patterns]
 template_structure = '(?si)(describe.*bug|steps.*reproduce|expected.*behav|actual.*behav)'
 bug_reporting_link = '(?i)(report|submit|file).{0,30}(bug|issue|defect).{0,30}(http|github|tracker|template)'
 issue_template_yaml = '(?i)^name:\s+.*(bug|defect|issue)'
+
+[[controls."OSPS-DO-02.01".passes]]
+handler = "manual"
+steps = [
+    "Check if project documentation clearly explains how to report defects",
+    "Verify the contributing guide sets expectations for how defects will be triaged and resolved",
+]
 
 [controls."OSPS-DO-02.01".remediation]
 safe = true

--- a/tests/darnit_baseline/test_handler_dispatch_integration.py
+++ b/tests/darnit_baseline/test_handler_dispatch_integration.py
@@ -549,8 +549,8 @@ body:
         assert result.evidence.get("relative_path") == f".github/ISSUE_TEMPLATE/{template_filename}"
 
     @pytest.mark.unit
-    def test_osps_do_02_01_fails_for_feature_only_template(self, tmp_path):
-        """OSPS-DO-02.01 should fail when only a feature template exists."""
+    def test_osps_do_02_01_warns_for_feature_only_template(self, tmp_path):
+        """OSPS-DO-02.01 should warn (manual fallback) when only a feature template exists."""
         from pathlib import Path
 
         from darnit.config import load_controls_from_effective, load_effective_config_by_name
@@ -585,4 +585,4 @@ body:
         )
         result = orchestrator.verify(control, context)
 
-        assert result.status == "FAIL"
+        assert result.status == "WARN"

--- a/tests/darnit_baseline/test_handler_dispatch_integration.py
+++ b/tests/darnit_baseline/test_handler_dispatch_integration.py
@@ -586,3 +586,38 @@ body:
         result = orchestrator.verify(control, context)
 
         assert result.status == "WARN"
+
+    @pytest.mark.unit
+    def test_osps_do_02_01_passes_for_contributing_md_with_bug_link(self, tmp_path):
+        """OSPS-DO-02.01 should pass when CONTRIBUTING.md contains a defect-reporting link.
+
+        Covers the pattern handler path: a project whose contributing guide
+        tells users to 'report a bug, file an issue at https://github.com/x/y/issues'
+        satisfies the control even without a .github/ISSUE_TEMPLATE/bug* file.
+        """
+        from pathlib import Path
+
+        from darnit.config import load_controls_from_effective, load_effective_config_by_name
+
+        contributing = tmp_path / "CONTRIBUTING.md"
+        contributing.write_text(
+            "# Contributing\n\n"
+            "To report a bug, file an issue at https://github.com/x/y/issues\n"
+        )
+
+        config = load_effective_config_by_name("openssf-baseline", Path("."))
+        controls = load_controls_from_effective(config)
+        control = next(ctrl for ctrl in controls if ctrl.control_id == "OSPS-DO-02.01")
+
+        orchestrator = SieveOrchestrator()
+        context = CheckContext(
+            owner="testorg",
+            repo="testrepo",
+            local_path=str(tmp_path),
+            default_branch="main",
+            control_id="OSPS-DO-02.01",
+            project_context={},
+        )
+        result = orchestrator.verify(control, context)
+
+        assert result.status == "PASS"


### PR DESCRIPTION
## Summary

Fixes #307.

The current evaluation for `OSPS-DO-02.01` fails projects when none of the specific issue template files are found. However, the [control requirement](https://baseline.openssf.org/versions/2026-02-19#osps-do-0201) states:

> When the project has made a release, the project documentation MUST include a guide for reporting defects.

Those specific files (`.github/ISSUE_TEMPLATE/bug*.md`, etc.) are **sufficient but not necessary** to satisfy the control  the guide could live anywhere in the docs. Automatically returning `FAIL` is therefore a misalignment.

## Changes

### `packages/darnit-baseline/openssf-baseline.toml`

- **Add `expr` to `file_exists` pass** - `expr = 'has(output.found_file)'`: ensures the file exists check only PASS when a matching file is actually found (correctly short-circuits to PASS on success).
- **Add `expr` to `pattern` pass** - `expr = 'output.any_match'`: ensures the pattern check correctly PASS when any match is found.  
- **Add `manual` fallback pass** - after the automated checks fail to find specific files, a `handler = "manual"` pass is now the final step with human reviewable steps:
  1. Check if project documentation clearly explains how to report defects
  2. Verify the contributing guide sets expectations for how defects will be triaged and resolved

This means the control now resolves as:
-  **PASS** - if a bug template file or contributing guide pattern is found automatically
-  **WARN** - if automated checks don't find the files but a human can verify via the manual steps (instead of FAIL)

### `tests/darnit_baseline/test_handler_dispatch_integration.py`

- Renamed `test_osps_do_02_01_fails_for_feature_only_template` → `test_osps_do_02_01_warns_for_feature_only_template`
- Updated assertion from `result.status == "FAIL"` → `result.status == "WARN"` to assert the correct manual-fallback behavior

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Control/TOML Changes Checklist

- [x] Control metadata defined in TOML (not Python code)
- [x] SARIF fields (description, severity, help_url) included where appropriate

## Testing

- [x] Tests pass locally (`uv run pytest tests/ --ignore=tests/integration/ -q`) - 2072 passed, 6 skipped
- [x] Relevant tests updated to assert the new WARN behavior
- [x] Linting passes (`uv run ruff check .`)