### PR TITLE
fix(release): exclude the upstream pytest mark from preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,11 @@ jobs:
         run: uv run ruff check .
 
       - name: Tests
-        run: uv run pytest tests/ --ignore=tests/integration/ -q
+        # Match ci.yml's mark exclusion. The `upstream` mark is on the CNCF
+        # .project/ spec-drift check, which is designed to be informational
+        # (docstring: "does NOT block PRs") and runs on a nightly schedule
+        # elsewhere. Preflight should not be stricter than the merge gate.
+        run: uv run pytest tests/ --ignore=tests/integration/ -m "not upstream" -q
 
       - name: Spec sync
         run: uv run python scripts/validate_sync.py --verbose


### PR DESCRIPTION
## Summary

Preflight ran the full test suite with no mark filter, so it picked up \`test_upstream_spec_unchanged\` -- the informational CNCF \`.project/\` spec-drift check (issue #62) that has been red on main since 2026-07-18. Main's CI passes because it uses \`pytest -m unit\`, which quietly excludes the \`upstream\` mark. The test's docstring literally says "does NOT block PRs".

Preflight should not be stricter than the merge gate. Match CI's mark exclusion with \`-m "not upstream"\`.

## Repro

Tag \`v0.1.0\` triggered [workflow run 30497167124](https://github.com/darnitdevorg/darnit/actions/runs/30497167124). Preflight's Tests step failed on:

\`\`\`
FAILED tests/darnit/context/test_dot_project_upstream.py::TestUpstreamSpecSync::test_upstream_spec_unchanged
Tracked hash: d8ca8361...
Current hash: 860df23e...
\`\`\`

Same drift as issue #62 and the second commit Aadarsh tried to sneak into #324. Not this PR's fight; the fix here is only to stop letting an informational check gate a release.

## Fix

Add \`-m "not upstream"\` to preflight's \`pytest\` invocation. Comment cites the reason.

## Non-blocking follow-up

Issue #62 (real upstream drift resolution -- sync \`dot_project.py\` to the new upstream and update the hash properly, or document why we diverge) still stands. This PR just stops it from blocking release cadence.

## Test plan

- [ ] Merge, retag \`v0.1.0\`, watch the release workflow complete.