### PR TITLE
fix(cli): reference darnit-mcp meta-package in generated MCP config

### DIFF
--- a/packages/darnit/src/darnit/cli.py
+++ b/packages/darnit/src/darnit/cli.py
@@ -580,7 +580,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     mcp_servers = config.setdefault("mcpServers", {})
     darnit_entry = {
         "command": "uvx",
-        "args": ["--from", "darnit", "darnit", "serve"],
+        "args": ["--from", "darnit-mcp", "darnit", "serve"],
     }
 
     if "darnit" in mcp_servers and not args.force:

--- a/tests/darnit/test_cli.py
+++ b/tests/darnit/test_cli.py
@@ -28,7 +28,7 @@ def test_install_claude_creates_settings(tmp_path, monkeypatch, caplog):
     assert "mcpServers" in data
     assert "darnit" in data["mcpServers"]
     assert data["mcpServers"]["darnit"]["command"] == "uvx"
-    assert data["mcpServers"]["darnit"]["args"] == ["--from", "darnit", "darnit", "serve"]
+    assert data["mcpServers"]["darnit"]["args"] == ["--from", "darnit-mcp", "darnit", "serve"]
 
     assert not any(
         record.levelname == "WARNING" and "deprecated" in record.message.lower() for record in caplog.records


### PR DESCRIPTION
## Summary

`darnit install` writes an MCP config that runs `uvx --from darnit darnit serve`, but there is no \`darnit\` package in the workspace or in \`packaging/pypi/public-packages.txt\`. The meta-package is \`darnit-mcp\` (root \`pyproject.toml\`, depends on \`darnit-core\`, \`darnit-baseline\`, \`darnit-gittuf\`, \`darnit-reproducibility\`).

Without this fix, the generated MCP config would fail to resolve once \`uvx\` tries to install the entry-point package, even after PyPI publishing succeeds. Found while assessing what stands between darnit and a first release.

## Scope

- One-character package-name change in the generated config
- Matching update to the assertion in \`test_install_claude_creates_settings\`
- No behavior change for anything that had already been installed; the config is regenerated by \`darnit install\`.

## Test plan

- [ ] \`uv run pytest tests/darnit/test_cli.py -q\` passes (24/24 locally)
- [ ] \`uv run ruff check\` clean on touched files