### PR TITLE
fix(release): map darnit-core to packages/darnit/pyproject.toml in preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,14 @@ jobs:
           fail=0
           while IFS= read -r pkg; do
             [ -z "$pkg" ] && continue
+            # PyPI name → filesystem path. Two special cases: darnit-mcp
+            # lives at the repo root, and darnit-core lives at packages/darnit/
+            # (its directory name differs from its PyPI name for historical
+            # reasons). Every other package has directory == PyPI name.
             case "$pkg" in
-              "darnit-mcp") pyproject="pyproject.toml" ;;
-              *)            pyproject="packages/$pkg/pyproject.toml" ;;
+              "darnit-mcp")  pyproject="pyproject.toml" ;;
+              "darnit-core") pyproject="packages/darnit/pyproject.toml" ;;
+              *)             pyproject="packages/$pkg/pyproject.toml" ;;
             esac
             if [ ! -f "$pyproject" ]; then
               echo "::error::Public package $pkg has no pyproject.toml at $pyproject"


### PR DESCRIPTION
## Summary

Preflight's version-parity check computes the pyproject path from the PyPI package name as \`packages/\$pkg/pyproject.toml\`. That works for the packages whose directory name matches their PyPI name (baseline, gittuf, reproducibility), and darnit-mcp had its own case for the root pyproject. But **darnit-core lives at \`packages/darnit/\`** and had no case, so preflight looked at the non-existent \`packages/darnit-core/pyproject.toml\` and failed.

Latent in the pre-#336 workflow too. Never surfaced because #261 never ran against a real tag.

## Repro

Tag \`v0.1.0\` triggered [workflow run 30495492728](https://github.com/darnitdevorg/darnit/actions/runs/30495492728). Preflight failed on:

\`\`\`
##[error]Public package darnit-core has no pyproject.toml at packages/darnit-core/pyproject.toml
OK: darnit-baseline pyproject.toml version=0.1.0 matches tag
OK: darnit-gittuf pyproject.toml version=0.1.0 matches tag
OK: darnit-reproducibility pyproject.toml version=0.1.0 matches tag
OK: darnit-mcp pyproject.toml version=0.1.0 matches tag
\`\`\`

Nothing was published (all publish jobs skipped after preflight failure). Tag \`v0.1.0\` has been deleted; will retag once this merges.

## Fix

One new \`case\` line adding the darnit-core -> packages/darnit mapping, plus a comment explaining why the mapping is a special case.

## Test plan

- [ ] Merge, retag \`v0.1.0\`, watch the release workflow complete.