### PR TITLE
fix(release): pass --repo to gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,6 +498,7 @@ jobs:
 
           # shellcheck disable=SC2086
           gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
             --title "$title" \
             --notes-file "$body_file" \
             $flags


### PR DESCRIPTION
## Summary
- The release job has no `actions/checkout` step, so `gh release create` fell back to `git` and failed with `fatal: not a git repository`.
- Passing `--repo \"\$GITHUB_REPOSITORY\"` uses the API path and avoids the working-tree requirement.

## Context
Caught in run [30650769783](https://github.com/darnitdevorg/darnit/actions/runs/30650769783) where all 5 publish jobs and container_build_push succeeded; only the Release step failed. v0.1.0's release entry was authored manually via `gh release create`; this fix unblocks v0.1.1+.

## Test plan
- [ ] Merge; next tagged release should produce a GitHub Release entry automatically.