### PR TITLE
fix(release): correct sigstore/cosign-installer v3.10.1 SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,7 +433,7 @@ jobs:
           sbom: false
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@0d05a4e36810cebf0e25e51fb1a4ee45ac1b75e2 # v3.10.1
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Sign image (cosign keyless)
         env:

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ requires-dist = [{ name = "darnit-core", editable = "packages/darnit" }]
 [[package]]
 name = "darnit-mcp"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "darnit-baseline" },
     { name = "darnit-core" },


### PR DESCRIPTION
## Summary
- Fix container_build_push job: the pinned SHA `0d05a4e3` does not exist in sigstore/cosign-installer, so GitHub Actions cannot resolve the action. Replaced with the real v3.10.1 SHA `7e8b541e`.
- Refresh `uv.lock`: after #339 added `[build-system]` to the root, uv resolves the root darnit-mcp package as `editable` instead of `virtual`.

## Context
Run [30645551505](https://github.com/darnitdevorg/darnit/actions/runs/30645551505) published all 5 PyPI wheels for v0.1.0, but container_build_push failed at the cosign install step. This unblocks the container image and GitHub Release for v0.1.0.

## Test plan
- [ ] Merge, then re-dispatch `release.yml` with tag `v0.1.0`.
- [ ] Confirm container image + GitHub Release complete (PyPI jobs will no-op via `skip-existing: true`).