### PR TITLE
fix(release): declare hatchling build-system for darnit-mcp meta-package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,17 @@ Homepage = "https://github.com/kusari-oss/darnit"
 Repository = "https://github.com/kusari-oss/darnit"
 Issues = "https://github.com/kusari-oss/darnit/issues"
 
+# darnit-mcp is a metadata-only meta-package: no source, only dependencies
+# that pull in darnit-core, darnit-baseline, darnit-gittuf, and
+# darnit-reproducibility. hatchling matches the backend the sibling packages
+# use; bypass-selection tells it to produce a wheel with no code payload.
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+bypass-selection = true
+
 [project.optional-dependencies]
 attestation = [
     "darnit-core[attestation]",


### PR DESCRIPTION
## Summary

Root \`pyproject.toml\` had a \`[project]\` table but no \`[build-system]\` block. Sibling packages under \`packages/*\` all declare one; the root did not because darnit-mcp is a metadata-only meta-package (no source, just deps) and nothing had exercised its build path until this release attempt.

## Repro

Tag \`v0.1.0\` triggered [workflow run 30498403465](https://github.com/darnitdevorg/darnit/actions/runs/30498403465). Preflight passed. Build succeeded for darnit-core, darnit-baseline, darnit-gittuf, darnit-reproducibility. darnit-mcp then:

\`\`\`
error: Package \`darnit-mcp\` is missing a \`build-system\`. For example...
##[error]Process completed with exit code 2.
\`\`\`

## Fix

Add \`[build-system]\` using hatchling (matches sibling packages) with \`bypass-selection = true\` so it produces a wheel with no code payload.

Verified locally:
\`\`\`
$ uv build --package darnit-mcp --out-dir /tmp/mcptest
Successfully built /tmp/mcptest/darnit_mcp-0.1.0.tar.gz
Successfully built /tmp/mcptest/darnit_mcp-0.1.0-py3-none-any.whl
\`\`\`

Tag \`v0.1.0\` has been deleted; will retag after this merges.

## Test plan

- [ ] Merge, retag \`v0.1.0\`, watch the release workflow complete.