### PR TITLE
fix(release): resolve signing identity against darnitdevorg after org move

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -218,7 +218,7 @@ jobs:
 
           python -m sigstore verify identity \
             --bundle /tmp/attestation.sigstore.json \
-            --cert-identity-regexp '^https://github\.com/kusari-oss/darnit/\.github/workflows/release\.yml@' \
+            --cert-identity-regexp "^https://github\.com/${{ github.repository }}/\.github/workflows/release\.yml@" \
             --cert-oidc-issuer https://token.actions.githubusercontent.com \
             "$wheel"
           echo "✓ Sigstore identity verified for $PKG $VERSION"
@@ -286,7 +286,7 @@ jobs:
         run: |
           set -euo pipefail
           cosign verify "$REF" \
-            --certificate-identity-regexp '^https://github\.com/kusari-oss/darnit/\.github/workflows/release\.yml@' \
+            --certificate-identity-regexp "^https://github\.com/${{ github.repository }}/\.github/workflows/release\.yml@" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             > /tmp/cosign-verify.json
           echo "✓ cosign verified $REF"
@@ -298,7 +298,7 @@ jobs:
           set -euo pipefail
           cosign verify-attestation "$REF" \
             --type spdx \
-            --certificate-identity-regexp '^https://github\.com/kusari-oss/darnit/\.github/workflows/release\.yml@' \
+            --certificate-identity-regexp "^https://github\.com/${{ github.repository }}/\.github/workflows/release\.yml@" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             > /tmp/cosign-verify-attestation.json
           echo "✓ cosign verified SBOM attestation on $REF"
@@ -373,7 +373,7 @@ jobs:
           bin="/tmp/dl/darnit-${VERSION}-${OS}-${ARCH}"
           cosign verify-blob \
             --bundle "${bin}.sigstore" \
-            --certificate-identity-regexp '^https://github\.com/kusari-oss/darnit/\.github/workflows/release\.yml@' \
+            --certificate-identity-regexp "^https://github\.com/${{ github.repository }}/\.github/workflows/release\.yml@" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             "$bin"
           echo "✓ cosign verified blob signature for ${OS}-${ARCH}"

--- a/packages/darnit/src/darnit/core/verification.py
+++ b/packages/darnit/src/darnit/core/verification.py
@@ -4,7 +4,9 @@ This module provides Sigstore-based verification for darnit plugins,
 supporting both signed and unsigned plugins with configurable policies.
 
 Default Trusted Publishers:
-    By default, plugins from kusari-oss and kusaridev are trusted.
+    By default, plugins from darnitdevorg, kusari-oss, and kusaridev are trusted.
+    darnitdevorg is the current publishing identity; kusari-oss and kusaridev
+    are retained so artifacts signed before the org migration still verify.
     Users can add additional trusted publishers in their configuration.
 
 Example:
@@ -16,7 +18,8 @@ Example:
         trusted_publishers=[
             "https://github.com/my-org",  # Add your org
         ],
-        # use_default_publishers=True (default) includes kusari-oss, kusaridev
+        # use_default_publishers=True (default) includes darnitdevorg,
+        # kusari-oss, kusaridev
     )
     verifier = PluginVerifier(config)
 
@@ -72,8 +75,10 @@ PYPI_JSON_API_URL = "https://pypi.org/pypi/{package}/{version}/json"
 # Default trusted publishers for darnit ecosystem
 # These are always trusted unless explicitly overridden
 DEFAULT_TRUSTED_PUBLISHERS = (
+    "https://github.com/darnitdevorg",
     "https://github.com/kusari-oss",
     "https://github.com/kusaridev",
+    "darnitdevorg",
     "kusari-oss",
     "kusaridev",
 )

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -2,9 +2,13 @@
 
 Maintainer-facing documentation for the darnit release pipeline. End-user install instructions live in [`docs/install/`](../docs/install/), including [from-source.md](../docs/install/from-source.md) for users wanting to try unreleased features before they're cut into a published release.
 
-> **Canonical repository home**: `https://github.com/kusari-oss/darnit`
+> **Canonical repository home**: `https://github.com/darnitdevorg/darnit`
 >
-> Earlier metadata referenced `kusaridev/darnit-mcp` and `kusaridev/baseline-mcp`. Those names are deprecated. All package URLs, workflow identities, and Sigstore signing certificates resolve against `kusari-oss/darnit`.
+> The repository moved from `kusari-oss/darnit` to `darnitdevorg/darnit`. GitHub redirects the old path, so stale URLs appear to work -- but Sigstore certificate identities do not redirect. Workflow identities and signing certificates for releases cut after the move resolve against `darnitdevorg/darnit`; artifacts published before it remain signed under `kusari-oss/darnit` and must be verified against that identity.
+>
+> Two things deliberately stay under the old org: the Homebrew tap (`kusari-oss/homebrew-tap`) and, for backward compatibility, the `kusari-oss` entry in `DEFAULT_TRUSTED_PUBLISHERS`.
+>
+> Earlier metadata referenced `kusaridev/darnit-mcp` and `kusaridev/baseline-mcp`. Those names are deprecated.
 
 ## Overview
 
@@ -13,7 +17,7 @@ darnit is released through five user-facing channels from a single tag-driven pi
 | Channel | Surface | Stable | Pre-release | Contract |
 |---|---|---|---|---|
 | PyPI | `pypi.org/project/darnit-*` | ✅ | TestPyPI | [pypi-publish-contract.md](../specs/012-packaging-distribution/contracts/pypi-publish-contract.md) |
-| Container | `ghcr.io/kusari-oss/darnit` | ✅ | ✅ (`-rc` tags) | [container-image-contract.md](../specs/012-packaging-distribution/contracts/container-image-contract.md) |
+| Container | `ghcr.io/darnitdevorg/darnit` | ✅ | ✅ (`-rc` tags) | [container-image-contract.md](../specs/012-packaging-distribution/contracts/container-image-contract.md) |
 | Binary | GitHub Release assets | ✅ | ✅ (marked pre-release) | [binary-artifact-contract.md](../specs/012-packaging-distribution/contracts/binary-artifact-contract.md) |
 | Homebrew | `kusari-oss/homebrew-tap` | ✅ | ❌ (stable only) | [homebrew-formula-contract.md](../specs/012-packaging-distribution/contracts/homebrew-formula-contract.md) |
 | Claude Code plugin | GitHub Release asset | ✅ | ❌ (stable only) | [claude-plugin-contract.md](../specs/012-packaging-distribution/contracts/claude-plugin-contract.md) |


### PR DESCRIPTION
## Summary

The repository moved from `kusari-oss/darnit` to `darnitdevorg/darnit`. GitHub redirects the old path, so git remotes, links, and `gh` commands all keep working -- which is exactly why this was easy to miss. **Sigstore certificate identities do not redirect.** Three things were still pinned to the old org, one of which breaks the next release.

Fixes the release-breaking items only. Cosmetic `kusari-oss` references (pyproject `Homepage`/`Repository`, docstring examples, SARIF `informationUri`, a link-filter string in `scanner.py`) are left for a separate PR so this diff stays reviewable.

## 1. Smoke-test verification would fail on the next release

`release-smoke.yml` hardcoded the signing workflow identity in four caret-anchored regexes:

```
^https://github\.com/kusari-oss/darnit/\.github/workflows/release\.yml@
```

Once `release.yml` runs from `darnitdevorg`, the OIDC certificate identity becomes `.../darnitdevorg/darnit/...`, the anchored regex stops matching, and every `sigstore verify` / `cosign verify` / `cosign verify-attestation` / `cosign verify-blob` step in the smoke suite fails.

Replaced the literal with `${{ github.repository }}` (lines 221, 289, 301, 376) so the identity follows the repo instead of needing another edit on the next move. `github.repository` cannot contain shell metacharacters, so interpolating it into the double-quoted argument is safe.

**Reviewer note:** this now verifies against *the current repo*. Re-running smoke against artifacts published **before** the migration will need the old identity passed explicitly, since those are genuinely signed under `kusari-oss/darnit`. That seemed better than permanently widening the accepted identity with a regex alternation -- an identity check should stay tight.

## 2. `DEFAULT_TRUSTED_PUBLISHERS` did not include the new org

`core/verification.py` listed only `kusari-oss` and `kusaridev`, so plugins signed by the current publishing identity would fail default verification.

Added `darnitdevorg`. **Kept `kusari-oss` and `kusaridev`** so anything already published and signed under the old identities still verifies for existing users. Retiring them is a deliberate follow-up once nothing signed under them is in circulation -- not something to bundle here.

## 3. The maintainer runbook asserted something now false

`packaging/README.md` stated that "All package URLs, workflow identities, and Sigstore signing certificates resolve against `kusari-oss/darnit`." That would actively mislead during a release. Corrected, including the container path (`ghcr.io/darnitdevorg/darnit` -- `release.yml` already derives this from `GITHUB_REPOSITORY_OWNER`, so the image itself self-healed).

Documented the two things that **deliberately stay** under the old org:
- `kusari-oss/homebrew-tap` -- the tap did not move, so `release.yml`'s dispatch target is correct as-is.
- The `kusari-oss` entry in the trusted publisher defaults, for the compatibility reason above.

## External actions this PR cannot cover

Both need checking before the next release:

- [ ] **PyPI trusted publishing** is configured per-project on PyPI with an explicit owner/repo/workflow. If it still names `kusari-oss`, publishing fails outright.
- [ ] **The GitHub App used for tap dispatch** (chosen over a PAT for cross-repo dispatch) must be installed on `darnitdevorg/darnit`. The tap side is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Framework Changes Checklist

- [x] No behavior change to the framework spec; `verification.py` change is a data addition to a constant
- [ ] `validate_sync.py` not run -- no TOML/handler/SARIF surface touched

## Testing

- [x] `uv run pytest tests/darnit/core/test_verification.py -q` -- 26 passed
- [x] `uv run ruff check` on the changed module -- clean
- [x] `release-smoke.yml` parses as valid YAML after the edit
- [ ] End-to-end verification is only exercisable by an actual release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)