### PR TITLE
feat(governance): narrow auto_detect = false to propose-only (constitution 1.3.0)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/015-tsc-charter"
+  "feature_directory": "specs/018-auto-detect-propose-only"
 }

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,69 @@
 <!--
 Sync Impact Report
 ==================
+Version change: 1.2.0 -> 1.3.0
+Modified principles:
+  - IV. Never Guess User Values: narrowed from a prohibition on
+    detection to a prohibition on concluding. Detection MAY now run
+    for a user-judgment key for the sole purpose of producing a
+    candidate to show a person; the candidate MUST NOT be consumed
+    as the key's value by control verification results, compliance
+    calculations, remediation action inputs, generated attestations,
+    or persisted project context. Human confirmation remains the only
+    transition that makes a value usable.
+Rationale for MINOR rather than MAJOR:
+  The core requirement -- the framework MUST NOT silently apply
+  values requiring user judgment -- is unchanged. Only the permitted
+  mechanism widens: producing a value and using a value were
+  previously conflated in a single sentence, and this amendment
+  separates them. This matches the justification recorded at
+  1.0.0 -> 1.1.0, where this same principle was widened to permit
+  confidence-based auto-acceptance and was classified MINOR on the
+  grounds that the core requirement stayed intact. Per the Governance
+  section, MAJOR is reserved for principle removal or incompatible
+  redefinition; no existing guarantee is withdrawn here.
+Reconciliation, not authorization:
+  The propose-only mechanism already ships. `allow_sieve_hints` and
+  `hint_sources` exist in the framework schema, and the OpenSSF
+  Baseline configuration enables them for `maintainers` and
+  `security_contact`. The previous wording therefore misdescribed the
+  system. This amendment corrects the document, not the behavior; no
+  code, configuration, or test changes accompany it.
+Added guidance:
+  - The flag pair is now stated explicitly: `auto_detect` governs
+    concluding, `allow_sieve_hints` governs proposing. The safety
+    property is enforced by the pair rather than by a ban on
+    detection.
+  - The confidence-threshold provision is now scoped to keys that do
+    NOT require user judgment. It previously read as unscoped, which
+    left it applicable to user-judgment keys by omission.
+  - A confirmation must record when it was made, by whom, and which
+    candidate it was based on, and may expire after a configurable
+    period. The period is deliberately not fixed here.
+Added sections: none
+Removed sections: none
+Templates requiring updates:
+  - .specify/templates/plan-template.md -- no changes needed
+  - .specify/templates/spec-template.md -- no changes needed
+  - .specify/templates/tasks-template.md -- no changes needed
+Dependent documents updated in the same change:
+  - CLAUDE.md (Conservative-by-Default section)
+  - ARCHITECTURE.md (normative restatement and the auto_detect note)
+  - docs/design/CONTEXT_PROMPTS.md, docs/IMPLEMENTATION_GUIDE.md
+  - docs/rfcs/0001-core-rearchitecture.md (Stage 0 row)
+Deliberately not updated:
+  - packages/ code, configuration, and their comments. Changing them
+    would change behavior, which this amendment does not do. They are
+    enumerated in specs/018-auto-detect-propose-only/research.md.
+Follow-up TODOs:
+  - GOVERNANCE.md:51 enumerates only GOVERNANCE.md, the Charter, and
+    the TSC roster as governance artifacts requiring a Charter vote.
+    The constitution is not listed. Add it, so the track for the next
+    amendment is not ambiguous.
+==================
+
+Sync Impact Report
+==================
 Version change: 1.1.0 -> 1.2.0
 Modified sections:
   - Development Workflow: item 3 (Spec sync) reworded to match the
@@ -99,20 +162,48 @@ The framework MUST NOT silently apply values that require user
 judgment. All auto-detected values MUST go through an explicit,
 configurable verification mechanism.
 
-- When `auto_detect = false` in TOML, the sieve MUST NOT run for
-  that key. No exceptions.
+A key marked `auto_detect = false` is a user-judgment key: its
+correct value requires a person's decision rather than observation.
+For such a key the framework MAY propose a candidate, but MUST NOT
+conclude the value on its own.
+
+- Detection MAY run for a user-judgment key for the sole purpose of
+  producing a candidate to show a person. Producing a candidate is
+  not applying it.
+- A candidate MUST NOT be consumed as the key's value by any of:
+  control verification results, compliance calculations, remediation
+  action inputs, generated attestations, or persisted project
+  context. Until it is confirmed, a user-judgment key is unverified,
+  and unverified counts as FAIL (Principle II).
+- A candidate shown to a person MUST be labelled as unconfirmed and
+  MUST carry its origin -- how it was produced. Origin is not
+  confidence: a high-confidence guess is still a guess.
+- Human confirmation is the only transition that makes a value
+  usable. Persisting a candidate does not confirm it, and a stored
+  candidate MUST remain distinguishable from a confirmed value on
+  every later read.
+- A confirmation MUST record when it was made, by whom, and which
+  candidate it was based on. A confirmation MAY expire after a
+  configurable period, after which the key reverts to a candidate
+  and MUST be confirmed again. This constitution does not fix that
+  period.
 - "Context Confirmation Required" is a hard stop — the tool MUST
   ask the user rather than filling values from heuristics.
-- Sieve auto-detection is acceptable ONLY for keys where
-  `auto_detect = true` in the TOML definition.
-- Auto-acceptance of detected values MAY use a confidence-based
-  threshold (e.g., `auto_accept_confidence = 0.8`), but this
-  MUST be explicitly configured per-implementation in TOML —
-  never implicit or hard-coded. Implementations MUST be able to
-  force manual confirmation for all fields by setting the
-  threshold to 1.0.
-- LLM-facing prompts MUST NOT contain guessed values in executable
-  code snippets.
+- Two flags govern two separate axes: `auto_detect` governs whether
+  a value may be concluded without a person, and `allow_sieve_hints`
+  governs whether a detected value may be proposed as a candidate.
+  Both default to false. The safety property is enforced by the pair,
+  not by a prohibition on detection.
+- For keys that do NOT require user judgment, auto-acceptance of
+  detected values MAY use a confidence-based threshold (e.g.,
+  `auto_accept_confidence = 0.8`), but this MUST be explicitly
+  configured per-implementation in TOML, never implicit or
+  hard-coded. Implementations MUST be able to force manual
+  confirmation for all such fields by setting the threshold to 1.0.
+  No threshold, at any value, authorizes concluding a user-judgment
+  key.
+- LLM-facing prompts MUST NOT contain guessed values or unconfirmed
+  candidates in executable code snippets.
 
 ### V. Sieve Pipeline Integrity
 
@@ -184,4 +275,4 @@ Compliance with these principles MUST be verified during code review.
 The CLAUDE.md project instructions serve as the runtime development
 guidance and MUST remain consistent with this constitution.
 
-**Version**: 1.2.0 | **Ratified**: 2026-03-08 | **Last Amended**: 2026-06-21
+**Version**: 1.3.0 | **Ratified**: 2026-03-08 | **Last Amended**: 2026-07-28

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@ Darnit is a plugin-based compliance auditing framework. It exposes compliance ch
 This is a compliance auditing tool. Incorrect results are worse than incomplete results:
 
 - **Never assume compliance.** A control that hasn't been explicitly verified as passing is NOT compliant. WARN means "we don't know" and is treated the same as FAIL for compliance calculations.
-- **Never guess user-specific values.** Maintainers, security contacts, governance models require explicit user confirmation. When `auto_detect = false` in TOML, the sieve must not run for that key.
+- **Never guess user-specific values.** Maintainers, security contacts, governance models require explicit user confirmation. When `auto_detect = false` in TOML, the sieve may propose a candidate for that key but must never conclude it; the value stays unverified until a person confirms it.
 - **Err on the side of caution.** When in doubt, return WARN (needs verification), not PASS.
 
 ### How a Typical Session Works
@@ -438,7 +438,7 @@ At audit time, the framework merges Layer 1 + Layer 2 into an "effective config"
 
 The framework TOML defines `[context.*]` sections that describe what project-specific information improves audit accuracy. Each context key has a type, prompt, hint, and list of affected controls. The `get_pending_context()` MCP tool returns unanswered prompts; the `confirm_project_context()` tool saves answers to `.project/project.yaml`.
 
-Context values with `auto_detect = true` can be discovered by sieve passes (e.g., detecting CI provider from `.github/workflows/` existence). Values with `auto_detect = false` require explicit user confirmation.
+Context values with `auto_detect = true` can be discovered by sieve passes (e.g., detecting CI provider from `.github/workflows/` existence). Values with `auto_detect = false` require explicit user confirmation. A candidate may still be proposed for such a key when `allow_sieve_hints = true`, in which case it is shown labelled as unconfirmed, alongside its origin, for the user to accept or correct; it is never applied on its own.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,5 +366,5 @@ else:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[`specs/015-tsc-charter/plan.md`](specs/015-tsc-charter/plan.md)
+[`specs/018-auto-detect-propose-only/plan.md`](specs/018-auto-detect-propose-only/plan.md)
 <!-- SPECKIT END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,16 +166,20 @@ This is a compliance auditing tool. Incorrect results are worse than incomplete 
 
 ### Never Guess User-Specific Values
 
-- Do NOT auto-detect and auto-apply values like maintainers, security contacts, or governance models. These require explicit user confirmation.
-- The TOML `auto_detect = false` flag means the sieve MUST NOT run for that key. No exceptions.
+- Do NOT auto-apply values like maintainers, security contacts, or governance models. These require explicit user confirmation.
+- The TOML `auto_detect = false` flag marks a **user-judgment key**. Detection MAY run for such a key to *propose* a candidate, but MUST NOT *conclude* the value. Producing a candidate is not applying it.
+- A candidate must never be consumed as the key's value by control verification results, compliance calculations, remediation inputs, generated attestations, or persisted project context. Until confirmed, the key is unverified, and unverified counts as FAIL.
+- A candidate shown to a person must be labelled as unconfirmed and carry its origin (how it was produced). Origin is not confidence: a high-confidence guess is still a guess.
+- Human confirmation is the only thing that makes a value usable. Writing a candidate to disk does not confirm it, and a stored candidate must still read as a candidate later.
 - When a tool returns "Context Confirmation Required," that is a hard stop — ask the user. Do not fill in values from git history, repo owner, or any heuristic source.
-- Sieve auto-detection is acceptable only for keys where `auto_detect = true` in the TOML definition.
+- Two flags, two axes: `auto_detect` governs whether a value may be concluded without a person; `allow_sieve_hints` governs whether a detected value may be proposed. Both default to false. The safety property comes from the pair, not from banning detection.
+- Confidence thresholds apply only to keys that do NOT require user judgment. No threshold, at any value, authorizes concluding a user-judgment key.
 
 ### Err on the Side of Caution
 
 - When in doubt about a control's status, return WARN (needs verification), not PASS.
 - When in doubt about a user's intent, ask. Do not proceed with assumptions.
-- When designing prompts that an LLM will see, assume the LLM will blindly execute any suggested command. Never put guessed values in executable code snippets.
+- When designing prompts that an LLM will see, assume the LLM will blindly execute any suggested command. Never put guessed values or unconfirmed candidates in executable code snippets.
 
 ## Development Guidelines
 

--- a/docs/IMPLEMENTATION_GUIDE.md
+++ b/docs/IMPLEMENTATION_GUIDE.md
@@ -699,6 +699,11 @@ presents questions to users:
   (which is used for validation). Useful when the display options differ from the
   validation set.
 
+`auto_detect = false` marks a user-judgment key: the framework may still
+propose a candidate for it (see `allow_sieve_hints` and `hint_sources`), but
+may never conclude the value on its own. The key stays unverified until a
+person confirms it.
+
 ```toml
 [context.governance_model]
 type = "enum"

--- a/docs/design/CONTEXT_PROMPTS.md
+++ b/docs/design/CONTEXT_PROMPTS.md
@@ -198,7 +198,7 @@ Each `[context.key]` section supports these fields:
 | `values` | list | Valid values for `enum` type |
 | `affects` | list | Control IDs that depend on this context |
 | `store_as` | string | Path in .project/ where value is stored (e.g., `governance.maintainers`) |
-| `auto_detect` | bool | Whether value can be auto-detected (default: false) |
+| `auto_detect` | bool | Whether the value may be **concluded** without user confirmation (default: false). This does not govern whether a candidate may be **proposed** -- see `allow_sieve_hints`. |
 | `auto_detect_method` | string | Method name for auto-detection (e.g., `github_collaborators`) |
 | `required` | bool | Whether this context is required (default: false) |
 | `hint_sources` | list | **Files to check for authoritative values** (e.g., `["CODEOWNERS", "MAINTAINERS.md"]`) |

--- a/docs/rfcs/0001-core-rearchitecture.md
+++ b/docs/rfcs/0001-core-rearchitecture.md
@@ -150,7 +150,7 @@ Two rules keep the ratchet honest:
 1. **Persistence does not launder authority.** A confirmed value retains authority `asserted` forever, along with the evidence it was based on -- including whether an LLM proposed it. Writing a guess into a file does not make it ground truth, and a later run must not report it as though a tool observed it.
 2. **Confirmations age.** Each stored value records `confirmed_at`, `confirmed_by`, and its basis. Past a configurable period it downgrades back to a candidate requiring re-confirmation. This gives staleness handling without requiring a bespoke drift signal per key. Proposed default: per-key, 180 days, with facts that rarely change (governance model) configured longer than facts that rot (security contact).
 
-**Change to `auto_detect = false`.** The project's current rule is absolute: the sieve MUST NOT run for a key marked `auto_detect = false`, "no exceptions." This RFC narrows it to **propose-only**: steps may run and produce a candidate for human confirmation, but may never conclude the key on their own. The safety property is preserved in full -- no guessed value is ever *used* unconfirmed -- while the user gets a pre-filled answer to accept instead of a blank field to research. This is a governance change to CLAUDE.md and the project constitution, not merely an RFC decision; see "Governance dependency."
+**Change to `auto_detect = false`.** The project's rule was absolute until constitution 1.3.0: the sieve MUST NOT run for a key marked `auto_detect = false`, "no exceptions." That amendment, the Stage 0 gate below, narrowed it to **propose-only**: steps may run and produce a candidate for human confirmation, but may never conclude the key on their own. The safety property is preserved in full -- no guessed value is ever *used* unconfirmed -- while the user gets a pre-filled answer to accept instead of a blank field to research. This is a governance change to CLAUDE.md and the project constitution, not merely an RFC decision; see "Governance dependency."
 
 ### Remediation trust boundary
 
@@ -244,7 +244,7 @@ Each stage lands as its own scoped spec/PR series with an executable acceptance 
 
 | Stage | Work | Acceptance gate |
 |---|---|---|
-| 0 | Governance: narrow `auto_detect = false` to propose-only in CLAUDE.md and the constitution | Change merged as its own PR, referenced by this RFC |
+| 0 | Governance: narrow `auto_detect = false` to propose-only in CLAUDE.md and the constitution | **Satisfied** by constitution 1.3.0 (spec `018-auto-detect-propose-only`), landed as its own PR. Principle IV now permits proposing a candidate for a user-judgment key and forbids concluding one without human confirmation. Phase 0 research for that feature also established that the mechanism already ships via `allow_sieve_hints`, so Stage 1 inherits a rule that matches the code rather than one it must first argue around. |
 | 1 | Add `authority` to results and handlers; implement the per-phase execution rule; extract `route()` from `cmd_run` into the public ActionPlan protocol; expose the pipeline loop over MCP | One reference control (SECURITY.md) runs the full Check/Collect/Remediate loop through the same protocol from both `darnit run` and a coding agent over MCP, with an LLM step demonstrably unable to produce a PASS |
 | 2 | Carve down `darnit-core`: Integration contract, `NormalizedFindings` + Scorecard/SARIF importers, derived cache keys, strategy-list runner, cost/safety invariant split; re-express existing controls over normalized findings | One full standard's controls run identically under both drivers; a control whose only evidence is suggestive reports inconclusive rather than pass; legacy phase-keyed TOML loads through the compatibility path with a lossless-translation test |
 | 3 | `darnit-agent` packaging (MCP + skill); `darnit-harness` driver with the deduped manual queue; confirmation persistence and expiry; remediation gating incl. denylist and prior-state capture | Reference suite green under both drivers; fitness test below passes; an injection-attempt fixture in repo content fails to influence an auto-merge decision |
@@ -277,7 +277,9 @@ Still open:
 
 ## Governance dependency
 
-Narrowing `auto_detect = false` from "the sieve MUST NOT run" to "steps may propose, never conclude" changes a rule the project constitution states with "no exceptions." The safety property is preserved -- no unconfirmed guess is ever used -- but the wording is absolute today and this RFC depends on it changing. Recommend landing that as its own small PR through the TSC before Stage 1 begins, with this RFC referencing it rather than assuming it.
+Narrowing `auto_detect = false` from "the sieve MUST NOT run" to "steps may propose, never conclude" changed a rule the project constitution stated with "no exceptions." The safety property is preserved in full -- no unconfirmed guess is ever used. **This dependency is now discharged**: the amendment landed as its own PR (constitution 1.3.0, spec `018-auto-detect-propose-only`) before Stage 1 begins, as recommended here.
+
+Phase 0 research for that amendment turned up something that strengthens the rest of this RFC: propose-only was already implemented. `allow_sieve_hints` and `hint_sources` exist in the framework schema and are enabled for `maintainers` and `security_contact` in the OpenSSF Baseline configuration, with `hint_sources` resolution running un-gated by `auto_detect`. The constitution had been describing a system the project no longer had. Stage 1 therefore inherits a written rule that matches the code, rather than one it must argue around.
 
 ## How to Participate
 

--- a/specs/018-auto-detect-propose-only/checklists/requirements.md
+++ b/specs/018-auto-detect-propose-only/checklists/requirements.md
@@ -1,0 +1,50 @@
+# Specification Quality Checklist: Propose-Only Auto-Detection for User-Judgment Keys
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+- [x] Content is ASCII-only (project writing rule)
+
+## Notes
+
+- Validation iteration 1 found two leaks and one unverifiable criterion, all
+  fixed before this checklist was finalized:
+  - "TOML" named in Key Entities and Assumptions (configuration-format
+    detail); replaced with "the current configuration" / "the existing
+    configuration mechanism".
+  - SC-004 originally required "byte-identical" audit results, which is not
+    verifiable for output containing timestamps; narrowed to "identical
+    results".
+- Clarification session 2026-07-28 resolved five decision points and grew the
+  requirements from 11 to 14. The most consequential: the spec originally
+  contradicted RFC-0001 on whether confirmations expire. They do.
+- The feature deliberately scopes to documentation changes only.
+  FR-011 pins that boundary, and SC-004 is its test. Implementation of the
+  newly permitted behavior belongs to RFC-0001 Stage 1.
+- Items marked incomplete require spec updates before `/speckit-clarify` or
+  `/speckit-plan`.

--- a/specs/018-auto-detect-propose-only/data-model.md
+++ b/specs/018-auto-detect-propose-only/data-model.md
@@ -1,0 +1,88 @@
+# Phase 1 Data Model: Canonical Vocabulary and Value Lifecycle
+
+This feature ships no code, so this document is not a schema. It fixes the
+vocabulary and the state machine the amended text must express, so that the
+constitution, CLAUDE.md, and ARCHITECTURE.md can be checked for agreement
+against something concrete rather than against each other.
+
+## Vocabulary
+
+Use these terms consistently across all amended documents. The right-hand
+column names what the term must not be confused with, because each confusion
+has already appeared somewhere in the repository.
+
+| Term | Meaning | Not to be confused with |
+|---|---|---|
+| User-judgment key | A context key whose correct value requires a person's decision rather than observation. Marked `auto_detect = false`. | Any key that merely happens to be unset. |
+| Candidate | A value produced by detection for a user-judgment key. Never the key's value. | A default. A candidate is never applied on silence. |
+| Confirmation | An explicit human decision accepting a candidate or supplying a replacement. | Persistence. Writing a candidate to disk is not confirming it. |
+| Propose | Produce and display a candidate. Gated by `allow_sieve_hints`. | Conclude. |
+| Conclude | Settle the key's value without a person. Gated by `auto_detect`. | Propose. |
+| Origin | How a candidate was produced (file read, detection method, model). Carried with the candidate. | Confidence. A high-confidence guess is still a guess. |
+
+## Value lifecycle
+
+```text
+                    (no value)
+                        |
+        detection runs  |  gated by allow_sieve_hints
+                        v
+                    CANDIDATE  --------- ignored / never answered --------.
+                        |                                                 |
+          human confirms|  the only transition that makes a value usable  |
+                        v                                                 |
+                    CONFIRMED                                             |
+                        |                                                 |
+        configured age  |  FR-006                                         |
+                        v                                                 v
+                    CANDIDATE                                    key stays unverified
+```
+
+State rules the amended text must support:
+
+1. Only CONFIRMED is usable. A key in CANDIDATE state is treated exactly as a
+   key with no value at all: unverified, and unverified counts as FAIL for
+   compliance (Principle II, unchanged).
+2. The CANDIDATE -> CONFIRMED transition requires a person. No confidence
+   value, at any threshold, substitutes for it (FR-004).
+3. CONFIRMED -> CANDIDATE happens on expiry and only on expiry. A newly
+   detected conflicting value does not demote a confirmation; it may surface
+   the conflict for a person to resolve.
+4. Confirmation does not upgrade the origin. A confirmed value records that a
+   person accepted a candidate and what that candidate was based on. A later
+   run must not report it as though a tool observed it directly. This is
+   RFC-0001's "persistence does not launder authority."
+5. There is no timeout that promotes a candidate. Silence keeps the key
+   unverified indefinitely.
+
+## Consumption paths
+
+FR-002 names five paths. They are listed here so the amendment can be checked
+sentence by sentence against them, which is what SC-003 measures.
+
+| Path | May consume CANDIDATE | May consume CONFIRMED |
+|---|---|---|
+| Control verification result | No | Yes |
+| Compliance calculation | No | Yes |
+| Remediation action input | No | Yes |
+| Generated attestation | No | Yes, recorded with its origin |
+| Persisted project context | Only as a candidate, distinguishable on read | Yes |
+
+The last row is the one most easily got wrong: a candidate may be written down,
+but it must be readable as a candidate afterwards. If a later run cannot tell
+the difference, persistence has laundered authority and rule 4 is broken.
+
+## Two flags, two axes
+
+The safety property is enforced by a pair of flags, not by a single ban. The
+amendment needs to say so, because Principle IV currently reads as though
+`auto_detect` alone carries the weight.
+
+| | `allow_sieve_hints = false` | `allow_sieve_hints = true` |
+|---|---|---|
+| **`auto_detect = false`** | Ask the person cold. No candidate produced. | Propose a candidate, require confirmation. The case this feature legitimizes. |
+| **`auto_detect = true`** | Detect and conclude without display. | Detect, conclude, and show what was found. |
+
+Both cells in the `auto_detect = false` row are safe, because neither concludes.
+The current constitutional text permits only the left cell, while the shipped
+configuration uses the right one for `maintainers` and `security_contact`.

--- a/specs/018-auto-detect-propose-only/plan.md
+++ b/specs/018-auto-detect-propose-only/plan.md
@@ -49,8 +49,9 @@ Python monorepo.
 configuration, or test file may be modified (FR-011, FR-013). The constitution
 bump is fixed at one MINOR increment (FR-009, 1.2.0 -> 1.3.0).
 
-**Scale/Scope**: Six prose files, one of which is the constitution. Fifteen
-inventory entries total, nine of which are deferred rather than changed.
+**Scale/Scope**: Six prose files, one of which is the constitution. Nineteen
+inventory entries: ten updated, five deferred, and four historical records left
+alone.
 
 ## Constitution Check
 
@@ -61,7 +62,7 @@ inventory entries total, nine of which are deferred rather than changed.
 | I. Plugin Separation | N/A | No code changes; no imports added in either direction. |
 | II. Conservative-by-Default | PASS | The amendment preserves every clause: unverified is not compliant, WARN counts as FAIL, false negatives are preferred. It narrows only the separate question of whether a candidate may be computed and shown. |
 | III. TOML-First Architecture | N/A | No control metadata moves. Configuration files are explicitly out of scope (FR-011). |
-| IV. Never Guess User Values | PASS (this is the principle under amendment) | The core requirement -- the framework MUST NOT silently apply values requiring user judgment -- survives verbatim. FR-002 through FR-007 exist to hold that line while the surrounding bullets change. FR-004 additionally closes a latent hole by scoping the confidence-threshold provision away from user-judgment keys, which today reads as unscoped. |
+| IV. Never Guess User Values | VIOLATED TODAY; this amendment is the remedy | The shipped system already breaches this principle as literally written: `collection.py:264-271` resolves `hint_sources` with no `auto_detect` gate, and `openssf-baseline.toml:287-289,300-301` enables it for `maintainers` and `security_contact` (research.md Finding 1). The breach is of the wording, not of the intent -- nothing concludes a user-judgment key. The core requirement -- the framework MUST NOT silently apply values requiring user judgment -- survives the amendment verbatim. FR-002 through FR-007 hold that line while the surrounding bullets change, and FR-004 closes a latent hole by scoping the confidence-threshold provision away from user-judgment keys, which today reads as unscoped. |
 | V. Sieve Pipeline Integrity | PASS | Phase ordering, INCONCLUSIVE semantics, and the no-short-circuit-to-PASS rule are untouched. |
 | Development Workflow | PASS | Lint, tests, and `validate_sync.py` all run and must pass. No spec-sync implication, since `docs/architecture/framework-design.md` already documents the propose mechanism (research.md, Finding 1) and needs no change. |
 

--- a/specs/018-auto-detect-propose-only/plan.md
+++ b/specs/018-auto-detect-propose-only/plan.md
@@ -1,0 +1,135 @@
+# Implementation Plan: Propose-Only Auto-Detection for User-Judgment Keys
+
+**Branch**: `018-auto-detect-propose-only` | **Date**: 2026-07-28 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/018-auto-detect-propose-only/spec.md`
+
+## Summary
+
+Amend the project constitution and the prose documentation that restates it so
+that a key requiring human judgment may have a candidate value proposed to a
+person, while keeping the prohibition on that candidate being used unconfirmed.
+RFC-0001 names this as the Stage 0 prerequisite for its Stage 1.
+
+Phase 0 research changed the character of this work. The propose-only behavior
+is not hypothetical and is not deferred to Stage 1: it already ships. The
+framework reads `hint_sources` files to produce candidate values for keys
+marked `auto_detect = false`, and a dedicated `allow_sieve_hints` flag exists,
+is documented in the authoritative framework spec, and is enabled for
+`maintainers` and `security_contact` in the OpenSSF Baseline configuration.
+This amendment therefore reconciles the constitution with behavior the project
+already has, rather than authorizing something new. See
+[research.md](research.md) for the evidence.
+
+That reframing makes the change lower-risk (no behavior moves) and more urgent
+(the governing document currently misdescribes the system).
+
+## Technical Context
+
+**Language/Version**: N/A -- this feature changes prose documents only. No
+source file is modified. Python 3.11/3.12 remains the workspace target.
+
+**Primary Dependencies**: None added or changed.
+
+**Storage**: N/A.
+
+**Testing**: The existing suites (`ruff check`, `pytest tests/ --ignore=tests/integration/`,
+`scripts/validate_sync.py`) serve as the regression evidence for FR-013. They
+must pass unchanged, and no test may need modification -- a test requiring a
+change would prove behavior moved.
+
+**Target Platform**: N/A.
+
+**Project Type**: Governance and documentation amendment within an existing
+Python monorepo.
+
+**Performance Goals**: N/A.
+
+**Constraints**: ASCII-only content per project writing rules. No source,
+configuration, or test file may be modified (FR-011, FR-013). The constitution
+bump is fixed at one MINOR increment (FR-009, 1.2.0 -> 1.3.0).
+
+**Scale/Scope**: Six prose files, one of which is the constitution. Fifteen
+inventory entries total, nine of which are deferred rather than changed.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Justification |
+|---|---|---|
+| I. Plugin Separation | N/A | No code changes; no imports added in either direction. |
+| II. Conservative-by-Default | PASS | The amendment preserves every clause: unverified is not compliant, WARN counts as FAIL, false negatives are preferred. It narrows only the separate question of whether a candidate may be computed and shown. |
+| III. TOML-First Architecture | N/A | No control metadata moves. Configuration files are explicitly out of scope (FR-011). |
+| IV. Never Guess User Values | PASS (this is the principle under amendment) | The core requirement -- the framework MUST NOT silently apply values requiring user judgment -- survives verbatim. FR-002 through FR-007 exist to hold that line while the surrounding bullets change. FR-004 additionally closes a latent hole by scoping the confidence-threshold provision away from user-judgment keys, which today reads as unscoped. |
+| V. Sieve Pipeline Integrity | PASS | Phase ordering, INCONCLUSIVE semantics, and the no-short-circuit-to-PASS rule are untouched. |
+| Development Workflow | PASS | Lint, tests, and `validate_sync.py` all run and must pass. No spec-sync implication, since `docs/architecture/framework-design.md` already documents the propose mechanism (research.md, Finding 1) and needs no change. |
+
+**Post-Phase-1 re-check**: PASS, unchanged. The design phase produced no new
+artifacts that touch code, so no gate moved. The one substantive change Phase 0
+forced was to FR-014's framing, recorded under Deviations below; it relaxes a
+requirement rather than adding a violation.
+
+### Deviations from clarified answers
+
+One clarified answer needs the user's confirmation before tasks are generated.
+
+**Q3 (flag naming).** The answer was to keep the `auto_detect` name and record
+the mismatch between name and meaning as known debt, which FR-014 now requires.
+Phase 0 found that the mismatch may not exist. The project already has two
+flags covering the two axes: `auto_detect` gates whether a value may be
+concluded automatically, and `allow_sieve_hints` gates whether a detected value
+may be shown as a suggestion. Under that reading `auto_detect = false` is an
+accurate name for "may not conclude," and the debt clause in FR-014 would
+record a problem the codebase does not have.
+
+Recommended resolution: keep FR-014's first sentence (the flag keeps its name
+and accepted values) and replace the debt clause with a requirement that the
+amendment describe the relationship between the two flags, since that
+relationship is the mechanism that makes propose-only safe and is currently
+documented nowhere near the rule it implements. Flagged for the user rather
+than applied unilaterally, because it edits a clarified answer.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-auto-detect-propose-only/
+  plan.md              # This file
+  research.md          # Phase 0: the FR-010 inventory and three findings
+  data-model.md        # Phase 1: canonical vocabulary and value lifecycle
+  checklists/
+    requirements.md    # Spec quality checklist
+  tasks.md             # Phase 2 output (/speckit-tasks -- NOT created here)
+```
+
+No `contracts/` directory: the feature exposes no interface. The nearest thing
+to a contract is the normative rule text itself, and drafting that in the plan
+phase would leave tasks as mechanical transcription while moving the reviewable
+substance out of the PR diff.
+
+No `quickstart.md`: there is nothing for a user to run. The equivalent
+verification is reading the amended rule, which the spec's Independent Tests
+already specify.
+
+### Files changed (repository root)
+
+```text
+.specify/memory/constitution.md    # Principle IV bullets; version 1.2.0 -> 1.3.0
+                                   # plus a new Sync Impact Report block
+CLAUDE.md                          # Conservative-by-Default section, lines 170-172
+ARCHITECTURE.md                    # line 29 (normative restatement), line 441
+docs/IMPLEMENTATION_GUIDE.md       # narrative around the auto_detect examples
+docs/design/CONTEXT_PROMPTS.md     # schema table entry for auto_detect
+docs/rfcs/0001-core-rearchitecture.md  # Stage 0 row: mark satisfied, link the PR
+```
+
+**Structure Decision**: No source tree is involved. The change set is six prose
+files at repository root and under `docs/`, listed above and derived from the
+inventory in research.md. Package directories under `packages/` are deliberately
+untouched; the inventory records those locations as deferred.
+
+## Complexity Tracking
+
+No constitution violations. Table omitted.

--- a/specs/018-auto-detect-propose-only/plan.md
+++ b/specs/018-auto-detect-propose-only/plan.md
@@ -72,23 +72,18 @@ requirement rather than adding a violation.
 
 ### Deviations from clarified answers
 
-One clarified answer needs the user's confirmation before tasks are generated.
-
-**Q3 (flag naming).** The answer was to keep the `auto_detect` name and record
-the mismatch between name and meaning as known debt, which FR-014 now requires.
-Phase 0 found that the mismatch may not exist. The project already has two
-flags covering the two axes: `auto_detect` gates whether a value may be
-concluded automatically, and `allow_sieve_hints` gates whether a detected value
+**Q3 (flag naming) -- resolved 2026-07-28.** The original answer was to keep the
+`auto_detect` name and record the mismatch between name and meaning as known
+debt. Phase 0 found the mismatch does not exist: the project already has two
+flags covering the two axes, where `auto_detect` gates whether a value may be
+concluded automatically and `allow_sieve_hints` gates whether a detected value
 may be shown as a suggestion. Under that reading `auto_detect = false` is an
-accurate name for "may not conclude," and the debt clause in FR-014 would
-record a problem the codebase does not have.
+accurate name for "may not conclude."
 
-Recommended resolution: keep FR-014's first sentence (the flag keeps its name
-and accepted values) and replace the debt clause with a requirement that the
-amendment describe the relationship between the two flags, since that
-relationship is the mechanism that makes propose-only safe and is currently
-documented nowhere near the rule it implements. Flagged for the user rather
-than applied unilaterally, because it edits a clarified answer.
+The user confirmed dropping the debt clause. FR-014 keeps the compatibility
+requirement, and the new FR-015 requires the amendment to explain the flag pair
+instead, since that relationship is the mechanism that makes propose-only safe
+and is currently documented nowhere near the rule it implements.
 
 ## Project Structure
 

--- a/specs/018-auto-detect-propose-only/research.md
+++ b/specs/018-auto-detect-propose-only/research.md
@@ -112,6 +112,8 @@ are left alone.
 | `docs/design/CONTEXT_PROMPTS.md:201` | schema table: "Whether value can be auto-detected" | Clarify to "whether a value may be concluded without confirmation" |
 | `docs/IMPLEMENTATION_GUIDE.md:707` | `auto_detect = false` example with no surrounding rule text | Add a sentence on what the flag now means |
 | `docs/rfcs/0001-core-rearchitecture.md:247` | Stage 0 row | Mark satisfied and link the PR (FR-012) |
+| `docs/rfcs/0001-core-rearchitecture.md:153` | "The project's current rule is absolute: the sieve MUST NOT run..." | Found during implementation, not Phase 0. Present-tense assertion of the old rule that the amendment falsifies. Rewritten to past tense. |
+| `docs/rfcs/0001-core-rearchitecture.md:280` | Governance dependency: "Recommend landing that as its own small PR through the TSC before Stage 1 begins" | Found during implementation. Dependency is discharged by this change; rewritten to record that, and to carry Finding 1 forward for Stage 1. |
 
 ### Deferred (recorded, not changed)
 

--- a/specs/018-auto-detect-propose-only/research.md
+++ b/specs/018-auto-detect-propose-only/research.md
@@ -1,0 +1,137 @@
+# Phase 0 Research: Propose-Only Auto-Detection for User-Judgment Keys
+
+The spec left no NEEDS CLARIFICATION markers, so this phase did the one piece
+of genuine research the feature requires: build the FR-010 inventory of every
+location that restates, documents, or enforces the previous wording. Building
+it surfaced three findings, the first of which changes how the amendment should
+be argued.
+
+## Finding 1: Propose-only already ships
+
+**Decision**: Frame the amendment as reconciling the constitution with existing
+behavior, not as authorizing future behavior.
+
+**Rationale**: The mechanism the RFC proposes to introduce is already built,
+documented, and enabled in production configuration.
+
+- `packages/darnit/src/darnit/config/framework_schema.py:802,807` defines both
+  `hint_sources: list[str]` and `allow_sieve_hints: bool = False` on the
+  context definition model.
+- `packages/darnit-baseline/openssf-baseline.toml:287-289,300-301` sets
+  `allow_sieve_hints = true` with `hint_sources` for `maintainers` and
+  `security_contact` -- two of the three keys the constitution names as
+  requiring human judgment.
+- `packages/darnit/src/darnit/context/collection.py:264-271` resolves
+  `hint_sources` by reading those files and returning a value tagged
+  `file:<name>`. This runs with **no `auto_detect` gate**. The function's own
+  docstring lists auto-detection as step 3 "if definition.auto_detect is true",
+  but `hint_sources` is step 3.5 and carries no such condition.
+- `packages/darnit/src/darnit/remediation/context_validator.py:219-258`
+  presents whatever was found as a labelled suggestion carrying its source and
+  confidence, and requires an explicit `confirm_project_data(...)` call with a
+  `<user-confirmed values>` placeholder rather than a pre-filled guess.
+- `docs/architecture/framework-design.md:838-840`, which CLAUDE.md names as the
+  authoritative framework specification, shows `auto_detect = false` alongside
+  `hint_sources` and `allow_sieve_hints = true` on the same key.
+
+So the shipped behavior is: candidate produced, labelled, never auto-applied,
+confirmation required. That is precisely propose-only, and it is precisely what
+the constitution's "the sieve MUST NOT run for that key. No exceptions." reads
+as forbidding.
+
+Two consequences. First, FR-013 (no observable behavior change) is satisfied by
+construction rather than by care -- there is no behavior to hold still, because
+the amendment only changes prose. Second, the argument to reviewers is stronger
+than the spec currently frames it: this is not loosening a safety rule to
+enable future work, it is correcting a governing document that misdescribes the
+system today, in the direction the design already went.
+
+**Alternatives considered**: Treating the finding as out of scope and amending
+on the RFC's forward-looking rationale alone. Rejected because a reviewer who
+finds `allow_sieve_hints` during review will reasonably ask why the PR did not
+mention it, and because leaving the contradiction unstated means the next
+person to read Principle IV literally may "fix" working code to match it.
+
+## Finding 2: The naming debt in FR-014 may not exist
+
+**Decision**: Recommend relaxing FR-014's debt clause. Flagged for user
+confirmation rather than applied, since it edits a clarified answer.
+
+**Rationale**: The Q3 clarification assumed that after this amendment
+`auto_detect = false` would misdescribe its own behavior, because detection
+would run. Finding 1 shows the project already separates the two axes across
+two flags:
+
+| Flag | Governs | Default |
+|---|---|---|
+| `auto_detect` | whether a value may be concluded without a person | `false` |
+| `allow_sieve_hints` | whether a detected value may be shown as a suggestion | `false` |
+
+Read that way, `auto_detect = false` accurately means "may not conclude," which
+is exactly what the amendment preserves. The name is fine. What is missing is
+not a rename but an explanation: nothing near the constitutional rule mentions
+that a second flag governs proposing, so a reader of Principle IV alone cannot
+tell that the safety property is enforced by the pair rather than by the ban.
+
+**Alternatives considered**: Keeping the debt clause as written, on the grounds
+that `auto_detect` still reads as being about detection generally. Rejected as
+recording debt that no future work would act on. Renaming was already rejected
+at Q3 for compatibility reasons and remains rejected.
+
+## Finding 3: A fourth normative restatement exists
+
+**Decision**: Add `ARCHITECTURE.md:29` to the change set.
+
+**Rationale**: The spec was written against two governing documents. The
+inventory found a third file stating the rule normatively rather than as an
+example: `ARCHITECTURE.md:29` reads "When `auto_detect = false` in TOML, the
+sieve must not run for that key," inside a Conservative-by-Default section that
+mirrors the constitution's structure. Under the Q5 answer (all prose updated),
+it is in scope. It is also the file a new contributor is most likely to read
+first, which makes leaving it stale worse than leaving a deep reference stale.
+
+**Alternatives considered**: None; this is a straightforward inventory result.
+
+## The inventory (FR-010)
+
+Disposition per the Q5 answer: prose is updated in this feature; code,
+configuration, and their comments are recorded as deferred; historical records
+are left alone.
+
+### Updated by this feature
+
+| Location | What it says | Disposition |
+|---|---|---|
+| `.specify/memory/constitution.md:102-103` | "the sieve MUST NOT run for that key. No exceptions." | Rewrite to propose-only |
+| `.specify/memory/constitution.md:106-107` | "acceptable ONLY for keys where `auto_detect = true`" | Rewrite; this is the sentence that forbids proposing |
+| `.specify/memory/constitution.md:108-113` | confidence threshold provision, currently unscoped | Scope to non-user-judgment keys per FR-004 |
+| `CLAUDE.md:170` | "MUST NOT run for that key. No exceptions." | Rewrite to match the constitution |
+| `CLAUDE.md:172` | "acceptable only for keys where `auto_detect = true`" | Rewrite to match |
+| `ARCHITECTURE.md:29` | "the sieve must not run for that key" | Rewrite; see Finding 3 |
+| `ARCHITECTURE.md:441` | "Values with `auto_detect = false` require explicit user confirmation" | Accurate but incomplete; extend to mention proposing |
+| `docs/design/CONTEXT_PROMPTS.md:201` | schema table: "Whether value can be auto-detected" | Clarify to "whether a value may be concluded without confirmation" |
+| `docs/IMPLEMENTATION_GUIDE.md:707` | `auto_detect = false` example with no surrounding rule text | Add a sentence on what the flag now means |
+| `docs/rfcs/0001-core-rearchitecture.md:247` | Stage 0 row | Mark satisfied and link the PR (FR-012) |
+
+### Deferred (recorded, not changed)
+
+| Location | Why deferred |
+|---|---|
+| `packages/darnit/src/darnit/config/framework_schema.py:792,807` | Code. Field definitions and docstrings; changing them risks behavior. |
+| `packages/darnit/src/darnit/context/collection.py:233` | Code. The docstring understates what the function does (Finding 1); correcting it is a code change. |
+| `packages/darnit-baseline/openssf-baseline.toml:284` | Configuration comment. |
+| `packages/darnit-baseline/src/darnit_baseline/tools.py:796-819` | Code. Reads the flag to choose prompt shape. |
+| `docs/architecture/framework-design.md:838` | Already consistent with propose-only; no change needed. Listed so the inventory is complete. |
+
+### Left alone (historical records)
+
+| Location | Why |
+|---|---|
+| `specs/001-tiered-control-automation/` (spec, plan, contracts, tasks, data-model) | Frozen record of a completed feature. Rewriting history would misrepresent what was decided then. |
+| `specs/003-auto-context-inference/` | Same. Also mostly refers to the unrelated `context/auto_detect.py` module. |
+| `docs/design/CONTEXT_SIEVE_DESIGN.md`, `docs/DECISION_FLOWS.md` | Refer to `prompt_if_auto_detected` and `auto_detected` source labels, which are different concepts. |
+| `docs/threatmodel/findings/` | Generated output referencing the unrelated `context/auto_detect.py` module path. |
+
+**Naming hazard for whoever implements this**: `packages/darnit/src/darnit/context/auto_detect.py`
+is a module about detecting context generally. It is not the TOML flag. Several
+inventory hits are that module and must not be touched.

--- a/specs/018-auto-detect-propose-only/spec.md
+++ b/specs/018-auto-detect-propose-only/spec.md
@@ -23,9 +23,10 @@
   justified by the precedent set at 1.0.0 -> 1.1.0, where the same principle
   was widened while its core requirement stayed intact.
 - Q: Does the configuration flag keep its name? -> A: Yes. The amendment
-  redefines the meaning of the existing flag only. Its name no longer describes
-  what it does, and that mismatch is recorded as known debt for a later stage
-  rather than fixed here.
+  redefines the meaning of the existing flag only. Revised after Phase 0
+  research: the project already separates the two axes across two flags, so
+  there is no naming debt to record. Instead the amendment explains the flag
+  pair, which is the mechanism that makes propose-only safe.
 - Q: How far does the amendment reach beyond the two governing documents? ->
   A: It also updates every prose document that restates the old rule, so that
   nothing in the documentation tree contradicts the amended rule on merge.
@@ -219,9 +220,12 @@ identical, because this feature changes documents only.
   or context-collection behavior.
 - **FR-014**: The existing configuration flag that marks user-judgment keys
   MUST keep its current name and accepted values, so that existing project
-  configuration continues to load unchanged. The amendment MUST record that the
-  flag's name no longer describes its narrowed meaning, as known debt to be
-  addressed in a later effort.
+  configuration continues to load unchanged.
+- **FR-015**: The governing documents MUST explain that proposing and
+  concluding are governed by two separate configuration flags, and that the
+  safety property is enforced by the pair rather than by a prohibition on
+  detection. A reader of the amended rule MUST be able to tell which flag
+  controls which behavior.
 
 ### Key Entities
 

--- a/specs/018-auto-detect-propose-only/spec.md
+++ b/specs/018-auto-detect-propose-only/spec.md
@@ -257,16 +257,27 @@ identical, because this feature changes documents only.
   by the amended text; a reader can cite the sentence that covers each.
 - **SC-004**: An audit of a fixed sample project produces identical results
   before and after the change, confirming zero behavior drift.
-- **SC-005**: 100% of the inventory entries from FR-010 are resolved as either
-  updated or explicitly unaffected, with no entry left undetermined.
+- **SC-005**: 100% of the inventory entries from FR-010 carry a disposition of
+  updated, deferred, or explicitly unaffected, with no entry left undetermined.
+  Deferred entries additionally carry a stated reason.
 - **SC-006**: RFC-0001's Stage 0 gate is satisfied: the change is merged as its
   own pull request and referenced from the RFC.
 
 ## Assumptions
 
-- The amendment follows the project's existing governance process for
-  architecture-affecting changes, including the comment period and maintainer
-  consensus described in GOVERNANCE.md.
+- The amendment is treated as a governance change and follows the Charter's TSC
+  voting rules, even though GOVERNANCE.md:51 enumerates only GOVERNANCE.md
+  itself, the Charter, and the TSC roster as governance artifacts. The
+  constitution is a governing document in substance, and RFC-0001 treats Stage 0
+  as requiring sign-off. The alternative reading -- that this is a routine Minor
+  Change needing one maintainer approval -- is defensible on the letter of both
+  documents, which is itself the reason the enumeration should be corrected.
+- If the amendment is not adopted, the contradiction identified in research.md
+  Finding 1 does not disappear; it inverts. The remedy would become a code change
+  gating `hint_sources` behind the user-judgment flag, disabling the propose-only
+  behavior currently enabled for maintainer lists and security contacts. That
+  path contradicts FR-013 and is out of scope here, but it is the alternative and
+  should be stated when the amendment is presented.
 - This feature delivers document changes only. Implementing the permitted
   behavior is a separate, later effort (RFC-0001 Stage 1) and is out of scope
   here. This is why FR-013 requires zero behavior change.

--- a/specs/018-auto-detect-propose-only/spec.md
+++ b/specs/018-auto-detect-propose-only/spec.md
@@ -1,0 +1,283 @@
+# Feature Specification: Propose-Only Auto-Detection for User-Judgment Keys
+
+**Feature Branch**: `018-auto-detect-propose-only`
+
+**Created**: 2026-07-27
+
+**Status**: Draft
+
+**Input**: User description: "Narrow `auto_detect = false` from 'the sieve MUST NOT run' to 'steps may propose, never conclude' - Stage 0 governance prerequisite from RFC-0001"
+
+## Clarifications
+
+### Session 2026-07-28
+
+- Q: Do confirmations expire? -> A: The amendment states that confirmations
+  record when and by whom they were made, and MAY expire per configuration.
+  The expiry period itself is left to implementation.
+- Q: Can a confidence threshold ever auto-accept a user-judgment key? -> A: No.
+  The existing provision permitting configurable confidence thresholds is
+  scoped explicitly to keys that do not require human judgment. Confidence-based
+  auto-acceptance at remediation time is a separate concern and is unaffected.
+- Q: What version does the constitution bump to? -> A: MINOR (1.3.0),
+  justified by the precedent set at 1.0.0 -> 1.1.0, where the same principle
+  was widened while its core requirement stayed intact.
+- Q: Does the configuration flag keep its name? -> A: Yes. The amendment
+  redefines the meaning of the existing flag only. Its name no longer describes
+  what it does, and that mismatch is recorded as known debt for a later stage
+  rather than fixed here.
+- Q: How far does the amendment reach beyond the two governing documents? ->
+  A: It also updates every prose document that restates the old rule, so that
+  nothing in the documentation tree contradicts the amended rule on merge.
+  Code, configuration files, and their comments are enumerated but left
+  untouched, because changing them would change behavior.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Maintainer amends the governance rule (Priority: P1)
+
+A darnit maintainer needs the project's own written rules to permit a workflow
+that is currently forbidden: showing a person a detected candidate value for a
+key that requires human judgment, so the person can accept or correct it rather
+than research it from scratch.
+
+Today both governing documents state that when a key is marked as requiring
+human judgment, detection is forbidden outright. That wording bans a safe and
+useful behavior along with the unsafe one, because it conflates *producing* a
+candidate with *using* it. The maintainer amends both documents so the rule
+forbids only the unsafe half: a detected value may be offered, but may never
+become the key's value without explicit human confirmation.
+
+**Why this priority**: RFC-0001 names this amendment as a hard prerequisite for
+its Stage 1. No implementation work in that direction can begin while the
+project's own constitution forbids it. This story is the entire reason the
+feature exists; everything else supports it.
+
+**Independent Test**: Read the amended text of both documents in isolation and
+confirm that (a) offering a candidate for a human-judgment key is permitted,
+and (b) accepting that candidate without explicit human confirmation is
+forbidden. No code needs to exist for this to be testable.
+
+**Acceptance Scenarios**:
+
+1. **Given** the constitution's principle on user-judgment values, **When** a
+   maintainer reads the amended rule, **Then** it permits detection to run for
+   the sole purpose of producing an unconfirmed candidate, and forbids that
+   candidate from being treated as the key's value.
+2. **Given** the runtime development guidance in CLAUDE.md, **When** it is
+   compared against the amended constitution, **Then** the two agree on the
+   rule with no contradictory statement remaining in either.
+3. **Given** the amendment, **When** the constitution's own amendment procedure
+   is applied, **Then** the version is bumped by one MINOR increment and the
+   recorded rationale states that the core requirement is unchanged.
+4. **Given** the merged amendment, **When** RFC-0001's Stage 0 row is checked,
+   **Then** it references this change as satisfied.
+
+---
+
+### User Story 2 - Contributor implements against an unambiguous rule (Priority: P2)
+
+A contributor is about to build the behavior the amendment permits. They need
+the rule to answer boundary questions without guesswork, because guessing wrong
+here reintroduces exactly the failure mode the original rule existed to
+prevent.
+
+The rule must be specific about what "never conclude" covers: an unconfirmed
+candidate must not reach audit results, compliance calculations, remediation
+actions, attestations, or persisted project context, and must not be laundered
+into confirmed status by a confidence score.
+
+**Why this priority**: A rule that permits the new behavior but leaves its
+limits vague is worse than the current strict rule, because it invites
+divergent interpretations across implementations. This must land with the
+amendment, not after it.
+
+**Independent Test**: Present the amended rule to two readers with a list of
+consumption paths (audit status, compliance math, remediation input,
+attestation, persisted context) and ask which are permitted to consume an
+unconfirmed candidate. Both should answer "none" without consulting code.
+
+**Acceptance Scenarios**:
+
+1. **Given** a key requiring human judgment and a detected candidate for it,
+   **When** an audit runs, **Then** the rule requires the key be treated as
+   unverified, identical to having no candidate at all.
+2. **Given** a configured confidence threshold for automatic acceptance,
+   **When** it is applied to a key requiring human judgment, **Then** the rule
+   forbids automatic acceptance regardless of the threshold value or the
+   candidate's confidence.
+3. **Given** an unconfirmed candidate, **When** project context is written to
+   disk, **Then** the rule forbids storing it in a form that later reads would
+   treat as confirmed.
+4. **Given** a prompt shown to a language model, **When** it references an
+   unconfirmed candidate, **Then** the rule forbids that candidate appearing
+   inside an executable snippet.
+5. **Given** a candidate presented to a person, **When** they view it, **Then**
+   the rule requires it be labelled as unconfirmed and carry its origin.
+
+---
+
+### User Story 3 - Reviewer confirms nothing regressed (Priority: P3)
+
+A reviewer needs assurance that loosening a written rule did not silently
+loosen behavior. Because the amendment permits something previously forbidden,
+any existing code or configuration that relied on the strict wording could now
+be read as compliant when it is not, or could be changed opportunistically
+under cover of the amendment.
+
+**Why this priority**: Valuable, but it verifies the first two stories rather
+than delivering new capability. If it slipped, the amendment would still be
+correct; the project would just have less confidence in it.
+
+**Independent Test**: Run the existing audit suite against a fixed sample
+project before and after the change and compare results. They must be
+identical, because this feature changes documents only.
+
+**Acceptance Scenarios**:
+
+1. **Given** the merged amendment, **When** an audit is run against a project
+   with keys requiring human judgment, **Then** the results are identical to a
+   run before the amendment.
+2. **Given** the inventory of places that restate or depend on the old wording,
+   **When** each is reviewed, **Then** every prose entry is updated to match and
+   every code or configuration entry is recorded as deferred with a reason.
+
+---
+
+### Edge Cases
+
+- A candidate is produced but the person never responds. The key stays
+  unconfirmed indefinitely and any control depending on it stays unverified;
+  there is no timeout that converts silence into acceptance.
+- A person confirms a candidate, and a later run detects a different value.
+  The stored confirmation stays authoritative for as long as it remains
+  unexpired; a new detection may surface a conflict but may not overwrite the
+  confirmation on its own.
+- A stored confirmation passes its configured expiry. It reverts to a
+  candidate and must be confirmed again before it is usable, so a key that was
+  compliant can return to unverified without anything in the project changing.
+- Detection fails or produces nothing. Behavior is unchanged from today: the
+  person is asked with no pre-filled answer.
+- A candidate is produced for a key that feeds a remediation action. The
+  remediation cannot proceed on the candidate; it is blocked on the same
+  confirmation as everything else.
+- Two keys are detected and the person confirms only one. The confirmed key
+  becomes usable; the other remains unverified. Confirmation is per-key.
+- The detected candidate is itself sourced from untrusted repository content.
+  It is still only a candidate, so the confirmation step remains the trust
+  boundary, and it must not be rendered as executable text on the way there.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The governing documents MUST permit detection to run for a key
+  marked as requiring human judgment, for the sole purpose of producing a
+  candidate value.
+- **FR-002**: The governing documents MUST forbid an unconfirmed candidate from
+  being consumed as the key's value by any of: control verification results,
+  compliance calculations, remediation actions, generated attestations, or
+  persisted project context.
+- **FR-003**: The governing documents MUST require that a candidate presented
+  to a person is labelled as unconfirmed and accompanied by its origin (how it
+  was detected).
+- **FR-004**: The governing documents MUST forbid confidence-based automatic
+  acceptance from applying to keys requiring human judgment, at any threshold
+  value. The existing provision permitting configurable confidence thresholds
+  MUST be scoped explicitly to keys that do not require human judgment, so that
+  no reader can apply it to a user-judgment key.
+- **FR-005**: The governing documents MUST state that human confirmation is the
+  only mechanism that converts a candidate into a usable value, and that
+  storing a candidate does not constitute confirmation.
+- **FR-006**: The governing documents MUST require that a stored confirmation
+  records when it was made, by whom, and what candidate it was based on, and
+  MUST permit a confirmation to expire after a configurable period, reverting
+  the key to a candidate that requires re-confirmation. The amendment MUST NOT
+  fix the period; that is left to implementation.
+- **FR-007**: The governing documents MUST retain the existing prohibition on
+  placing unconfirmed values inside executable snippets in prompts shown to
+  language models.
+- **FR-008**: Both the project constitution and the runtime development
+  guidance MUST be amended together and MUST NOT contain any statement that
+  contradicts the amended rule.
+- **FR-009**: The constitution MUST record the amendment under its own
+  amendment procedure, bumping the version by one MINOR increment. The recorded
+  rationale MUST state that the core requirement (no unconfirmed value is ever
+  used) is unchanged and only the permitted mechanism widens, matching the
+  justification used the last time this same principle was widened.
+- **FR-010**: An inventory MUST be produced of every location that restates,
+  documents, or enforces the previous wording, with each entry marked as
+  updated, deferred, or explicitly unaffected.
+- **FR-011**: Every prose document that restates the previous wording MUST be
+  updated alongside the governing documents, so that no document contradicts
+  the amended rule once merged. Locations in code, configuration, or their
+  comments MUST be recorded in the inventory as deferred and MUST NOT be
+  changed by this feature.
+- **FR-012**: RFC-0001 MUST reference this change as satisfying its Stage 0
+  gate.
+- **FR-013**: This feature MUST NOT change any observable audit, remediation,
+  or context-collection behavior.
+- **FR-014**: The existing configuration flag that marks user-judgment keys
+  MUST keep its current name and accepted values, so that existing project
+  configuration continues to load unchanged. The amendment MUST record that the
+  flag's name no longer describes its narrowed meaning, as known debt to be
+  addressed in a later effort.
+
+### Key Entities
+
+- **User-judgment key**: A named piece of project context whose correct value
+  requires a person's decision rather than observation. Examples in the current
+  configuration include maintainer lists, security contacts, and governance
+  model.
+- **Candidate value**: A value produced by detection for a user-judgment key.
+  Carries its origin and, where the detecting step provides one, a confidence
+  indication. Is never the key's value.
+- **Confirmation**: An explicit human decision that a candidate is correct, or
+  a human-supplied replacement. The only transition that makes a value usable.
+  Records when it was made, by whom, and the candidate it was based on, and has
+  a lifetime after which it reverts to a candidate.
+- **Origin record**: The description of how a candidate was produced, retained
+  alongside it so a person can judge whether to trust it.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Two independent readers, given only the amended documents and a
+  list of five consumption paths, agree on which paths may consume an
+  unconfirmed candidate, with 100% agreement and the answer being "none".
+- **SC-002**: Zero statements remain in any prose document, governing or
+  contributor-facing, asserting that detection must not run for user-judgment
+  keys.
+- **SC-003**: All five consumption paths named in FR-002 are explicitly covered
+  by the amended text; a reader can cite the sentence that covers each.
+- **SC-004**: An audit of a fixed sample project produces identical results
+  before and after the change, confirming zero behavior drift.
+- **SC-005**: 100% of the inventory entries from FR-010 are resolved as either
+  updated or explicitly unaffected, with no entry left undetermined.
+- **SC-006**: RFC-0001's Stage 0 gate is satisfied: the change is merged as its
+  own pull request and referenced from the RFC.
+
+## Assumptions
+
+- The amendment follows the project's existing governance process for
+  architecture-affecting changes, including the comment period and maintainer
+  consensus described in GOVERNANCE.md.
+- This feature delivers document changes only. Implementing the permitted
+  behavior is a separate, later effort (RFC-0001 Stage 1) and is out of scope
+  here. This is why FR-013 requires zero behavior change.
+- The existing configuration mechanism for marking user-judgment keys is
+  retained unchanged, including its name and accepted values; only the meaning
+  of the mark is narrowed. See FR-014.
+- The permission to propose applies regardless of how the candidate was
+  produced. No detection source can conclude a user-judgment key, so no source
+  needs to be singled out.
+- Existing automatic-acceptance behavior for keys that do not require human
+  judgment is unaffected.
+- This rule governs the verification side only, where a wrong answer is an
+  invisible false pass. Automatic acceptance of remediation output, where a
+  wrong answer is a visible and revertible change, is a separate trust boundary
+  and is out of scope here.
+- The safety property being preserved is that no unconfirmed value is ever
+  used. The property being dropped is that no unconfirmed value is ever
+  computed. These were previously conflated in a single sentence.

--- a/specs/018-auto-detect-propose-only/tasks.md
+++ b/specs/018-auto-detect-propose-only/tasks.md
@@ -144,7 +144,7 @@ contains a statement that detection must not run for user-judgment keys.
 - [X] T028 [P] Grep all prose for surviving statements of the old rule (`grep -rn "must not run" --include="*.md" .`) and confirm only historical spec records under `specs/001-*` and `specs/003-*` remain, satisfying SC-002
 - [X] T029 [P] Confirm every file touched is ASCII-only per the project writing rule
 - [X] T030 Read the amended Principle IV cold and confirm a sentence can be cited for each of the five consumption paths, satisfying SC-003
-- [ ] T031 Open the PR against `darnitdevorg/darnit` from the fork, describing the change as reconciling the constitution with shipped behavior (research.md Finding 1) rather than as loosening a safety rule
+- [X] T031 Open the PR against `darnitdevorg/darnit` from the fork, describing the change as reconciling the constitution with shipped behavior (research.md Finding 1) rather than as loosening a safety rule
 - [ ] T032 Request TSC review under the Charter's voting rules, on the grounds that the constitution is a governing artifact in substance even though `GOVERNANCE.md:51` lists only that document, the Charter, and the roster
 - [ ] T033 File a follow-up issue to add the constitution to the `GOVERNANCE.md:51` enumeration, so the next amendment does not have to relitigate which track applies
 

--- a/specs/018-auto-detect-propose-only/tasks.md
+++ b/specs/018-auto-detect-propose-only/tasks.md
@@ -1,0 +1,220 @@
+---
+
+description: "Task list for feature 018: propose-only auto-detection for user-judgment keys"
+---
+
+# Tasks: Propose-Only Auto-Detection for User-Judgment Keys
+
+**Input**: Design documents from `/specs/018-auto-detect-propose-only/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: No test tasks. This feature changes prose only, so there is nothing
+to test. The existing suites serve as regression evidence for FR-013 and appear
+as verification tasks in Phase 6, not as new tests.
+
+**Organization**: Grouped by user story. Because every story edits the same
+small set of prose files, `[P]` appears far less often here than in a code
+feature. Two tasks are parallel only when they touch different files.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+No source tree is involved. All paths are prose files at repository root or
+under `docs/` and `.specify/`. See plan.md "Files changed" for the full set.
+
+---
+
+## Phase 1: Setup (Baseline Capture)
+
+**Purpose**: Record the before-state that SC-004 compares against. This must
+happen before any file is edited, or the comparison is worthless.
+
+- [ ] T001 Run `uv run pytest tests/ --ignore=tests/integration/ -q` and record the pass count in a scratch note; this is the FR-013 baseline
+- [ ] T002 [P] Run `uv run ruff check .` and confirm zero errors before any edit
+- [ ] T003 [P] Run an audit against a fixed sample project that has `maintainers` unset and save the output to `/tmp/018-audit-before.txt` for the SC-004 comparison
+
+**Checkpoint**: Before-state captured. Editing can begin.
+
+---
+
+## Phase 2: Foundational (Canonical Wording)
+
+**Purpose**: Fix the vocabulary once, before three stories write into the same
+paragraphs. Skipping this is how SC-001 fails: if one story writes "candidate"
+and another writes "suggestion", the amended documents disagree with each other
+even though every individual edit looks correct.
+
+**CRITICAL**: No story work can begin until T004 is done.
+
+- [ ] T004 Draft the replacement text for Principle IV as one coherent block in a scratch file, using only the six terms fixed in `specs/018-auto-detect-propose-only/data-model.md` ("user-judgment key", "candidate", "confirmation", "propose", "conclude", "origin"), covering every clause required by FR-001 through FR-007 and FR-015
+
+**Checkpoint**: One agreed block of normative text exists. Stories now place it.
+
+---
+
+## Phase 3: User Story 1 - Maintainer amends the governance rule (Priority: P1) -- MVP
+
+**Goal**: The permission flip itself. After this phase the project's governing
+documents permit proposing a candidate for a user-judgment key and forbid using
+it unconfirmed.
+
+**Independent Test**: Read the amended constitution and CLAUDE.md in isolation
+and confirm that offering a candidate is permitted while accepting one without
+human confirmation is forbidden. No code needs to exist.
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] Replace the absolute prohibition at `.specify/memory/constitution.md:102-103` ("the sieve MUST NOT run for that key. No exceptions.") with the propose-only rule from T004, satisfying FR-001
+- [ ] T006 [US1] Replace `.specify/memory/constitution.md:106-107` ("Sieve auto-detection is acceptable ONLY for keys where `auto_detect = true`"), which is the sentence that actually forbids proposing, per FR-001
+- [ ] T007 [P] [US1] Rewrite `CLAUDE.md:170` and `CLAUDE.md:172` to match the amended constitution exactly in substance, per FR-008
+- [ ] T008 [P] [US1] Rewrite the normative restatement at `ARCHITECTURE.md:29` ("the sieve must not run for that key"), found during Phase 0 research and absent from the original spec; see research.md Finding 3
+- [ ] T009 [US1] Bump the constitution version from 1.2.0 to 1.3.0 at `.specify/memory/constitution.md:186` and add a new Sync Impact Report block at the top recording the change, per FR-009
+- [ ] T010 [US1] In the Sync Impact Report, justify MINOR by citing the 1.0.0 -> 1.1.0 precedent where this same principle was widened while its core requirement stayed intact, per FR-009
+- [ ] T011 [P] [US1] Mark the Stage 0 row at `docs/rfcs/0001-core-rearchitecture.md:247` as satisfied and reference this PR, per FR-012
+
+**Checkpoint**: The rule has changed. A reader of the constitution alone now
+gets the right answer to "may darnit show me a detected maintainer list?"
+
+---
+
+## Phase 4: User Story 2 - Contributor implements against an unambiguous rule (Priority: P2)
+
+**Goal**: The precision. After this phase the amended rule answers boundary
+questions without guesswork, so no implementation can read the loosened rule as
+permission to consume a candidate.
+
+**Independent Test**: Give the amended rule and the five consumption paths from
+data-model.md to two readers and ask which may consume an unconfirmed
+candidate. Both answer "none" without consulting code.
+
+**Note**: These tasks edit the same Principle IV block as US1, so none of them
+are parallel with each other. This is the cost of the two stories sharing a
+paragraph, and it is why T004 exists.
+
+### Implementation for User Story 2
+
+- [ ] T012 [US2] Add the FR-002 clause to `.specify/memory/constitution.md` Principle IV naming all five consumption paths explicitly (verification result, compliance calculation, remediation input, generated attestation, persisted context), so SC-003 can cite a sentence per path
+- [ ] T013 [US2] Scope the existing confidence-threshold provision at `.specify/memory/constitution.md:108-113` to keys that do NOT require human judgment, closing the hole where it currently reads as unscoped, per FR-004
+- [ ] T014 [US2] Add the FR-005 clause stating that human confirmation is the only transition that makes a value usable, and that storing a candidate does not constitute confirming it
+- [ ] T015 [US2] Add the FR-006 clause requiring a confirmation to record when it was made, by whom, and what it was based on, and permitting expiry after a configurable period without naming the period
+- [ ] T016 [US2] Verify the existing prohibition on guessed values in executable snippets survives the rewrite at `.specify/memory/constitution.md:114-115`, per FR-007; this clause must not be lost while its neighbours change
+- [ ] T017 [US2] Add the FR-015 clause explaining that `auto_detect` gates concluding and `allow_sieve_hints` gates proposing, and that the safety property is enforced by the pair rather than by a ban on detection
+- [ ] T018 [US2] Mirror T012 through T017 into the Conservative-by-Default section of `CLAUDE.md` at the level of detail appropriate to runtime guidance, keeping substance identical per FR-008
+
+**Checkpoint**: The rule is now precise enough to implement against. US1 plus
+US2 together are the complete governance change.
+
+---
+
+## Phase 5: User Story 3 - Reviewer confirms nothing regressed (Priority: P3)
+
+**Goal**: Evidence that loosening the written rule did not loosen behavior, and
+that no document anywhere still states the old rule.
+
+**Independent Test**: Audit results identical before and after; no prose file
+contains a statement that detection must not run for user-judgment keys.
+
+### Implementation for User Story 3
+
+- [ ] T019 [P] [US3] Extend `ARCHITECTURE.md:441` ("Values with `auto_detect = false` require explicit user confirmation") to mention that a candidate may be proposed, per FR-011
+- [ ] T020 [P] [US3] Clarify the schema table entry at `docs/design/CONTEXT_PROMPTS.md:201` from "Whether value can be auto-detected" to language distinguishing concluding from proposing, per FR-011
+- [ ] T021 [P] [US3] Add a sentence near the `auto_detect = false` example at `docs/IMPLEMENTATION_GUIDE.md:707` explaining what the flag now means, per FR-011
+- [ ] T022 [US3] Confirm every entry in the research.md inventory carries a disposition of updated, deferred, or unaffected, with none left undetermined, per FR-010 and SC-005
+- [ ] T023 [US3] Verify no file under `packages/` was modified (`git diff --name-only | grep packages/` returns nothing), enforcing the FR-011 deferral and the FR-013 boundary
+
+**Checkpoint**: Documentation tree is internally consistent. Nothing in
+`packages/` moved.
+
+---
+
+## Phase 6: Polish & Verification
+
+**Purpose**: Prove the success criteria and get the change in front of the TSC.
+
+- [ ] T024 Re-run `uv run pytest tests/ --ignore=tests/integration/ -q` and confirm the pass count matches the T001 baseline exactly; any test needing modification disproves FR-013
+- [ ] T025 [P] Re-run `uv run ruff check .` and `uv run python scripts/validate_sync.py --verbose`, both must pass
+- [ ] T026 [P] Re-run the T003 audit, diff against `/tmp/018-audit-before.txt`, and confirm no substantive difference, satisfying SC-004
+- [ ] T027 [P] Grep all prose for surviving statements of the old rule (`grep -rn "must not run" --include="*.md" .`) and confirm only historical spec records under `specs/001-*` and `specs/003-*` remain, satisfying SC-002
+- [ ] T028 [P] Confirm every file touched is ASCII-only per the project writing rule
+- [ ] T029 Read the amended Principle IV cold and confirm a sentence can be cited for each of the five consumption paths, satisfying SC-003
+- [ ] T030 Open the PR against `darnitdevorg/darnit` from the fork, describing the change as reconciling the constitution with shipped behavior (research.md Finding 1) rather than as loosening a safety rule
+- [ ] T031 Start the GOVERNANCE.md comment period and request TSC review; the amendment cannot merge on a single approval
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies. Must complete before any edit, or SC-004 has no baseline.
+- **Foundational (Phase 2)**: Depends on Setup. BLOCKS all stories.
+- **User Story 1 (Phase 3)**: Depends on T004. Delivers the permission flip.
+- **User Story 2 (Phase 4)**: Depends on US1, because it adds clauses to the block US1 places. Not independent in the usual sense; see note below.
+- **User Story 3 (Phase 5)**: Depends on US1 for the canonical wording it propagates. Independent of US2.
+- **Polish (Phase 6)**: Depends on all stories.
+
+### A note on story independence
+
+The template assumes stories are independently deliverable. Here US1 is, and
+US2 is not: US2 writes clauses into the paragraph US1 replaces. Shipping US1
+alone would be worse than shipping nothing, because it grants the permission
+without the limits. Treat US1 + US2 as the atomic unit for merge; only US3 is
+genuinely separable, and only in the sense that it could follow in a second PR.
+
+### Parallel Opportunities
+
+- T002 and T003 in Setup
+- T007, T008, T011 in US1 (constitution, CLAUDE.md, ARCHITECTURE.md, RFC are four different files)
+- T019, T020, T021 in US3 (three different files)
+- T025, T026, T027, T028 in Polish
+- Nothing in US2 is parallel; every task edits the same Principle IV block
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After T005 and T006 land the constitution text, these three are independent:
+Task: "Rewrite CLAUDE.md:170,172 to match the amended constitution"
+Task: "Rewrite the normative restatement at ARCHITECTURE.md:29"
+Task: "Mark the Stage 0 row satisfied at docs/rfcs/0001-core-rearchitecture.md:247"
+```
+
+---
+
+## Implementation Strategy
+
+### Recommended: US1 + US2 as one PR
+
+1. Phase 1 Setup, Phase 2 Foundational
+2. Phase 3 (US1) and Phase 4 (US2) together
+3. Phase 5 (US3) in the same PR if the diff stays readable
+4. Phase 6 verification, then open the PR and start the comment period
+
+RFC-0001 Stage 0 requires this land as its own PR, so the temptation to bundle
+it with Stage 1 groundwork should be resisted (FR-012, SC-006).
+
+### If the diff gets large
+
+Split US3 into a follow-up PR. It touches only non-normative prose, so the
+governing documents stay consistent either way. Do not split US1 from US2.
+
+---
+
+## Notes
+
+- `packages/darnit/src/darnit/context/auto_detect.py` is a module about context
+  detection generally, NOT the TOML flag. Several inventory hits are that
+  module and must not be touched. This is the single most likely mistake.
+- Historical spec records under `specs/001-tiered-control-automation/` and
+  `specs/003-auto-context-inference/` state the old rule and are deliberately
+  left alone. Rewriting them would misrepresent what was decided then.
+- `docs/architecture/framework-design.md:838` already shows `auto_detect = false`
+  alongside `allow_sieve_hints = true` and needs no change; it is the evidence
+  that the design already went this way.

--- a/specs/018-auto-detect-propose-only/tasks.md
+++ b/specs/018-auto-detect-propose-only/tasks.md
@@ -105,7 +105,8 @@ paragraph, and it is why T004 exists.
 - [ ] T015 [US2] Add the FR-006 clause requiring a confirmation to record when it was made, by whom, and what it was based on, and permitting expiry after a configurable period without naming the period
 - [ ] T016 [US2] Verify the existing prohibition on guessed values in executable snippets survives the rewrite at `.specify/memory/constitution.md:114-115`, per FR-007; this clause must not be lost while its neighbours change
 - [ ] T017 [US2] Add the FR-015 clause explaining that `auto_detect` gates concluding and `allow_sieve_hints` gates proposing, and that the safety property is enforced by the pair rather than by a ban on detection
-- [ ] T018 [US2] Mirror T012 through T017 into the Conservative-by-Default section of `CLAUDE.md` at the level of detail appropriate to runtime guidance, keeping substance identical per FR-008
+- [ ] T018 [US2] Add the FR-003 clause to `.specify/memory/constitution.md` Principle IV requiring that a candidate shown to a person is labelled as unconfirmed and carries its origin, so a reader can judge whether to trust it; this is the clause that makes US2 acceptance scenario 5 checkable
+- [ ] T019 [US2] Mirror T012 through T018 into the Conservative-by-Default section of `CLAUDE.md` at the level of detail appropriate to runtime guidance, keeping substance identical per FR-008
 
 **Checkpoint**: The rule is now precise enough to implement against. US1 plus
 US2 together are the complete governance change.
@@ -122,11 +123,11 @@ contains a statement that detection must not run for user-judgment keys.
 
 ### Implementation for User Story 3
 
-- [ ] T019 [P] [US3] Extend `ARCHITECTURE.md:441` ("Values with `auto_detect = false` require explicit user confirmation") to mention that a candidate may be proposed, per FR-011
-- [ ] T020 [P] [US3] Clarify the schema table entry at `docs/design/CONTEXT_PROMPTS.md:201` from "Whether value can be auto-detected" to language distinguishing concluding from proposing, per FR-011
-- [ ] T021 [P] [US3] Add a sentence near the `auto_detect = false` example at `docs/IMPLEMENTATION_GUIDE.md:707` explaining what the flag now means, per FR-011
-- [ ] T022 [US3] Confirm every entry in the research.md inventory carries a disposition of updated, deferred, or unaffected, with none left undetermined, per FR-010 and SC-005
-- [ ] T023 [US3] Verify no file under `packages/` was modified (`git diff --name-only | grep packages/` returns nothing), enforcing the FR-011 deferral and the FR-013 boundary
+- [ ] T020 [P] [US3] Extend `ARCHITECTURE.md:441` ("Values with `auto_detect = false` require explicit user confirmation") to mention that a candidate may be proposed, per FR-011
+- [ ] T021 [P] [US3] Clarify the schema table entry at `docs/design/CONTEXT_PROMPTS.md:201` from "Whether value can be auto-detected" to language distinguishing concluding from proposing, per FR-011
+- [ ] T022 [P] [US3] Add a sentence near the `auto_detect = false` example at `docs/IMPLEMENTATION_GUIDE.md:707` explaining what the flag now means, per FR-011
+- [ ] T023 [US3] Confirm every entry in the research.md inventory carries a disposition of updated, deferred, or unaffected, with none left undetermined, per FR-010 and SC-005
+- [ ] T024 [US3] Verify no file under `packages/` was modified (`git diff --name-only | grep packages/` returns nothing), enforcing the FR-011 deferral and the FR-013 boundary
 
 **Checkpoint**: Documentation tree is internally consistent. Nothing in
 `packages/` moved.
@@ -137,14 +138,15 @@ contains a statement that detection must not run for user-judgment keys.
 
 **Purpose**: Prove the success criteria and get the change in front of the TSC.
 
-- [ ] T024 Re-run `uv run pytest tests/ --ignore=tests/integration/ -q` and confirm the pass count matches the T001 baseline exactly; any test needing modification disproves FR-013
-- [ ] T025 [P] Re-run `uv run ruff check .` and `uv run python scripts/validate_sync.py --verbose`, both must pass
-- [ ] T026 [P] Re-run the T003 audit, diff against `/tmp/018-audit-before.txt`, and confirm no substantive difference, satisfying SC-004
-- [ ] T027 [P] Grep all prose for surviving statements of the old rule (`grep -rn "must not run" --include="*.md" .`) and confirm only historical spec records under `specs/001-*` and `specs/003-*` remain, satisfying SC-002
-- [ ] T028 [P] Confirm every file touched is ASCII-only per the project writing rule
-- [ ] T029 Read the amended Principle IV cold and confirm a sentence can be cited for each of the five consumption paths, satisfying SC-003
-- [ ] T030 Open the PR against `darnitdevorg/darnit` from the fork, describing the change as reconciling the constitution with shipped behavior (research.md Finding 1) rather than as loosening a safety rule
-- [ ] T031 Start the GOVERNANCE.md comment period and request TSC review; the amendment cannot merge on a single approval
+- [ ] T025 Re-run `uv run pytest tests/ --ignore=tests/integration/ -q` and confirm the pass count matches the T001 baseline exactly; any test needing modification disproves FR-013
+- [ ] T026 [P] Re-run `uv run ruff check .` and `uv run python scripts/validate_sync.py --verbose`, both must pass
+- [ ] T027 [P] Re-run the T003 audit, diff against `/tmp/018-audit-before.txt`, and confirm the only differences are timestamps and absolute paths; any difference in control status, level outcome, or finding count disproves SC-004
+- [ ] T028 [P] Grep all prose for surviving statements of the old rule (`grep -rn "must not run" --include="*.md" .`) and confirm only historical spec records under `specs/001-*` and `specs/003-*` remain, satisfying SC-002
+- [ ] T029 [P] Confirm every file touched is ASCII-only per the project writing rule
+- [ ] T030 Read the amended Principle IV cold and confirm a sentence can be cited for each of the five consumption paths, satisfying SC-003
+- [ ] T031 Open the PR against `darnitdevorg/darnit` from the fork, describing the change as reconciling the constitution with shipped behavior (research.md Finding 1) rather than as loosening a safety rule
+- [ ] T032 Request TSC review under the Charter's voting rules, on the grounds that the constitution is a governing artifact in substance even though `GOVERNANCE.md:51` lists only that document, the Charter, and the roster
+- [ ] T033 File a follow-up issue to add the constitution to the `GOVERNANCE.md:51` enumeration, so the next amendment does not have to relitigate which track applies
 
 ---
 
@@ -170,9 +172,9 @@ genuinely separable, and only in the sense that it could follow in a second PR.
 ### Parallel Opportunities
 
 - T002 and T003 in Setup
-- T007, T008, T011 in US1 (constitution, CLAUDE.md, ARCHITECTURE.md, RFC are four different files)
-- T019, T020, T021 in US3 (three different files)
-- T025, T026, T027, T028 in Polish
+- T007, T008, T011 in US1 (CLAUDE.md, ARCHITECTURE.md, and the RFC are three different files)
+- T020, T021, T022 in US3 (three different files)
+- T026, T027, T028, T029 in Polish
 - Nothing in US2 is parallel; every task edits the same Principle IV block
 
 ---
@@ -195,7 +197,7 @@ Task: "Mark the Stage 0 row satisfied at docs/rfcs/0001-core-rearchitecture.md:2
 1. Phase 1 Setup, Phase 2 Foundational
 2. Phase 3 (US1) and Phase 4 (US2) together
 3. Phase 5 (US3) in the same PR if the diff stays readable
-4. Phase 6 verification, then open the PR and start the comment period
+4. Phase 6 verification, then open the PR and request TSC review
 
 RFC-0001 Stage 0 requires this land as its own PR, so the temptation to bundle
 it with Stage 1 groundwork should be resisted (FR-012, SC-006).

--- a/specs/018-auto-detect-propose-only/tasks.md
+++ b/specs/018-auto-detect-propose-only/tasks.md
@@ -35,9 +35,9 @@ under `docs/` and `.specify/`. See plan.md "Files changed" for the full set.
 **Purpose**: Record the before-state that SC-004 compares against. This must
 happen before any file is edited, or the comparison is worthless.
 
-- [ ] T001 Run `uv run pytest tests/ --ignore=tests/integration/ -q` and record the pass count in a scratch note; this is the FR-013 baseline
-- [ ] T002 [P] Run `uv run ruff check .` and confirm zero errors before any edit
-- [ ] T003 [P] Run an audit against a fixed sample project that has `maintainers` unset and save the output to `/tmp/018-audit-before.txt` for the SC-004 comparison
+- [X] T001 Run `uv run pytest tests/ --ignore=tests/integration/ -q` and record the pass count in a scratch note; this is the FR-013 baseline
+- [X] T002 [P] Run `uv run ruff check .` and confirm zero errors before any edit
+- [X] T003 [P] Run an audit against a fixed sample project that has `maintainers` unset and save the output to `/tmp/018-audit-before.txt` for the SC-004 comparison
 
 **Checkpoint**: Before-state captured. Editing can begin.
 
@@ -52,7 +52,7 @@ even though every individual edit looks correct.
 
 **CRITICAL**: No story work can begin until T004 is done.
 
-- [ ] T004 Draft the replacement text for Principle IV as one coherent block in a scratch file, using only the six terms fixed in `specs/018-auto-detect-propose-only/data-model.md` ("user-judgment key", "candidate", "confirmation", "propose", "conclude", "origin"), covering every clause required by FR-001 through FR-007 and FR-015
+- [X] T004 Draft the replacement text for Principle IV as one coherent block in a scratch file, using only the six terms fixed in `specs/018-auto-detect-propose-only/data-model.md` ("user-judgment key", "candidate", "confirmation", "propose", "conclude", "origin"), covering every clause required by FR-001 through FR-007 and FR-015
 
 **Checkpoint**: One agreed block of normative text exists. Stories now place it.
 
@@ -70,13 +70,13 @@ human confirmation is forbidden. No code needs to exist.
 
 ### Implementation for User Story 1
 
-- [ ] T005 [US1] Replace the absolute prohibition at `.specify/memory/constitution.md:102-103` ("the sieve MUST NOT run for that key. No exceptions.") with the propose-only rule from T004, satisfying FR-001
-- [ ] T006 [US1] Replace `.specify/memory/constitution.md:106-107` ("Sieve auto-detection is acceptable ONLY for keys where `auto_detect = true`"), which is the sentence that actually forbids proposing, per FR-001
-- [ ] T007 [P] [US1] Rewrite `CLAUDE.md:170` and `CLAUDE.md:172` to match the amended constitution exactly in substance, per FR-008
-- [ ] T008 [P] [US1] Rewrite the normative restatement at `ARCHITECTURE.md:29` ("the sieve must not run for that key"), found during Phase 0 research and absent from the original spec; see research.md Finding 3
-- [ ] T009 [US1] Bump the constitution version from 1.2.0 to 1.3.0 at `.specify/memory/constitution.md:186` and add a new Sync Impact Report block at the top recording the change, per FR-009
-- [ ] T010 [US1] In the Sync Impact Report, justify MINOR by citing the 1.0.0 -> 1.1.0 precedent where this same principle was widened while its core requirement stayed intact, per FR-009
-- [ ] T011 [P] [US1] Mark the Stage 0 row at `docs/rfcs/0001-core-rearchitecture.md:247` as satisfied and reference this PR, per FR-012
+- [X] T005 [US1] Replace the absolute prohibition at `.specify/memory/constitution.md:102-103` ("the sieve MUST NOT run for that key. No exceptions.") with the propose-only rule from T004, satisfying FR-001
+- [X] T006 [US1] Replace `.specify/memory/constitution.md:106-107` ("Sieve auto-detection is acceptable ONLY for keys where `auto_detect = true`"), which is the sentence that actually forbids proposing, per FR-001
+- [X] T007 [P] [US1] Rewrite `CLAUDE.md:170` and `CLAUDE.md:172` to match the amended constitution exactly in substance, per FR-008
+- [X] T008 [P] [US1] Rewrite the normative restatement at `ARCHITECTURE.md:29` ("the sieve must not run for that key"), found during Phase 0 research and absent from the original spec; see research.md Finding 3
+- [X] T009 [US1] Bump the constitution version from 1.2.0 to 1.3.0 at `.specify/memory/constitution.md:186` and add a new Sync Impact Report block at the top recording the change, per FR-009
+- [X] T010 [US1] In the Sync Impact Report, justify MINOR by citing the 1.0.0 -> 1.1.0 precedent where this same principle was widened while its core requirement stayed intact, per FR-009
+- [X] T011 [P] [US1] Mark the Stage 0 row at `docs/rfcs/0001-core-rearchitecture.md:247` as satisfied and reference this PR, per FR-012
 
 **Checkpoint**: The rule has changed. A reader of the constitution alone now
 gets the right answer to "may darnit show me a detected maintainer list?"
@@ -99,14 +99,14 @@ paragraph, and it is why T004 exists.
 
 ### Implementation for User Story 2
 
-- [ ] T012 [US2] Add the FR-002 clause to `.specify/memory/constitution.md` Principle IV naming all five consumption paths explicitly (verification result, compliance calculation, remediation input, generated attestation, persisted context), so SC-003 can cite a sentence per path
-- [ ] T013 [US2] Scope the existing confidence-threshold provision at `.specify/memory/constitution.md:108-113` to keys that do NOT require human judgment, closing the hole where it currently reads as unscoped, per FR-004
-- [ ] T014 [US2] Add the FR-005 clause stating that human confirmation is the only transition that makes a value usable, and that storing a candidate does not constitute confirming it
-- [ ] T015 [US2] Add the FR-006 clause requiring a confirmation to record when it was made, by whom, and what it was based on, and permitting expiry after a configurable period without naming the period
-- [ ] T016 [US2] Verify the existing prohibition on guessed values in executable snippets survives the rewrite at `.specify/memory/constitution.md:114-115`, per FR-007; this clause must not be lost while its neighbours change
-- [ ] T017 [US2] Add the FR-015 clause explaining that `auto_detect` gates concluding and `allow_sieve_hints` gates proposing, and that the safety property is enforced by the pair rather than by a ban on detection
-- [ ] T018 [US2] Add the FR-003 clause to `.specify/memory/constitution.md` Principle IV requiring that a candidate shown to a person is labelled as unconfirmed and carries its origin, so a reader can judge whether to trust it; this is the clause that makes US2 acceptance scenario 5 checkable
-- [ ] T019 [US2] Mirror T012 through T018 into the Conservative-by-Default section of `CLAUDE.md` at the level of detail appropriate to runtime guidance, keeping substance identical per FR-008
+- [X] T012 [US2] Add the FR-002 clause to `.specify/memory/constitution.md` Principle IV naming all five consumption paths explicitly (verification result, compliance calculation, remediation input, generated attestation, persisted context), so SC-003 can cite a sentence per path
+- [X] T013 [US2] Scope the existing confidence-threshold provision at `.specify/memory/constitution.md:108-113` to keys that do NOT require human judgment, closing the hole where it currently reads as unscoped, per FR-004
+- [X] T014 [US2] Add the FR-005 clause stating that human confirmation is the only transition that makes a value usable, and that storing a candidate does not constitute confirming it
+- [X] T015 [US2] Add the FR-006 clause requiring a confirmation to record when it was made, by whom, and what it was based on, and permitting expiry after a configurable period without naming the period
+- [X] T016 [US2] Verify the existing prohibition on guessed values in executable snippets survives the rewrite at `.specify/memory/constitution.md:114-115`, per FR-007; this clause must not be lost while its neighbours change
+- [X] T017 [US2] Add the FR-015 clause explaining that `auto_detect` gates concluding and `allow_sieve_hints` gates proposing, and that the safety property is enforced by the pair rather than by a ban on detection
+- [X] T018 [US2] Add the FR-003 clause to `.specify/memory/constitution.md` Principle IV requiring that a candidate shown to a person is labelled as unconfirmed and carries its origin, so a reader can judge whether to trust it; this is the clause that makes US2 acceptance scenario 5 checkable
+- [X] T019 [US2] Mirror T012 through T018 into the Conservative-by-Default section of `CLAUDE.md` at the level of detail appropriate to runtime guidance, keeping substance identical per FR-008
 
 **Checkpoint**: The rule is now precise enough to implement against. US1 plus
 US2 together are the complete governance change.
@@ -123,11 +123,11 @@ contains a statement that detection must not run for user-judgment keys.
 
 ### Implementation for User Story 3
 
-- [ ] T020 [P] [US3] Extend `ARCHITECTURE.md:441` ("Values with `auto_detect = false` require explicit user confirmation") to mention that a candidate may be proposed, per FR-011
-- [ ] T021 [P] [US3] Clarify the schema table entry at `docs/design/CONTEXT_PROMPTS.md:201` from "Whether value can be auto-detected" to language distinguishing concluding from proposing, per FR-011
-- [ ] T022 [P] [US3] Add a sentence near the `auto_detect = false` example at `docs/IMPLEMENTATION_GUIDE.md:707` explaining what the flag now means, per FR-011
-- [ ] T023 [US3] Confirm every entry in the research.md inventory carries a disposition of updated, deferred, or unaffected, with none left undetermined, per FR-010 and SC-005
-- [ ] T024 [US3] Verify no file under `packages/` was modified (`git diff --name-only | grep packages/` returns nothing), enforcing the FR-011 deferral and the FR-013 boundary
+- [X] T020 [P] [US3] Extend `ARCHITECTURE.md:441` ("Values with `auto_detect = false` require explicit user confirmation") to mention that a candidate may be proposed, per FR-011
+- [X] T021 [P] [US3] Clarify the schema table entry at `docs/design/CONTEXT_PROMPTS.md:201` from "Whether value can be auto-detected" to language distinguishing concluding from proposing, per FR-011
+- [X] T022 [P] [US3] Add a sentence near the `auto_detect = false` example at `docs/IMPLEMENTATION_GUIDE.md:707` explaining what the flag now means, per FR-011
+- [X] T023 [US3] Confirm every entry in the research.md inventory carries a disposition of updated, deferred, or unaffected, with none left undetermined, per FR-010 and SC-005
+- [X] T024 [US3] Verify no file under `packages/` was modified (`git diff --name-only | grep packages/` returns nothing), enforcing the FR-011 deferral and the FR-013 boundary
 
 **Checkpoint**: Documentation tree is internally consistent. Nothing in
 `packages/` moved.
@@ -138,12 +138,12 @@ contains a statement that detection must not run for user-judgment keys.
 
 **Purpose**: Prove the success criteria and get the change in front of the TSC.
 
-- [ ] T025 Re-run `uv run pytest tests/ --ignore=tests/integration/ -q` and confirm the pass count matches the T001 baseline exactly; any test needing modification disproves FR-013
-- [ ] T026 [P] Re-run `uv run ruff check .` and `uv run python scripts/validate_sync.py --verbose`, both must pass
-- [ ] T027 [P] Re-run the T003 audit, diff against `/tmp/018-audit-before.txt`, and confirm the only differences are timestamps and absolute paths; any difference in control status, level outcome, or finding count disproves SC-004
-- [ ] T028 [P] Grep all prose for surviving statements of the old rule (`grep -rn "must not run" --include="*.md" .`) and confirm only historical spec records under `specs/001-*` and `specs/003-*` remain, satisfying SC-002
-- [ ] T029 [P] Confirm every file touched is ASCII-only per the project writing rule
-- [ ] T030 Read the amended Principle IV cold and confirm a sentence can be cited for each of the five consumption paths, satisfying SC-003
+- [X] T025 Re-run `uv run pytest tests/ --ignore=tests/integration/ -q` and confirm the pass count matches the T001 baseline exactly; any test needing modification disproves FR-013
+- [X] T026 [P] Re-run `uv run ruff check .` and `uv run python scripts/validate_sync.py --verbose`, both must pass
+- [X] T027 [P] Re-run the T003 audit, diff against `/tmp/018-audit-before.txt`, and confirm the only differences are timestamps and absolute paths; any difference in control status, level outcome, or finding count disproves SC-004
+- [X] T028 [P] Grep all prose for surviving statements of the old rule (`grep -rn "must not run" --include="*.md" .`) and confirm only historical spec records under `specs/001-*` and `specs/003-*` remain, satisfying SC-002
+- [X] T029 [P] Confirm every file touched is ASCII-only per the project writing rule
+- [X] T030 Read the amended Principle IV cold and confirm a sentence can be cited for each of the five consumption paths, satisfying SC-003
 - [ ] T031 Open the PR against `darnitdevorg/darnit` from the fork, describing the change as reconciling the constitution with shipped behavior (research.md Finding 1) rather than as loosening a safety rule
 - [ ] T032 Request TSC review under the Charter's voting rules, on the grounds that the constitution is a governing artifact in substance even though `GOVERNANCE.md:51` lists only that document, the Charter, and the roster
 - [ ] T033 File a follow-up issue to add the constitution to the `GOVERNANCE.md:51` enumeration, so the next amendment does not have to relitigate which track applies


### PR DESCRIPTION
## Summary

Principle IV of the constitution says that when a context key is marked
`auto_detect = false`, "the sieve MUST NOT run for that key. No exceptions."
That one sentence conflates two different prohibitions: *computing* a candidate
value, and *using* one. Only the second carries the safety property.

This amendment separates them. For a user-judgment key, detection MAY run to
produce a candidate to show a person, but MUST NOT conclude the value on its
own. Constitution 1.2.0 -> 1.3.0, MINOR.

**This is reconciliation, not authorization.** Propose-only already ships:

- `framework_schema.py:802,807` defines `hint_sources` and `allow_sieve_hints`
- `openssf-baseline.toml:287-289,300-301` enables them for `maintainers` and
  `security_contact` -- two of the three keys the constitution names as
  requiring human judgment
- `collection.py:264-271` resolves `hint_sources` with **no `auto_detect` gate**
- `context_validator.py:219-258` presents the result as a labelled suggestion
  and requires an explicit `confirm_project_data(...)` call

So the shipped behavior is: candidate produced, labelled, never auto-applied,
confirmation required. That is precisely propose-only, and precisely what
Principle IV reads as forbidding. The PR corrects a governing document that
misdescribes the system, in the direction the design already went. See
`specs/018-auto-detect-propose-only/research.md` Finding 1.

Consequence: no observable behavior changes. There is no behavior to hold
still, because the amendment only changes prose.

## What the amendment adds

- A candidate MUST NOT be consumed by any of five paths: control verification
  results, compliance calculations, remediation action inputs, generated
  attestations, or persisted project context. Until confirmed, the key is
  unverified, and unverified counts as FAIL (Principle II).
- A candidate shown to a person MUST be labelled unconfirmed and carry its
  origin. Origin is not confidence -- a high-confidence guess is still a guess.
- Human confirmation is the only transition that makes a value usable.
  Persisting a candidate does not confirm it, and a stored candidate MUST stay
  distinguishable from a confirmed value on every later read.
- Confirmations record when, by whom, and from which candidate, and MAY expire.
- Two flags, two axes: `auto_detect` governs whether a value may be *concluded*
  without a person; `allow_sieve_hints` governs whether one may be *proposed*.
  Both default false. The safety property is enforced by the pair, not by a
  prohibition on detection.
- The confidence-threshold provision is scoped to non-user-judgment keys. No
  threshold, at any value, authorizes concluding a user-judgment key.

## Why MINOR rather than MAJOR

The core requirement is unchanged: never silently apply a value that requires
user judgment. This follows the 1.0.0 -> 1.1.0 precedent recorded at
constitution.md:32-38, where Principle IV was previously widened and classified
MINOR on the same grounds.

## Scope

Prose only. Every normative restatement of the old wording is updated
(constitution, CLAUDE.md, ARCHITECTURE.md, CONTEXT_PROMPTS.md,
IMPLEMENTATION_GUIDE.md, RFC-0001). Code, configuration, and their comments are
recorded as deferred with reasons; historical spec records are left alone. Full
inventory in `research.md`.

Discharges the Stage 0 governance dependency named by RFC-0001 (line 280).

## Reviewer attention

- **Governance track**: the constitution's Governance section requires only a
  description, a version bump, and a consistency check -- no vote. GOVERNANCE.md:51
  escalates only itself, the Charter, and the TSC roster to the Charter, and does
  not name the constitution. This PR nonetheless requests TSC review, on the
  view that amending a governing document is governance. A follow-up issue will
  propose adding the constitution to that enumeration.
- **`collection.py:233`'s docstring still understates what the function does** --
  it lists auto-detection as gated by `auto_detect`, but `hint_sources` is
  un-gated. Deferred as a code change; it is the gap Finding 1 describes.

## Test plan

- [ ] Full test suite passes (one pre-existing failure on this branch:
      `test_upstream_spec_unchanged`, a hash drift against the upstream CNCF
      `.project/` spec, identical before and after this change)
- [ ] `uv run python scripts/validate_sync.py --verbose` passes
- [ ] Audit output on a fixed sample repo unchanged before/after. Note: two
      license controls (`OSPS-LE-02.02`, `OSPS-LE-03.02`) flap across identical
      runs because `OSPS-LE-02.02` shells out to `gh api` and the sample repo has
      no remote. Pre-existing nondeterminism, unrelated to this change; worth its
      own issue.
- [ ] Every normative restatement of the old wording is updated or recorded as
      deferred with a reason

Spec: `specs/018-auto-detect-propose-only/`