### PR TITLE
docs(governance): record the actual amendment track for constitution 1.3.0

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -55,11 +55,13 @@ Deliberately not updated:
   - packages/ code, configuration, and their comments. Changing them
     would change behavior, which this amendment does not do. They are
     enumerated in specs/018-auto-detect-propose-only/research.md.
-Follow-up TODOs:
-  - GOVERNANCE.md:51 enumerates only GOVERNANCE.md, the Charter, and
-    the TSC roster as governance artifacts requiring a Charter vote.
-    The constitution is not listed. Add it, so the track for the next
-    amendment is not ambiguous.
+Amendment track:
+  - Merged under this document's own Governance section: description,
+    version bump, consistency validation. No Charter vote.
+    GOVERNANCE.md:51 omits the constitution from the artifacts
+    requiring a TSC vote deliberately. The TSC is an oversight body
+    and does not take a day-to-day role, so routine amendments that
+    preserve a principle's core requirement do not go to it.
 ==================
 
 Sync Impact Report

--- a/specs/018-auto-detect-propose-only/spec.md
+++ b/specs/018-auto-detect-propose-only/spec.md
@@ -265,13 +265,13 @@ identical, because this feature changes documents only.
 
 ## Assumptions
 
-- The amendment is treated as a governance change and follows the Charter's TSC
-  voting rules, even though GOVERNANCE.md:51 enumerates only GOVERNANCE.md
-  itself, the Charter, and the TSC roster as governance artifacts. The
-  constitution is a governing document in substance, and RFC-0001 treats Stage 0
-  as requiring sign-off. The alternative reading -- that this is a routine Minor
-  Change needing one maintainer approval -- is defensible on the letter of both
-  documents, which is itself the reason the enumeration should be corrected.
+- The amendment follows this constitution's own Governance section: a described
+  change, a version bump, and a consistency check, approved as a Minor Change.
+  It does not go to the TSC. GOVERNANCE.md:51 omits the constitution from the
+  artifacts requiring a Charter vote deliberately -- the TSC is an oversight
+  body that does not take a day-to-day role -- so the omission is correct and
+  needs no follow-up. RFC-0001's Stage 0 sign-off is satisfied by maintainer
+  approval of this PR.
 - If the amendment is not adopted, the contradiction identified in research.md
   Finding 1 does not disappear; it inverts. The remedy would become a code change
   gating `hint_sources` behind the user-judgment flag, disabling the propose-only

--- a/specs/018-auto-detect-propose-only/tasks.md
+++ b/specs/018-auto-detect-propose-only/tasks.md
@@ -136,7 +136,7 @@ contains a statement that detection must not run for user-judgment keys.
 
 ## Phase 6: Polish & Verification
 
-**Purpose**: Prove the success criteria and get the change in front of the TSC.
+**Purpose**: Prove the success criteria and land the change.
 
 - [X] T025 Re-run `uv run pytest tests/ --ignore=tests/integration/ -q` and confirm the pass count matches the T001 baseline exactly; any test needing modification disproves FR-013
 - [X] T026 [P] Re-run `uv run ruff check .` and `uv run python scripts/validate_sync.py --verbose`, both must pass
@@ -145,8 +145,8 @@ contains a statement that detection must not run for user-judgment keys.
 - [X] T029 [P] Confirm every file touched is ASCII-only per the project writing rule
 - [X] T030 Read the amended Principle IV cold and confirm a sentence can be cited for each of the five consumption paths, satisfying SC-003
 - [X] T031 Open the PR against `darnitdevorg/darnit` from the fork, describing the change as reconciling the constitution with shipped behavior (research.md Finding 1) rather than as loosening a safety rule
-- [ ] T032 Request TSC review under the Charter's voting rules, on the grounds that the constitution is a governing artifact in substance even though `GOVERNANCE.md:51` lists only that document, the Charter, and the roster
-- [ ] T033 File a follow-up issue to add the constitution to the `GOVERNANCE.md:51` enumeration, so the next amendment does not have to relitigate which track applies
+- [X] T032 Merge as a Minor Change under the constitution's own Governance section. No TSC review: the TSC is an oversight body and does not take a day-to-day role, so `GOVERNANCE.md:51` omits the constitution deliberately
+- [X] T033 Dropped. Follows from T032 -- the `GOVERNANCE.md:51` enumeration is correct as written and needs no amendment
 
 ---
 
@@ -197,7 +197,7 @@ Task: "Mark the Stage 0 row satisfied at docs/rfcs/0001-core-rearchitecture.md:2
 1. Phase 1 Setup, Phase 2 Foundational
 2. Phase 3 (US1) and Phase 4 (US2) together
 3. Phase 5 (US3) in the same PR if the diff stays readable
-4. Phase 6 verification, then open the PR and request TSC review
+4. Phase 6 verification, then open the PR for maintainer approval
 
 RFC-0001 Stage 0 requires this land as its own PR, so the temptation to bundle
 it with Stage 1 groundwork should be resisted (FR-012, SC-006).


### PR DESCRIPTION
## Summary

Follow-up to #332. That PR shipped constitution 1.3.0 with a Sync Impact Report
TODO asserting that `GOVERNANCE.md:51` should be amended to list the
constitution among the artifacts requiring a Charter vote, and a matching spec
assumption that the amendment would follow the Charter's TSC voting rules.

Both were wrong. The omission at `GOVERNANCE.md:51` is deliberate: the TSC is an
oversight board that oversees general development but does not take a
day-to-day role. Constitution amendments merge under the constitution's own
Governance section -- a described change, a version bump, and a consistency
check -- by ordinary maintainer approval. That is in fact how 1.3.0 landed.

## Changes

- `.specify/memory/constitution.md` -- replaces the 1.3.0 "Follow-up TODOs"
  block with an "Amendment track" block recording the track actually used and
  why `GOVERNANCE.md:51` is correct as written
- `specs/018-auto-detect-propose-only/spec.md` -- corrects the Assumptions entry
  that claimed the Charter's voting rules applied
- `specs/018-auto-detect-propose-only/tasks.md` -- T032 rewritten to the actual
  track, T033 dropped as following from it, two other stale TSC references fixed

Documentation only. No normative text in Principle IV changes, and the 1.3.0
version number stands -- the correction is to the report describing how the
amendment merged, not to the amendment.

`GOVERNANCE.md` itself needs no change.

## Test plan

- [ ] No change to any principle, requirement, or normative statement
- [ ] No surviving claim in the repo that the constitution requires a TSC vote