### PR TITLE
fix(release): skip-existing on all publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
         with:
           packages-dir: dist/darnit-core/
           password: ${{ secrets.PYPI_API_TOKEN }}
-          skip-existing: false
+          skip-existing: true
 
   publish-darnit-baseline:
     name: Publish darnit-baseline to PyPI
@@ -266,7 +266,7 @@ jobs:
         with:
           packages-dir: dist/darnit-baseline/
           password: ${{ secrets.PYPI_API_TOKEN }}
-          skip-existing: false
+          skip-existing: true
 
   publish-darnit-gittuf:
     name: Publish darnit-gittuf to PyPI
@@ -287,7 +287,7 @@ jobs:
         with:
           packages-dir: dist/darnit-gittuf/
           password: ${{ secrets.PYPI_API_TOKEN }}
-          skip-existing: false
+          skip-existing: true
 
   publish-darnit-reproducibility:
     name: Publish darnit-reproducibility to PyPI
@@ -308,7 +308,7 @@ jobs:
         with:
           packages-dir: dist/darnit-reproducibility/
           password: ${{ secrets.PYPI_API_TOKEN }}
-          skip-existing: false
+          skip-existing: true
 
   publish-darnit-mcp:
     name: Publish darnit-mcp to PyPI
@@ -334,7 +334,7 @@ jobs:
         with:
           packages-dir: dist/darnit-mcp/
           password: ${{ secrets.PYPI_API_TOKEN }}
-          skip-existing: false
+          skip-existing: true
 
   # Build + push + cosign-sign the multi-arch container image. Depends on
   # publish-darnit-mcp because the Dockerfile does `pip install


### PR DESCRIPTION
## Summary

Flip \`skip-existing\` from \`false\` to \`true\` on all five \`publish-*\` jobs.

## Context

v0.1.0 successfully published \`darnit-core\`, \`darnit-baseline\`, \`darnit-gittuf\`, and \`darnit-reproducibility\`, then hit PyPI's new-project rate limit on \`darnit-mcp\` with a 429 "Too many new projects created". A \`workflow_dispatch\` retry against the same tag would 400 on the four already-published packages ("version exists, can't overwrite") and fail the whole run again.

\`skip-existing: true\` makes already-published wheels a no-op instead of a hard failure. The immutability guarantee we cared about is enforced by PyPI itself (which rejects overwrites of the same version); this setting just makes accidental retries harmless.

## Test plan

- [ ] Merge, then trigger the release workflow via **Actions -> Release -> Run workflow -> tag: \`v0.1.0\`**. Expect: four \`publish-*\` jobs report "skip-existing" success; \`publish-darnit-mcp\` either publishes (rate limit cleared) or 429s again (rate limit still active, wait longer).