### PR TITLE
fix(baseline): correct per-level classification and bump OSPS spec to v2026.02.19 (#342)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,1 @@
-{
-  "feature_directory": "specs/018-auto-detect-propose-only"
-}
+{"feature_directory": "specs/019-verdict-correctness"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,5 +370,5 @@ else:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[`specs/018-auto-detect-propose-only/plan.md`](specs/018-auto-detect-propose-only/plan.md)
+[`specs/019-verdict-correctness/plan.md`](specs/019-verdict-correctness/plan.md)
 <!-- SPECKIT END -->

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -5,10 +5,10 @@
 
 ## What is This?
 
-**OpenSSF Baseline MCP Server** is an AI-powered compliance audit tool that checks repositories against the [OpenSSF Baseline](https://baseline.openssf.org) security standard (OSPS v2025.10.10).
+**OpenSSF Baseline MCP Server** is an AI-powered compliance audit tool that checks repositories against the [OpenSSF Baseline](https://baseline.openssf.org) security standard (OSPS v2026.02.19).
 
 ### Key Features
-- 🔍 **62 security controls** across 3 maturity levels
+- 🔍 **65 security controls** across 3 maturity levels
 - 🤖 **MCP integration** - works with Claude, Cursor, and other AI tools
 - 🔧 **Auto-remediation** - fix common issues automatically
 - 📊 **Multiple output formats** - Markdown, JSON, SARIF
@@ -86,7 +86,7 @@ Add to your MCP settings with the same configuration.
 | Tool | Purpose |
 |------|---------|
 | `audit_openssf_baseline` | Run compliance audit |
-| `list_available_checks` | Show all 62 controls |
+| `list_available_checks` | Show all 65 controls |
 | `get_project_config` | View project.toml config |
 | `init_project_config` | Create project.toml |
 | `generate_threat_model` | STRIDE threat analysis |
@@ -134,9 +134,11 @@ audit_openssf_baseline(
 | 🔴 | ERROR | Check couldn't run |
 
 ### Maturity Levels
-- **Level 1** (24 controls) - Basic security hygiene
-- **Level 2** (18 controls) - Enhanced security practices
-- **Level 3** (20 controls) - Advanced security maturity
+- **Level 1** (25 controls) - Basic security hygiene (includes 1 upstream-retired control retained for backward compatibility)
+- **Level 2** (19 controls) - Enhanced security practices
+- **Level 3** (21 controls) - Advanced security maturity
+
+Upstream OSPS Baseline v2026.02.19 defines 64 controls (24 / 19 / 21). Darnit ships one additional Level 1 control (`OSPS-BR-01.02`) that upstream retired in [ossf/security-baseline#443](https://github.com/ossf/security-baseline/pull/443); it is retained because the underlying "sanitize `github.head_ref`" concern is still valid, and it is included in Level 1 audits.
 
 ---
 

--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -809,10 +809,15 @@ steps = [
 docs_url = "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections"
 context_hints = ["ci.provider"]
 
+# OSPS-BR-01.02 was retired upstream in ossf/security-baseline#443. Darnit
+# retains this check because the underlying "sanitize `github.head_ref`"
+# concern is still valid, but it is no longer part of the OSPS Baseline at
+# any maturity level. The `deprecated` tag excludes it from per-level
+# regression comparisons against upstream.
 [controls."OSPS-BR-01.02"]
 name = "SecureBranchNames"
 description = "Branch names are handled safely in workflows"
-tags = { level = 1, domain = "BR", build = true, security = true }
+tags = { level = 1, domain = "BR", build = true, security = true, deprecated = true }
 when = { ci_provider = "github" }
 
 # Exec: grep for unsafe ${{ github.head_ref }} — exit code 1 (no matches) = PASS
@@ -870,6 +875,102 @@ steps = [
 ]
 docs_url = "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions"
 context_hints = ["ci.provider"]
+
+# Added in OSPS Baseline v2026.02.19. Applies at L1, L2, L3. Requires
+# reasoning about workflow triggers (pull_request vs pull_request_target),
+# job-level permissions, and use of secrets in workflows that build or run
+# untrusted code. This is not straightforwardly automatable without workflow
+# parsing; the initial implementation ships with a manual pass only. See
+# https://github.com/darnitdevorg/darnit/issues (follow-up for auto-verification).
+[controls."OSPS-BR-01.03"]
+name = "IsolateUntrustedCIInputs"
+description = "CI/CD pipelines isolate untrusted code from privileged credentials"
+tags = { level = 1, domain = "BR", build = true, security = true, ci-cd = true }
+when = { ci_provider = "github" }
+docs_url = "https://baseline.openssf.org/versions/2026-02-19#OSPS-BR-01.03"
+location_hint = ".github/workflows"
+help_md = """CI/CD pipelines that operate on untrusted code snapshots MUST prevent access to privileged credentials and assets.
+
+**Why:** workflows triggered on `pull_request_target` (or that check out fork code and then run it before review) have access to repository secrets by default. Untrusted contributor code can exfiltrate those secrets.
+
+**Remediation guidance:**
+1. Use the `pull_request` trigger (not `pull_request_target`) whenever running fork-authored code.
+2. If `pull_request_target` is required, minimize `secrets:` and `permissions:` at the workflow and job level; check out only trusted refs before the fork's code runs.
+3. Split jobs: a low-privilege job runs the fork code; a separate, gated job accepts artifacts and uses privileged credentials.
+4. Set explicit `permissions:` blocks on workflows; default to `contents: read` and grant more only where needed.
+
+**References:**
+- [GitHub docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
+- [GitHub blog: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
+"""
+
+[[controls."OSPS-BR-01.03".passes]]
+handler = "manual"
+steps = [
+    "Enumerate workflows in .github/workflows/",
+    "For each workflow, check the `on:` triggers. Any use of `pull_request_target` requires audit.",
+    "For workflows using `pull_request_target`, verify: (a) they do not check out the fork's HEAD and execute it, or (b) they use a minimum-privilege job model.",
+    "Verify workflow-level and job-level `permissions:` blocks are set explicitly and follow least-privilege.",
+    "Verify that steps executing untrusted code (fork PRs, contributor input) do not have `secrets:` or write-level tokens in scope.",
+]
+
+[controls."OSPS-BR-01.03".remediation]
+safe = false
+dry_run_supported = false
+
+[[controls."OSPS-BR-01.03".remediation.handlers]]
+handler = "manual"
+steps = [
+    "Review each workflow trigger; replace `pull_request_target` with `pull_request` where the workflow does not need write access to the repository.",
+    "Add an explicit `permissions:` block at the workflow level with the minimum required scopes.",
+    "For workflows that must use `pull_request_target`, split the fork-code execution into an isolated job with no `secrets:` and no elevated permissions.",
+]
+docs_url = "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions"
+
+# Added in OSPS Baseline v2026.02.19. Applies at L3 only. Also requires
+# workflow parsing (identifying input parameters and how they are consumed
+# in shell/scripts). Ships with a manual pass only for the same reasons as
+# BR-01.03.
+[controls."OSPS-BR-01.04"]
+name = "SanitizeCollaboratorInput"
+description = "CI/CD pipelines sanitize collaborator input before use"
+tags = { level = 3, domain = "BR", build = true, security = true, ci-cd = true }
+when = { ci_provider = "github" }
+docs_url = "https://baseline.openssf.org/versions/2026-02-19#OSPS-BR-01.04"
+location_hint = ".github/workflows"
+help_md = """CI/CD pipelines that accept trusted collaborator input MUST sanitize and validate that input before use.
+
+**Why:** manual workflow inputs (`workflow_dispatch` parameters) and `issue_comment` triggers accept text that flows directly into shell commands. Even from trusted collaborators, unsanitized input is a shell-injection risk if a collaborator account is compromised.
+
+**Remediation guidance:**
+1. Assign collaborator inputs to environment variables and reference them via `"$VAR"` rather than direct `${{ ... }}` interpolation into `run:` blocks.
+2. Validate inputs against an allowlist or a strict regex before use.
+3. Prefer typed inputs (`type: choice`, `type: environment`) where the shape is enumerable.
+
+**References:**
+- [GitHub docs: Understanding the risk of script injections](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)
+"""
+
+[[controls."OSPS-BR-01.04".passes]]
+handler = "manual"
+steps = [
+    "Enumerate workflows in .github/workflows/ that accept collaborator input (workflow_dispatch inputs, issue_comment, discussion, etc.).",
+    "For each such workflow, inspect run: blocks for direct interpolation of ${{ inputs.* }} or ${{ github.event.* }} into shell commands.",
+    "Verify inputs are routed through env: variables and referenced as $VAR (quoted) inside shell, or validated against an allowlist before use.",
+]
+
+[controls."OSPS-BR-01.04".remediation]
+safe = false
+dry_run_supported = false
+
+[[controls."OSPS-BR-01.04".remediation.handlers]]
+handler = "manual"
+steps = [
+    "For each interpolated input, add an env: mapping and reference it via double-quoted $VAR in the shell.",
+    "Where an input has a fixed set of expected values, convert the workflow input to `type: choice` with an explicit options list.",
+    "Where an input is free-form, add a validation step that exits nonzero if the value does not match the expected pattern.",
+]
+docs_url = "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections"
 
 [controls."OSPS-BR-03.01"]
 name = "SecureRepositoryURL"
@@ -1435,6 +1536,55 @@ steps = [
     "Describe tools used for dependency management (Dependabot, Renovate, etc.)",
 ]
 
+# Added in OSPS Baseline v2026.02.19. Applies at L2 and L3, lowest = L2.
+# The check searches common build-instruction locations for a recognizable
+# build/install/setup section header. Regex is intentionally broad to admit
+# BUILD.md, INSTALL.md, and common README headings.
+[controls."OSPS-DO-07.01"]
+name = "BuildInstructions"
+description = "Documentation includes instructions to build the software"
+tags = { level = 2, domain = "DO", documentation = true }
+docs_url = "https://baseline.openssf.org/versions/2026-02-19#OSPS-DO-07.01"
+location_hint = "README.md"
+help_md = """Project documentation MUST include instructions on how to build the software, including required libraries, frameworks, SDKs, and dependencies.
+
+**Where to document:** typically the README.md, CONTRIBUTING.md, or a dedicated BUILD.md / INSTALL.md. Automation configurations (Makefile targets, uv/npm/cargo scripts) can also satisfy this when they are documented.
+
+**Remediation:**
+1. Add a `## Building` or `## Installation` section to your README.
+2. List required toolchains (compiler versions, package managers, SDKs).
+3. Show the minimum command(s) to produce a working build.
+"""
+
+[[controls."OSPS-DO-07.01".passes]]
+handler = "pattern"
+files = ["README.md", "README.rst", "BUILD.md", "INSTALL.md", "CONTRIBUTING.md", "docs/build.md", "docs/install.md"]
+
+[controls."OSPS-DO-07.01".passes.pattern.patterns]
+build_section_header = "(?im)^#+\\s*(building|build|install|installation|getting\\s+started|setup|compile|compiling)\\b"
+
+[[controls."OSPS-DO-07.01".passes]]
+handler = "manual"
+steps = [
+    "Open README.md (or the project's main documentation entry point).",
+    "Verify there is a section describing how to build the software.",
+    "Verify required toolchains, SDKs, and dependencies are listed.",
+    "Verify at least one command shows how to produce a working build.",
+]
+
+[controls."OSPS-DO-07.01".remediation]
+safe = true
+dry_run_supported = true
+
+[[controls."OSPS-DO-07.01".remediation.handlers]]
+handler = "manual"
+steps = [
+    "Add a Building / Installation section to README.md",
+    "List required toolchains and their minimum versions",
+    "Include the minimum command(s) needed to produce a working build",
+    "Link to any Makefile targets or scripts the build depends on",
+]
+
 # =============================================================================
 # Level 1 Controls - Governance (GV)
 # =============================================================================
@@ -1540,7 +1690,7 @@ create_dirs = false
 [controls."OSPS-LE-01.01"]
 name = "HasLicense"
 description = "Repository has a license file"
-tags = { level = 1, domain = "LE", legal = true, license = true }
+tags = { level = 2, domain = "LE", legal = true, license = true }
 
 docs_url = "https://baseline.openssf.org/versions/2025-10-10#OSPS-LE-01.01"
 location_hint = "CONTRIBUTING.md"

--- a/packages/darnit-baseline/src/darnit_baseline/implementation.py
+++ b/packages/darnit-baseline/src/darnit_baseline/implementation.py
@@ -33,7 +33,7 @@ class OSPSBaselineImplementation:
 
     @property
     def spec_version(self) -> str:
-        return "OSPS v2025.10.10"
+        return "OSPS v2026.02.19"
 
     def get_all_controls(self) -> list[ControlSpec]:
         """Get all OSPS controls."""

--- a/specs/019-verdict-correctness/checklists/requirements.md
+++ b/specs/019-verdict-correctness/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Conservative-by-default verdict correctness
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Two user stories, both P1: level classification fix (issue #342) and definitive-404 verdict fix (issue #343). Bundled at spec level; expected to ship as two PRs.
+- FR-001 and FR-002 mention specific TOML file paths (`openssf-baseline.toml`, `docs/USAGE_GUIDE.md`). These are cited as anchors to the framework's own artifacts, not as prescribed implementation locations — the requirement is the classification, not the file.
+- FR-004 uses the phrase "HTTP 404 with body indicating the branch is not protected." This is a domain fact about the GitHub API response, not an implementation choice; it is the definition of the signal the framework acts on.
+- Ready for `/speckit-plan` (no `/speckit-clarify` needed).

--- a/specs/019-verdict-correctness/contracts/cel-post-step.md
+++ b/specs/019-verdict-correctness/contracts/cel-post-step.md
@@ -1,0 +1,63 @@
+# Contract: sieve orchestrator CEL post-step
+
+**Scope:** internal framework contract between `packages/darnit/src/darnit/sieve/orchestrator.py` and its callers (the sieve orchestrator itself). Not a public API. Not a plugin protocol.
+
+**Function:** `_apply_cel_expr(handler_config, handler_result) -> HandlerResult`.
+
+## Current behavior (before this spec)
+
+Given a handler that returned PASS or FAIL (INCONCLUSIVE / ERROR are passed through unchanged) and a pass config carrying a CEL `expr`:
+
+| Handler status | CEL result | Post-step status |
+|----------------|------------|------------------|
+| PASS           | true       | PASS             |
+| PASS           | false      | INCONCLUSIVE     |
+| FAIL           | true       | **PASS**         |
+| FAIL           | false      | **INCONCLUSIVE** |
+
+The last two rows are the root cause of issue #343: a handler-conclusive FAIL is being overridden by the CEL post-step in both directions.
+
+## New behavior (after this spec)
+
+| Handler status | CEL result | Post-step status |
+|----------------|------------|------------------|
+| PASS           | true       | PASS             |
+| PASS           | false      | INCONCLUSIVE     |
+| FAIL           | true       | INCONCLUSIVE     |
+| FAIL           | false      | **FAIL**         |
+
+Interpretation:
+
+- Both entities (handler and CEL) agreeing on PASS -> conclusive PASS.
+- Both entities agreeing on FAIL -> conclusive FAIL.
+- Handler and CEL disagreeing (PASS+false or FAIL+true) -> INCONCLUSIVE, pipeline continues.
+
+Rationale: the two disagreement rows are ambiguous — one signal says compliant, the other says not — and INCONCLUSIVE correctly defers to the next pass. The two agreement rows are conclusive and preserve the handler's original conclusion; the CEL post-step confirms rather than contradicts.
+
+## Invariants preserved
+
+- ERROR and INCONCLUSIVE from the handler are passed through unchanged (no CEL evaluation attempted). Unchanged from today.
+- When `expr` is absent from the pass config, the handler's original result is returned unchanged. Unchanged from today.
+- When CEL evaluation raises or returns an error (not a boolean), the handler's original result is returned unchanged. Unchanged from today.
+- Confidence, message, and evidence handling remain the same: the returned `HandlerResult` may synthesize a new message ("CEL expression passed", "CEL expression evaluated to false") but must include the original evidence.
+
+## Test coverage required
+
+The unit test suite must exercise all eight cells of the transition table (four rows above, times "expr present" and "expr absent" -> but the "absent" case is trivially handled and can be covered once). At minimum:
+
+1. Handler PASS + CEL true + expr -> PASS
+2. Handler PASS + CEL false + expr -> INCONCLUSIVE
+3. Handler FAIL + CEL true + expr -> INCONCLUSIVE (new)
+4. Handler FAIL + CEL false + expr -> FAIL (new; this is issue #343)
+5. Handler INCONCLUSIVE + any CEL + expr -> INCONCLUSIVE (pass-through)
+6. Handler ERROR + any CEL + expr -> ERROR (pass-through)
+7. Any handler status + no expr -> unchanged
+8. Any handler status + CEL evaluation error -> unchanged
+
+Tests live at `tests/darnit/sieve/test_orchestrator_cel.py`.
+
+## Downstream effect on TOML controls
+
+Twelve controls in `packages/darnit-baseline/openssf-baseline.toml` combine `fail_exit_codes` + `expr` in the same pass (audit in `research.md` R5). All twelve get the new semantics automatically; no TOML change is required for the branch-protection fix beyond the LE-01.01 level tag.
+
+An integration test at `tests/darnit_baseline/controls/test_branch_protection.py` should exercise at least one of the four named branch-protection controls (`OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`) end-to-end with a stubbed `gh api` command that returns the exact "Branch not protected" 404 response documented in `research.md` R3.

--- a/specs/019-verdict-correctness/data-model.md
+++ b/specs/019-verdict-correctness/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: verdict correctness (issues #342 and #343)
+
+No new entities. This spec touches the existing framework and implementation types listed below.
+
+## Existing entities used
+
+### `PassOutcome` (framework, `packages/darnit/src/darnit/sieve/models.py`)
+
+Four-valued enum representing the result of a single sieve pass.
+
+- `PASS` — verified compliant.
+- `FAIL` — verified non-compliant.
+- `INCONCLUSIVE` — cannot determine; pipeline continues to next pass.
+- `ERROR` — handler or framework failure.
+
+No schema change. The CEL post-step transition table is what changes; see [`contracts/cel-post-step.md`](contracts/cel-post-step.md).
+
+### `HandlerResult` (framework, `packages/darnit/src/darnit/sieve/models.py`)
+
+Handler return value carrying `status: PassOutcome`, `message: str`, `confidence: float`, and `evidence: dict[str, Any]`.
+
+The `evidence` dict is what CEL evaluates against. For exec handlers with `output_format = "json"`, the shape is:
+
+```python
+evidence = {
+    "stdout": str,
+    "stderr": str,
+    "exit_code": int,
+    "json": dict | list,   # parsed body, absent if JSON decode fails
+}
+```
+
+No schema change.
+
+### `ControlSpec` (framework, `packages/darnit/src/darnit/core/plugin.py`)
+
+Control definition parsed from TOML. Carries `id`, `name`, `description`, `tags` (including `level: int`), `passes: list[PassSpec]`, `remediation: RemediationSpec`, etc.
+
+**Change:** `OSPS-LE-01.01.tags.level` transitions from `1` to `2` in `packages/darnit-baseline/openssf-baseline.toml`. No structural change to `ControlSpec` itself.
+
+### Upstream OSPS Baseline YAML (external, vendored fixture)
+
+Files: `baseline/OSPS-<domain>.yaml` in `ossf/security-baseline` (pinned to release v2025.10.10). Per-control shape (subset relevant to the regression test):
+
+```yaml
+- id: OSPS-LE-01.01
+  applicability:
+    - maturity-2
+    - maturity-3
+```
+
+Loaded at test time by `tests/darnit_baseline/test_level_counts.py`; the applicability lists derive the expected per-level control set. Fixture vendored under `tests/darnit_baseline/fixtures/osps-baseline/` (or wherever the existing drift check already keeps a copy — to be reused rather than duplicated).
+
+## Relationships
+
+```
+Upstream OSPS YAML (source of truth for pinned spec version)
+        |
+        | (parsed by test)
+        v
+Expected per-level control set (24 / 18 / 20)
+        =========
+Actual per-level control set (from openssf-baseline.toml, via framework config load)
+```
+
+Test asserts equality between the two sets and fails with a symmetric diff listing misclassified controls when they diverge.
+
+## State transitions
+
+No new states. The one behavioral change is the CEL post-step transition, documented as a contract in `contracts/cel-post-step.md`.

--- a/specs/019-verdict-correctness/plan.md
+++ b/specs/019-verdict-correctness/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Conservative-by-default verdict correctness
+
+**Branch**: `019-verdict-correctness` | **Date**: 2026-07-31 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/019-verdict-correctness/spec.md`
+
+## Summary
+
+Two independent fixes ship under this spec:
+
+- **US1 (issue #342):** Reclassify `OSPS-LE-01.01` from Level 1 to Level 2 in `packages/darnit-baseline/openssf-baseline.toml` so per-level counts match OSPS Baseline v2025.10.10 (24 / 18 / 20).
+- **US2 (issue #343):** Change the sieve orchestrator's CEL post-step so a handler-conclusive FAIL is preserved when the CEL expression also evaluates falsy. Today, `gh api /repos/.../branches/.../protection` returns exit 1 on 404 (exec handler → FAIL), and then the CEL expression `has(output.json.required_pull_request_reviews)` returns false against the `{"message": "Branch not protected"}` body, which the orchestrator maps to INCONCLUSIVE. The pipeline then falls through to the manual handler, yielding WARN. The fix keeps FAIL when both the handler and CEL agree there is no compliance.
+
+A regression test asserts per-level counts equal the upstream OSPS Baseline for the pinned `spec_version` so future TOML edits cannot silently drift out of parity.
+
+## Technical Context
+
+**Language/Version**: Python 3.11/3.12 (workspace targets, unchanged).
+
+**Primary Dependencies**: `cel-python` (for CEL evaluation in the sieve orchestrator), `PyYAML` (for the regression test that reads upstream OSPS Baseline YAML). No new runtime deps.
+
+**Storage**: TOML only. `packages/darnit-baseline/openssf-baseline.toml` for LE-01.01 tag; upstream OSPS Baseline YAML fixtures vendored under `tests/darnit_baseline/fixtures/` (already used by the existing `upstream` mark).
+
+**Testing**: `pytest` with existing marks (`unit`, `integration`, `upstream`). Unit tests for orchestrator CEL post-step change. Regression test for per-level counts runs under `unit` (uses vendored fixture, no network).
+
+**Target Platform**: Cross-platform. No platform-specific changes.
+
+**Project Type**: Library + CLI + MCP server (existing workspace layout, no new packages).
+
+**Performance Goals**: N/A — correctness fix, not a perf change.
+
+**Constraints**: (a) must not regress any currently-passing control; (b) must preserve WARN = "unknown" and FAIL = "known non-compliant" semantics; (c) framework code change must respect Principle I (plugin separation) — no import of implementation packages.
+
+**Scale/Scope**: ~5 lines of TOML (US1), ~10 lines of orchestrator Python (US2), plus ~150 lines of tests (per-level regression + orchestrator unit tests + branch-protection integration tests).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Plugin Separation:** US1 is confined to `packages/darnit-baseline/openssf-baseline.toml` (implementation). US2 modifies `packages/darnit/src/darnit/sieve/orchestrator.py` (framework); no cross-package imports introduced. PASS.
+- **II. Conservative-by-Default:** Both fixes strengthen this principle. US2 makes a definitive negative surface as FAIL rather than being downgraded to INCONCLUSIVE (then WARN). US1 removes a manufactured false-negative at Level 1 (over-scoping). Neither weakens WARN semantics. PASS.
+- **III. TOML-First:** US1 is TOML-only. US2 modifies orchestrator engine code, not a control definition; control metadata remains in TOML. PASS.
+- **IV. Never Guess User Values:** Not applicable — no user-judgment keys touched.
+- **V. Sieve Pipeline Integrity:** The current CEL post-step in `orchestrator.py:71-75` demotes handler-conclusive FAIL to INCONCLUSIVE when CEL returns false. This is arguably an existing violation of §V ("orchestrator stops at first conclusive result" — the handler was conclusive, and the orchestrator's post-step undid it). The fix restores that guarantee. PASS (and clarifies §V's application to the CEL post-step).
+
+**All gates pass. No entries in Complexity Tracking.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/019-verdict-correctness/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (below)
+├── data-model.md        # Phase 1 output (below)
+├── quickstart.md        # Phase 1 output (below)
+├── contracts/           # Phase 1 output (below)
+└── tasks.md             # Phase 2 output (/speckit-tasks command - NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+packages/darnit/                          # Framework
+├── src/darnit/sieve/
+│   └── orchestrator.py                   # US2: CEL post-step logic (lines 60-75)
+└── (no other framework changes)
+
+packages/darnit-baseline/                 # Implementation
+├── openssf-baseline.toml                 # US1: LE-01.01 level tag (line ~1543)
+└── (no plugin Python changes)
+
+tests/
+├── darnit/sieve/
+│   └── test_orchestrator_cel.py          # US2: unit tests for the CEL post-step change
+└── darnit_baseline/
+    ├── test_level_counts.py              # US1: regression test for 24/18/20 parity
+    └── controls/
+        └── test_branch_protection.py     # US2: integration test with fake 404 body
+```
+
+**Structure Decision:** Single-project workspace layout (existing). No new packages; edits are localized to `packages/darnit/src/darnit/sieve/orchestrator.py` (framework) and `packages/darnit-baseline/openssf-baseline.toml` (implementation). Tests split under the existing `tests/darnit/` and `tests/darnit_baseline/` trees to mirror the package they exercise.
+
+## Phase 0: Outline & Research
+
+Consolidated in [`research.md`](research.md). Highlights:
+
+1. **Current CEL post-step semantics** — confirmed at `packages/darnit/src/darnit/sieve/orchestrator.py:60-75`. Handler FAIL + CEL false → INCONCLUSIVE (root cause of #343).
+2. **exec handler exit-code classification** — confirmed at `packages/darnit/src/darnit/sieve/builtin_handlers.py:247-266`. `pass_exit_codes` → PASS, `fail_exit_codes` → FAIL, else INCONCLUSIVE.
+3. **`gh api` behavior for unprotected branch** — HTTP 404 with body `{"message": "Branch not protected", "documentation_url": "..."}`. `gh api` exit code is 1. JSON body is parsed by exec handler's `output_format = "json"` path.
+4. **Regression-test source of truth** — the OSPS Baseline YAML at `ossf/security-baseline` (`baseline/OSPS-*.yaml`) is the authoritative applicability map. Options for consuming it: fetch at test time (network dependency), vendor a fixture (needs update on spec bump), or reuse the existing `upstream`-marked drift-check fixture. Decision recorded in research.md.
+5. **Regression risk for the orchestrator change** — audit all TOML passes that combine `fail_exit_codes` + `expr` before flipping the post-step semantics. Grep in research.md.
+6. **Semantic content of LE-01.01 vs upstream** — noted but out of scope: darnit's `OSPS-LE-01.01` is implemented as a LICENSE-file check (`name = "HasLicense"`), while OSPS Baseline v2025.10.10 defines LE-01.01 as a DCO/CLA contribution track. This spec fixes only the level tag; the content misalignment is a separate issue to file after this ships.
+
+## Phase 1: Design & Contracts
+
+### Data model
+
+The change touches four entities already defined in the framework; no new data model is introduced. See [`data-model.md`](data-model.md) for the mapping.
+
+### Contracts
+
+The framework's sieve engine has one internal contract that this spec modifies: the CEL post-step transformation. Documented in [`contracts/cel-post-step.md`](contracts/cel-post-step.md). No external (public API, CLI, MCP) contract changes.
+
+### Agent context update
+
+Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `CLAUDE.md` to point to `specs/019-verdict-correctness/plan.md`.
+
+**Output**: [`data-model.md`](data-model.md), [`contracts/cel-post-step.md`](contracts/cel-post-step.md), [`quickstart.md`](quickstart.md), updated `CLAUDE.md`.
+
+## Complexity Tracking
+
+*No entries — Constitution Check has no violations.*

--- a/specs/019-verdict-correctness/quickstart.md
+++ b/specs/019-verdict-correctness/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart: verdict correctness (issues #342 and #343)
+
+Two independent verifications, one per user story. Both should be reproducible from a clean checkout.
+
+## US1: per-level counts match upstream OSPS Baseline
+
+**Setup:** none. Uses vendored upstream fixture.
+
+**Command:**
+
+```sh
+uv run pytest tests/darnit_baseline/test_level_counts.py -v
+```
+
+**Expected:**
+
+- Test passes.
+- Assertion output shows Level 1 = 24, Level 2 = 18, Level 3 = 20 controls.
+- `OSPS-LE-01.01` appears in the Level 2 set, not Level 1.
+
+**Manual cross-check:**
+
+```sh
+uv run python -c "
+from darnit.core.discovery import get_implementation
+impl = get_implementation('openssf-baseline')
+for lvl in (1, 2, 3):
+    controls = impl.get_controls_by_level(lvl)
+    print(f'Level {lvl}: {len(controls)} controls')
+    if lvl == 1:
+        assert 'OSPS-LE-01.01' not in {c.id for c in controls}, 'LE-01.01 leaked into L1'
+    if lvl == 2:
+        assert 'OSPS-LE-01.01' in {c.id for c in controls}, 'LE-01.01 missing from L2'
+print('OK')
+"
+```
+
+## US2: branch-protection controls report FAIL on definitive 404
+
+**Setup:** requires either (a) a test repository with no branch protection and authenticated `gh`, or (b) the integration test's stubbed `gh api` command. Path (b) runs offline.
+
+**Command (path b, unit-marked integration test):**
+
+```sh
+uv run pytest tests/darnit_baseline/controls/test_branch_protection.py -v
+```
+
+**Expected:**
+
+- Test passes.
+- For each of `OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`: given a stubbed exec response with `exit_code=1` and `stdout` containing the `{"message": "Branch not protected", ...}` body, the pass resolves to FAIL.
+- No pass resolves to WARN or INCONCLUSIVE.
+
+**Manual live-repo check (path a, requires authenticated `gh`):**
+
+Point at any repository whose default branch has no branch protection:
+
+```sh
+uv run darnit audit /path/to/unprotected-repo --output json | jq '.controls[] | select(.id | test("AC-03|QA-03.01|QA-07.01")) | {id, status}'
+```
+
+**Expected output:**
+
+```json
+{"id": "OSPS-AC-03.01", "status": "FAIL"}
+{"id": "OSPS-AC-03.02", "status": "FAIL"}
+{"id": "OSPS-QA-03.01", "status": "FAIL"}
+{"id": "OSPS-QA-07.01", "status": "FAIL"}
+```
+
+All four MUST be FAIL, not WARN.
+
+## Orchestrator unit tests
+
+**Command:**
+
+```sh
+uv run pytest tests/darnit/sieve/test_orchestrator_cel.py -v
+```
+
+**Expected:** all eight cases from the transition table in `contracts/cel-post-step.md` pass, including the two new-behavior rows (Handler FAIL + CEL true -> INCONCLUSIVE; Handler FAIL + CEL false -> FAIL).
+
+## Regression sweep
+
+**Command:**
+
+```sh
+uv run pytest tests/ --ignore=tests/integration/ -m "not upstream" -q
+```
+
+**Expected:** no test that was previously passing regresses. Any test relying on the old CEL post-step behavior for `fail_exit_codes` + `expr` combinations (i.e., asserting PASS from a handler-FAIL + CEL-true state) is documented in `research.md` R5 as testing buggy behavior and must be updated or removed.

--- a/specs/019-verdict-correctness/research.md
+++ b/specs/019-verdict-correctness/research.md
@@ -1,0 +1,101 @@
+# Research: verdict correctness (issues #342 and #343)
+
+## R1: Current CEL post-step semantics
+
+**Decision:** The framework's CEL post-step at `packages/darnit/src/darnit/sieve/orchestrator.py:60-75` is the direct cause of #343. It reads:
+
+```python
+if cel_result.value:
+    return HandlerResult(status=HandlerResultStatus.PASS, ...)
+else:
+    return HandlerResult(status=HandlerResultStatus.INCONCLUSIVE, ...)
+```
+
+This maps CEL true -> PASS and CEL false -> INCONCLUSIVE regardless of what the handler originally returned. For the branch-protection controls, the exec handler returns FAIL (exit code 1 matches `fail_exit_codes = [1]`), then the CEL expression `has(output.json.required_pull_request_reviews)` returns false on the 404 body, and the FAIL is demoted to INCONCLUSIVE. The pipeline then falls through to the `manual` handler, which yields "needs verification" -> WARN.
+
+**Rationale for changing this vs a per-control CEL workaround:** the current behavior treats CEL as overriding the handler entirely, which is not what §V of the constitution intends ("orchestrator stops at first conclusive result"). A per-control CEL rewrite would be fragile (CEL cannot easily express "keep the handler's FAIL") and would not fix similar bugs in the other 11 controls that combine `fail_exit_codes` + `expr` (see R5).
+
+**Alternatives considered:** (a) TOML-only CEL workaround per control — rejected as fragile and localized; (b) new TOML config knob `expr_semantics` — rejected as unnecessary surface area; the semantics we want are the correct default.
+
+## R2: exec handler exit-code classification
+
+**Decision:** Confirmed at `packages/darnit/src/darnit/sieve/builtin_handlers.py:247-266`:
+
+```python
+if proc.returncode in pass_exit_codes:
+    return PASS
+elif fail_exit_codes and proc.returncode in fail_exit_codes:
+    return FAIL
+else:
+    return INCONCLUSIVE
+```
+
+No change needed to the exec handler. The classification is correct; the downstream CEL post-step is what corrupts the verdict.
+
+## R3: `gh api` behavior for unprotected branch
+
+**Decision:** For a branch with no protection, `gh api /repos/{owner}/{repo}/branches/{branch}/protection` returns HTTP 404 with body:
+
+```json
+{
+  "message": "Branch not protected",
+  "documentation_url": "https://docs.github.com/rest/branches/branch-protection#get-branch-protection",
+  "status": "404"
+}
+```
+
+`gh api` exit code is `1`. The exec handler's `output_format = "json"` parses the body into `output.json`, so `output.json.message == "Branch not protected"` is available inside CEL if needed for a per-control expression. Tests should include a fixture with exactly this response shape (status 404, JSON body, exit code 1).
+
+**Rationale:** the message string is stable and appears in official GitHub REST docs. Matching on `output.json.message == "Branch not protected"` is a stronger signal than matching on exit code 1 alone (which could also mean network failure, auth failure, or other 4xx).
+
+**Alternatives considered:** exit-code-only matching (too broad — 404 for other reasons like nonexistent branch also produces exit 1); status-only matching (`output.json.status == "404"` — same issue).
+
+## R4: Regression-test source of truth for per-level counts
+
+**Decision:** Vendor the upstream OSPS Baseline YAML files under `tests/darnit_baseline/fixtures/osps-baseline/` (or reuse an existing fixture location if one already holds them for the drift check), and parse them at test time to derive expected per-level counts for the pinned `spec_version`. The test is marked `unit` (no network) and runs on every PR.
+
+**Rationale:** three options were considered:
+- **Fetch at test time.** Rejected: introduces network dependency in unit tests; fragile against upstream outages.
+- **Hard-code the expected counts (24/18/20).** Rejected: the test would silently drift out of correctness if upstream changes; the whole point is to detect drift.
+- **Vendor + parse.** Accepted: the vendored copy is the source of truth for the pinned spec version; a spec bump becomes an explicit, reviewable diff (vendor bump + expected-counts update) rather than a silent drift.
+
+**Existing infrastructure:** the repo already has an `upstream` pytest mark on a CNCF spec-drift check (`tests/` — search for `mark.upstream`). That check runs nightly and does not block PRs by design (see `.github/workflows/ci.yml` mark exclusion). The per-level counts test is *different* — it must block PRs. Do not conflate the two marks.
+
+## R5: Regression audit for orchestrator change
+
+**Decision:** Twelve controls combine `fail_exit_codes` + `expr` in the same pass and are affected by the orchestrator change:
+
+```
+OSPS-AC-01.01, OSPS-AC-02.01, OSPS-AC-03.01, OSPS-AC-03.02, OSPS-BR-03.01,
+OSPS-GV-02.01, OSPS-LE-02.01, OSPS-QA-01.01, OSPS-QA-03.01, OSPS-QA-07.01,
+OSPS-VM-03.01, OSPS-VM-04.01
+```
+
+For all twelve, the exec handler returns FAIL only when `proc.returncode == 1` (matches `fail_exit_codes`). In that state:
+
+- **Old:** CEL true -> PASS, CEL false -> INCONCLUSIVE. Both are wrong: a handler-conclusive FAIL should not become PASS just because CEL evaluates truthily on an incomplete evidence dict, and it should not become INCONCLUSIVE when CEL agrees the pass condition is unmet.
+- **New:** CEL true -> INCONCLUSIVE (handler and CEL disagree; ambiguous, safer to be inconclusive), CEL false -> FAIL (both agree; conclusive). This aligns with §II (conservative-by-default) and §V (respect handler conclusion).
+
+**Regression risk:** low. A test that today expects PASS from an `fail_exit_codes`+`expr` combo would be exercising the "handler said fail but CEL said pass" ambiguity, which is not a coherent PASS signal. Such a test's assertion likely reflects the bug, not a real user requirement. The plan's tasks include auditing the existing test suite for such assertions.
+
+**Rationale:** the alternative — leave the orchestrator alone and paper over #343 per-control — would leave 11 other controls in the same broken state.
+
+## R6: LE-01.01 semantic content vs upstream (out of scope, noted)
+
+**Observation:** darnit's `openssf-baseline.toml` defines `OSPS-LE-01.01` with `name = "HasLicense"`, `description = "Repository has a license file"`, and a `file_exists` + regex-content check against `LICENSE` / `LICENSE.md` / `COPYING`. OSPS Baseline v2025.10.10 defines `OSPS-LE-01.01` as a legal-contribution track (DCO or CLA) at maturity 2/3. These are not the same control.
+
+**Decision:** Out of scope for this spec. This spec fixes only the level tag; the content misalignment (darnit's implementation checks license file, not contribution track) is a separate issue that should be filed after this ships. Fixing the tag first still improves correctness because it stops over-scoping the Level 1 audit; fixing the content later is an independent change that would replace the pass definitions and remediation.
+
+**Follow-up:** file an issue after this feature ships noting the semantic drift and pointing at upstream `baseline/OSPS-LE.yaml`.
+
+## Consolidated per-level counts (target)
+
+For OSPS Baseline v2025.10.10, after this fix:
+
+| Level | Count | Notes |
+|-------|-------|-------|
+| 1     | 24    | LE-01.01 removed from L1 |
+| 2     | 18    | LE-01.01 added to L2 |
+| 3     | 20    | Unchanged |
+
+These match `docs/USAGE_GUIDE.md:137-139` and the upstream OSPS applicability.

--- a/specs/019-verdict-correctness/spec.md
+++ b/specs/019-verdict-correctness/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Conservative-by-default verdict correctness
+
+**Feature Branch**: `019-verdict-correctness`
+
+**Created**: 2026-07-31
+
+**Status**: Draft
+
+**Input**: User description: "342 and 343" (Fix issues #342 and #343: OSPS-LE-01.01 miscategorized as Level 1, and branch-protection 404 returning WARN instead of FAIL)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Level 1 audit does not over-scope (Priority: P1)
+
+An operator running `darnit audit --level 1` against their repository expects to be evaluated only against the controls the OSPS Baseline defines as Level 1. Today the audit includes `OSPS-LE-01.01` (DCO / commit sign-off), which OSPS Baseline v2025.10.10 places at Level 2. Fixing this restores parity with the upstream spec and with darnit's own documentation.
+
+**Why this priority**: The framework's compliance verdict must match the specification it claims to implement. Over-scoping a Level 1 audit produces false negatives (a repo shown as non-compliant with L1 for a control the spec does not require at that level). Users cannot trust the level filter until this is corrected.
+
+**Independent Test**: Run `darnit audit --level 1` (or programmatically enumerate the L1 control set) against any repository, then compare the resulting control identifiers to the OSPS Baseline v2025.10.10 applicability filter. The counts must be L1=24, L2=18, L3=20 and `OSPS-LE-01.01` must NOT appear at Level 1.
+
+**Acceptance Scenarios**:
+
+1. **Given** the framework config is loaded with OSPS Baseline v2025.10.10, **When** the user requests the Level 1 control set, **Then** the set contains exactly 24 controls and does not include `OSPS-LE-01.01`.
+2. **Given** OSPS Baseline v2025.10.10 assigns `OSPS-LE-01.01` to `[maturity-2, maturity-3]`, **When** the user requests the Level 2 control set, **Then** `OSPS-LE-01.01` is present.
+3. **Given** the maintainer is verifying the framework's fidelity to upstream, **When** a spec-sync regression test runs, **Then** per-level counts must match the OSPS Baseline for the pinned spec version, and any drift fails CI with a diff of the mismatched controls.
+
+---
+
+### User Story 2 - Definitive "not protected" is reported as failing (Priority: P1)
+
+An operator running a live audit against a repository whose default branch has no branch protection expects the branch-protection controls to be reported as FAIL. Today they are reported as WARN ("could not automatically verify"), which under the framework's conservative-by-default rules still counts against compliance but obscures the fact that darnit has a definitive answer.
+
+**Why this priority**: WARN semantically means "the framework does not know." Emitting WARN when the framework does know (the GitHub API returned a definitive "Branch not protected" response) trains users to distrust WARN, blurs the compliance report, and hides an actionable finding. This is a straight verdict-correctness bug against the constitution's "err on the side of caution" principle: when we have a definitive negative, we must state it.
+
+**Independent Test**: Point a live audit at a repository whose default branch has no branch protection (or configure a test repo with no protection) with authenticated GitHub access, then observe the verdicts for `OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`. All four must be FAIL, not WARN.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository whose default branch has no branch protection and the framework has authenticated access to the GitHub API, **When** any branch-protection control runs, **Then** the control resolves as FAIL with a reason stating the branch is not protected.
+2. **Given** the same repository but the framework cannot reach the GitHub API (network error, rate-limit exhaustion, or unauthenticated request), **When** any branch-protection control runs, **Then** the control resolves as WARN (unchanged from today) because the answer is genuinely unknown.
+3. **Given** a repository whose default branch IS protected but with weak settings, **When** a branch-protection control runs, **Then** the control's normal per-setting evaluation applies (unchanged; this spec does not change how a 200 response is graded).
+
+---
+
+### Edge Cases
+
+- What happens when the upstream OSPS Baseline is updated to a new spec version (e.g., v2026.x) that reclassifies `OSPS-LE-01.01` again? The regression test must be keyed to the pinned spec version (`spec_version` in the framework config), not to hard-coded counts. A future spec bump is a separate task that updates both the pin and the expected counts together.
+- What happens when the branch-protection API returns a 4xx that is NOT the specific "Branch not protected" 404 (e.g., 403 permission denied, 401 unauthenticated, 404 with a different body such as "Not Found")? The response is not definitive; the control remains WARN. This spec only changes the specific 404 + "Branch not protected" body signal.
+- What happens when a branch other than the default is queried and returns "Branch not protected"? Same rule applies: the response is definitive for that branch and resolves FAIL.
+- What happens for controls outside the branch-protection family that today return WARN on a definitive negative? Out of scope for this spec. The pattern may apply elsewhere and can be lifted into a follow-up if identified, but this spec is bounded to the four branch-protection controls named in issue #343.
+- What happens when a user has customized `openssf-baseline.toml` locally? The framework does not distinguish local customization from ship-default; the level assignment is read as-is. Users who override intentionally will not be affected by the shipped regression test unless they run it against their own config.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The framework MUST classify `OSPS-LE-01.01` at Level 2 (matching OSPS Baseline v2025.10.10's `applicability: [maturity-2, maturity-3]`), so that it is excluded from Level 1 audits and included in Level 2 audits.
+- **FR-002**: For OSPS Baseline v2025.10.10, the framework's per-level control counts MUST equal Level 1 = 24, Level 2 = 18, Level 3 = 20 (the values documented in `docs/USAGE_GUIDE.md`).
+- **FR-003**: The framework MUST include an automated regression check that fails when per-level control counts diverge from the upstream OSPS Baseline for the pinned `spec_version`. The check must identify which controls are misclassified so the diff is actionable.
+- **FR-004**: When a branch-protection control receives a definitive "not protected" response from the GitHub API (HTTP 404 with body indicating the branch is not protected), the control MUST resolve to FAIL, not WARN, with a reason that states the branch is unprotected.
+- **FR-005**: FAIL and WARN verdict semantics MUST be preserved: a WARN result must continue to mean "the framework could not determine compliance" (network failure, missing authentication, ambiguous API response). This spec strengthens FAIL by removing one class of false WARN; it does not weaken WARN by folding in ambiguous cases.
+- **FR-006**: The change in FR-004 MUST apply to at minimum the four branch-protection controls named in issue #343: `OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`. Any control that queries `/repos/{owner}/{repo}/branches/{branch}/protection` and interprets the response should benefit from the same signal, but the acceptance bar is these four.
+- **FR-007**: Documentation is not required to change: `docs/USAGE_GUIDE.md` already states the correct 24/18/20 split, so the TOML fix restores consistency. For User Story 2, no new user-facing docs are required; the verdict change is observable in existing audit output.
+
+### Key Entities
+
+- **OSPS Control**: a unit of compliance verification identified by an OSPS identifier (e.g., `OSPS-LE-01.01`). Carries a level assignment and applicability that must match the upstream OSPS Baseline for the pinned spec version.
+- **Control verdict**: the four-valued outcome of running a control: PASS (verified compliant), FAIL (verified non-compliant), WARN (could not determine), ERROR (framework or handler failure). This spec sharpens the boundary between FAIL and WARN for one class of API response.
+- **Upstream OSPS Baseline**: the authoritative external specification (currently v2025.10.10 as pinned in the framework config) whose control-to-level mapping the framework's TOML must mirror.
+- **GitHub branch-protection API response**: the input signal used by branch-protection controls. This spec treats one specific response (HTTP 404 + "Branch not protected" body) as a definitive negative rather than an ambiguous one.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For OSPS Baseline v2025.10.10, per-level control counts equal 24 / 18 / 20, matching the upstream spec and darnit's existing user documentation.
+- **SC-002**: A live audit against a repository whose default branch has no branch protection reports FAIL (not WARN) for all four named branch-protection controls (`OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`).
+- **SC-003**: The audit regression test suite includes a check that fails CI when the framework's per-level counts drift from the upstream OSPS Baseline for the pinned spec version, and the check's failure output identifies the misclassified control identifiers.
+- **SC-004**: No previously-passing control regresses. For branch-protection controls specifically: any API response other than the "definitive not protected" signal continues to produce the same verdict it produces today (no ambiguous or 200-response case flips from WARN or PASS to FAIL).
+- **SC-005**: A user reading an audit report can distinguish "we know this fails" from "we could not verify" without consulting external documentation; WARN means "unknown" and FAIL means "known non-compliant."
+
+## Assumptions
+
+- The framework's pinned OSPS spec version stays at `OSPS v2025.10.10` (`openssf-baseline.toml:12`) for this work. If the upstream spec bumps during implementation, that is a separate spec-sync task that updates both the pin and the expected per-level counts together.
+- The regression test consults the upstream OSPS Baseline as its source of truth. The mechanism (fetched at test time, vendored fixture, or existing CNCF drift check hooks) is an implementation decision left to planning; the requirement is that the check is automated and CI-blocking.
+- The "definitive not protected" signal is the specific combination of HTTP status 404 and a response body indicating the branch is not protected. Other 4xx responses (401, 403) and other 404 bodies remain ambiguous and continue to produce WARN.
+- The change to branch-protection controls does not alter their behavior when the branch IS protected. Existing per-setting evaluation for a 200 response is unchanged.
+- Issues #342 and #343 are bundled in this spec because they share the same theme (conservative-by-default verdict correctness) but they are independent implementation targets and are expected to ship as separate PRs. The bundling is spec-level only; either can be implemented and merged without the other.
+- Constitution reference: this work strengthens Principle II (Conservative-by-default). WARN counts the same as FAIL for compliance math today; this spec does not change that math, only the reported label.

--- a/specs/019-verdict-correctness/tasks.md
+++ b/specs/019-verdict-correctness/tasks.md
@@ -1,0 +1,192 @@
+---
+
+description: "Task list for feature 019: verdict correctness fixes (issues #342 and #343)"
+---
+
+# Tasks: Conservative-by-default verdict correctness
+
+**Input**: Design documents from `/specs/019-verdict-correctness/`
+
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/cel-post-step.md`, `quickstart.md`
+
+**Tests**: Included. The spec explicitly requires a regression test (FR-003), and the orchestrator change (US2) is a framework-level behavior shift that must be TDD'd to avoid regressing the 12 affected controls (research.md R5).
+
+**Organization**: Tasks are grouped by user story. The two stories in this spec are fully independent and are expected to ship as separate PRs (spec.md Assumptions).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies).
+- **[Story]**: Which user story this task belongs to (US1, US2).
+- File paths are absolute-from-repo-root and always specified.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: The vendored upstream OSPS Baseline fixture used by the US1 regression test. Vendor once; both the test infra and the test itself live in Phase 3.
+
+- [X] T001 Create fixtures directory at `tests/darnit_baseline/fixtures/osps-baseline/` with a README pointing to the upstream release (`ossf/security-baseline` tag `v2025.10.10`) it was vendored from and the date/commit vendored.
+- [X] T002 Vendor the OSPS Baseline YAML files (`baseline/OSPS-*.yaml`) from `ossf/security-baseline` at tag `v2025.10.10` into `tests/darnit_baseline/fixtures/osps-baseline/`. Copy the source files verbatim (do not summarize into JSON) so future spec bumps produce a reviewable diff.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: None. The two user stories touch disjoint files (`packages/darnit-baseline/openssf-baseline.toml` for US1; `packages/darnit/src/darnit/sieve/orchestrator.py` for US2) and have no shared prerequisites beyond the Phase 1 fixture (which is only used by US1).
+
+**Checkpoint**: Setup complete. US1 and US2 can start in parallel (in separate branches for separate PRs).
+
+---
+
+## Phase 3: User Story 1 - Level 1 audit does not over-scope (Priority: P1) MVP-A
+
+**Goal**: `OSPS-LE-01.01` classified at Level 2, per-level counts match upstream OSPS Baseline v2025.10.10 (24 / 18 / 20). Regression test asserts parity going forward.
+
+**Independent Test**: `uv run pytest tests/darnit_baseline/test_level_counts.py -v` passes and asserts L1=24, L2=18, L3=20 with `OSPS-LE-01.01` NOT in the Level 1 set (from `quickstart.md` US1).
+
+**Ships as its own PR.**
+
+### Tests for User Story 1 (write first, must FAIL before implementation)
+
+- [X] T003 [P] [US1] Write per-level counts regression test at `tests/darnit_baseline/test_level_counts.py`. The test loads the vendored fixture from `tests/darnit_baseline/fixtures/osps-baseline/`, derives expected per-level sets from each control's `applicability` field, loads the framework's actual per-level sets via `get_implementation('openssf-baseline').get_controls_by_level(n)`, and asserts equality (symmetric diff empty). On failure, the test's message must list the misclassified control identifiers in both directions. Mark with `@pytest.mark.unit`. Confirm this test FAILS on `main` (before T005) with `OSPS-LE-01.01` reported in the L1-only-in-framework set.
+
+- [X] T004 [P] [US1] Extend the test in T003 with a companion assertion that the count summary (`{1: 24, 2: 18, 3: 20}`) matches the values documented in `docs/USAGE_GUIDE.md:137-139`. This is a secondary check: if the doc drifts, the test still fails. Both assertions live in the same test file.
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Change the `level` tag for `OSPS-LE-01.01` from `1` to `2` at `packages/darnit-baseline/openssf-baseline.toml:1543`. Line reads: `tags = { level = 1, domain = "LE", legal = true, license = true }`. Change to `level = 2`. No other change in this file.
+
+- [X] T006 [US1] Run `uv run pytest tests/darnit_baseline/test_level_counts.py -v` and confirm it now passes. Run `uv run python scripts/validate_sync.py --verbose` and confirm no regression.
+
+### Manual verification (per quickstart.md US1)
+
+- [X] T007 [US1] Execute the quickstart cross-check block from `specs/019-verdict-correctness/quickstart.md` (US1 section, "Manual cross-check") and confirm it prints `OK` without assertion errors.
+
+**Checkpoint**: US1 is fully functional and shippable as a standalone PR. Level 1 audits no longer over-scope; regression test blocks CI on future drift.
+
+---
+
+## Phase 4: User Story 2 - Definitive "not protected" is reported as failing (Priority: P1) MVP-B
+
+**Goal**: Branch-protection controls report FAIL (not WARN) when the GitHub API returns HTTP 404 with body "Branch not protected". The fix modifies the sieve orchestrator's CEL post-step so a handler-conclusive FAIL is preserved when the CEL expression also evaluates falsy (see `contracts/cel-post-step.md`).
+
+**Independent Test**: `uv run pytest tests/darnit_baseline/controls/test_branch_protection.py -v` passes; all four named controls (`OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`) resolve to FAIL against a stubbed 404 response (from `quickstart.md` US2 path b).
+
+**Ships as its own PR, independent of US1.**
+
+### Tests for User Story 2 (write first, must FAIL before implementation)
+
+- [ ] T008 [P] [US2] Write orchestrator CEL post-step unit tests at `tests/darnit/sieve/test_orchestrator_cel.py`. Cover all eight cells of the transition table in `specs/019-verdict-correctness/contracts/cel-post-step.md` (test coverage section, items 1-8). Each test asserts the exact resulting `PassOutcome` for a given (handler status, CEL result, `expr` presence) triple. Mark with `@pytest.mark.unit`. Confirm tests 3 and 4 (the new-behavior rows: FAIL+true and FAIL+false) FAIL on `main` before T012.
+
+- [ ] T009 [P] [US2] Write branch-protection integration test at `tests/darnit_baseline/controls/test_branch_protection.py`. For each of `OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`: patch the exec handler's subprocess call to return `returncode=1`, `stdout=b'{"message": "Branch not protected", "documentation_url": "...", "status": "404"}'`, and assert the control's final `PassOutcome` is `FAIL` (not `INCONCLUSIVE`, not `WARN`). Also assert that the resulting message string contains "Branch not protected" so users can see the reason. Mark with `@pytest.mark.unit`. Confirm all four assertions FAIL on `main` before T012.
+
+- [ ] T010 [P] [US2] Regression-guard test at `tests/darnit_baseline/controls/test_branch_protection.py` (same file as T009): given the same four controls, patch the exec handler to return `returncode=0` with a healthy branch-protection JSON body (containing `required_pull_request_reviews`, `required_status_checks`, `required_pull_request_reviews.required_approving_review_count=1`), and assert the final outcome is `PASS` for each. Confirms the orchestrator change does not regress the happy path.
+
+### Audit before implementation
+
+- [ ] T011 [P] [US2] Audit the existing test suite for tests that rely on the old (buggy) CEL post-step behavior for `H=FAIL + CEL=true -> PASS`. Grep `tests/` for handler results with `status=HandlerResultStatus.FAIL` combined with a truthy-CEL assertion expecting PASS. For each hit, determine whether the test is exercising buggy behavior (documented in `research.md` R5) or a legitimate scenario, and record the finding in this task's completion note. Do NOT modify tests yet — that happens in T013 if needed.
+
+### Implementation for User Story 2
+
+- [ ] T012 [US2] Modify `_apply_cel_expr` in `packages/darnit/src/darnit/sieve/orchestrator.py` (lines 60-75) to implement the new transition table from `contracts/cel-post-step.md`. Specifically: when the handler returned FAIL, CEL true yields INCONCLUSIVE (was PASS); CEL false yields the original FAIL (was INCONCLUSIVE). Preserve all existing invariants: pass-through of ERROR/INCONCLUSIVE handler statuses, pass-through when `expr` is absent, pass-through on CEL evaluation error. Update the docstring at lines 33-42 to reflect the new table. Do NOT introduce new config knobs or TOML fields; the semantics change is the correct default.
+
+- [ ] T013 [US2] For each existing test flagged in T011 as relying on buggy behavior: update the assertion to match the new (correct) semantics, and add a one-line comment referencing `specs/019-verdict-correctness/contracts/cel-post-step.md` for context. If none were flagged, this task is a no-op — note that in the task completion.
+
+- [ ] T014 [US2] Run `uv run pytest tests/darnit/sieve/test_orchestrator_cel.py -v` and confirm all eight cases pass.
+
+- [ ] T015 [US2] Run `uv run pytest tests/darnit_baseline/controls/test_branch_protection.py -v` and confirm the four FAIL assertions from T009 and the four PASS assertions from T010 all pass.
+
+### Full regression sweep
+
+- [ ] T016 [US2] Run `uv run pytest tests/ --ignore=tests/integration/ -m "not upstream" -q` and confirm no regression outside the tests updated in T013. If any test unrelated to the audit in T011 fails, stop and diagnose; do not blanket-update assertions.
+
+### Manual verification (per quickstart.md US2, live-repo path)
+
+- [ ] T017 [US2] Optional: if a repository with no branch protection is available, execute the "Manual live-repo check" block from `quickstart.md` US2 and confirm all four named controls report `FAIL` in the JSON output. If no such repo is available, skip and rely on T009/T010 unit coverage. Record which path was used.
+
+**Checkpoint**: US2 is fully functional and shippable as a standalone PR. Branch-protection controls give conclusive verdicts; the orchestrator's CEL post-step correctly preserves handler conclusions.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+- [ ] T018 Run the full quickstart (`specs/019-verdict-correctness/quickstart.md`) end-to-end after both US1 and US2 have merged, and confirm every command produces the documented output. This is a final smoke test independent of the story-level checks.
+
+- [ ] T019 [P] File a follow-up GitHub issue in `darnitdevorg/darnit` for the LE-01.01 semantic content drift noted in `research.md` R6 (darnit implements LE-01.01 as `HasLicense`, but upstream OSPS defines it as DCO/CLA contribution track). Link this feature's PR(s) for context and reference upstream `baseline/OSPS-LE.yaml`. Do NOT bundle the content fix into this feature — it is a separate scope.
+
+- [ ] T020 Add an entry in `CHANGELOG.md` (or wherever release notes accumulate for v0.1.x) noting the two verdict corrections: LE-01.01 reclassified to Level 2; branch-protection controls now FAIL on definitive 404. Cite issues #342 and #343.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies. Blocks only Phase 3 (US1 depends on the vendored fixture).
+- **Foundational (Phase 2)**: Empty. No blocking work.
+- **User Story 1 (Phase 3)**: Depends on Phase 1 (fixture vendored). Independent of US2.
+- **User Story 2 (Phase 4)**: Independent of US1 and Phase 1. Can start immediately after Phase 2 checkpoint (which is trivially satisfied).
+- **Polish (Phase 5)**: Depends on both US1 and US2 having merged.
+
+### Story-level Dependencies
+
+- **US1 and US2 have zero dependency on each other.** They touch different files, exercise different tests, and can be developed, reviewed, and merged in either order or in parallel by different contributors. The spec bundles them by theme only.
+
+### Within Each User Story
+
+- Tests are written and confirmed FAILING before implementation (TDD).
+- For US2 specifically: T011 (audit of existing tests) must complete before T012 (the orchestrator change) so we know which tests need updating in T013.
+
+### Parallel Opportunities
+
+- T001 and T002 are sequential (T002 vendors into the dir T001 creates).
+- Within US1: T003 and T004 are the same file and depend on T001+T002; not parallel to each other but can be a single commit.
+- Within US2: T008, T009, T010, T011 are all [P] — different files, no shared state, all read-only against the (still-unfixed) codebase.
+- Cross-story: **US1 and US2 can run entirely in parallel** by two contributors on two branches after Phase 1 completes.
+
+---
+
+## Parallel Example: User Story 2 setup
+
+```bash
+# T008 through T011 can be spawned as four parallel work items after Phase 1 checkpoint:
+Task: "Write orchestrator CEL post-step unit tests at tests/darnit/sieve/test_orchestrator_cel.py"
+Task: "Write branch-protection integration test at tests/darnit_baseline/controls/test_branch_protection.py (FAIL cases)"
+Task: "Add branch-protection regression guard test at tests/darnit_baseline/controls/test_branch_protection.py (PASS cases)"
+Task: "Audit existing tests for reliance on buggy H=FAIL+CEL=true -> PASS behavior"
+```
+
+---
+
+## Implementation Strategy
+
+### Two independent shippable PRs
+
+The spec explicitly bundles US1 and US2 at the spec level only. Each should ship as its own PR:
+
+**PR A (US1):** T001 + T002 + T003 + T004 + T005 + T006 + T007. Small: one TOML line change, one new test file, one vendored fixture directory. Low risk. Merge first if convenient; not blocking on US2.
+
+**PR B (US2):** T008 + T009 + T010 + T011 + T012 + T013 + T014 + T015 + T016 + T017. Larger: framework-level orchestrator change with 12 downstream controls affected. TDD required. Higher review burden.
+
+**Polish (Phase 5):** After both PRs merge. T018-T020 can be a single small PR or folded into the second PR's cleanup.
+
+### Suggested MVP scope
+
+Either US1 or US2 alone is a valid MVP for this spec. If cadence dictates picking one:
+
+- **Pick US1 first** if the goal is a quick, low-risk correctness win with immediate user-visible impact (Level 1 audits stop over-scoping).
+- **Pick US2 first** if the goal is to unlock better verdicts across 12 controls (broader reach, but larger change).
+
+### Parallel team strategy
+
+With two contributors: A takes PR A (US1), B takes PR B (US2). Neither blocks the other. Merge in whichever order reviews complete. Then the polish PR reconciles.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no shared state.
+- Every task cites the exact file path it edits or the exact command it runs.
+- TDD is enforced: T003, T008, T009, T010 must fail on `main` before their corresponding implementation tasks are begun.
+- Commit granularity: at least one commit per completed task, more if a task naturally splits (e.g., T002 could be one commit per vendored YAML file if that helps the diff).
+- Constitution reminder: this feature strengthens Principles II and V. Any code review comment that would move a "we know it fails" case back to WARN should be rejected on constitutional grounds.

--- a/tests/darnit_baseline/fixtures/osps-baseline/OSPS-AC.yaml
+++ b/tests/darnit_baseline/fixtures/osps-baseline/OSPS-AC.yaml
@@ -1,0 +1,322 @@
+title: Access Control
+description: |
+  Access Control focuses on the mechanisms and
+  policies that control access to the project's version
+  control system and CI/CD pipelines. These controls help
+  ensure that only authorized users can access sensitive
+  data, modify repository settings, or execute build and
+  release processes.
+controls:
+  - id: OSPS-AC-01
+    title: |
+      Use MFA for Sensitive Actions
+    objective: |
+      Reduce the risk of account compromise or insider threats by requiring
+      multi-factor authentication for collaborators modifying the project
+      repository settings or accessing sensitive data.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: CC-G-1
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2d
+          - reference-id: 1.2e
+          - reference-id: 1.2f
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+          - reference-id: PS.1
+          - reference-id: PS.2
+      - reference-id: CSF
+        entries:
+          - reference-id: PR.A-02
+          - reference-id: PR.A-05
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+          - reference-id: 347-352
+          - reference-id: 333-858
+          - reference-id: 152-725
+          - reference-id: 201-246
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G2.6
+          - reference-id: P3.3
+          - reference-id: E1.2
+          - reference-id: E1.3
+          - reference-id: E1.4
+          - reference-id: E3.1
+      - reference-id: SAMM
+        entries:
+          - reference-id: Operations -Environment Management -Configuration Hardening Lvl1
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.1
+          - reference-id: 8.2.1
+          - reference-id: 8.3.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-4(21)
+          - reference-id: AC-17
+          - reference-id: CM-5
+          - reference-id: CM-6
+          - reference-id: IA-2
+          - reference-id: IA-5
+          - reference-id: 1.2e
+          - reference-id: 1.2f
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.4.2
+          - reference-id: Claim 2.1.5   
+          - reference-id: Claim 2.2.2   
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: GV.02          
+    assessment-requirements:
+      - id: OSPS-AC-01.01
+        text: |
+          When a user attempts to read or modify a sensitive resource in the project's
+          authoritative repository, the system MUST require the user to complete
+          a multi-factor authentication process.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Enforce multi-factor authentication for the project's version
+          control system, requiring collaborators to provide a second form of
+          authentication when accessing sensitive data or modifying repository
+          settings. Passkeys are acceptable for this control.
+
+  - id: OSPS-AC-02
+    title: |
+      Restrict Collaborator Permissions
+    objective: |
+      Reduce the risk of unauthorized access to the project's repository by
+      limiting the permissions granted to new collaborators.
+    guideline-mappings:
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2f
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.2
+          - reference-id: PO.3.2
+          - reference-id: PS.1
+          - reference-id: PS.2
+      - reference-id: CSF
+        entries:
+          - reference-id: PR.AA-02
+          - reference-id: PR.AA-05
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+          - reference-id: 802-056
+          - reference-id: 368-633
+          - reference-id: 152-725
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: P2.3
+          - reference-id: E1.2
+          - reference-id: E3.3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-2
+          - reference-id: AC-3
+          - reference-id: AC-4(21)
+          - reference-id: AC-5
+          - reference-id: AC-6
+          - reference-id: CM-5
+          - reference-id: CM-7
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 2.2.2   
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: GV.02      
+    assessment-requirements:
+      - id: OSPS-AC-02.01
+        text: |
+          When a new collaborator is added, the version control system MUST
+          require manual permission assignment, or restrict the collaborator
+          permissions to the lowest available privileges by default.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Most public version control systems are configured in this manner.
+          Ensure the project's version control system always assigns the lowest
+          available permissions to collaborators by default when added, granting
+          additional permissions only when necessary.
+
+  - id: OSPS-AC-03
+    title: |
+      Protect the Primary Branch from Accidental Modification
+    objective: |
+      Reduce the risk of accidental changes or deletion of the primary branch
+      of the project's repository by preventing unintentional modification.
+    guideline-mappings:
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2f
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+          - reference-id: PS.1
+          - reference-id: PS.2
+      - reference-id: CSF
+        entries:
+          - reference-id: PR.A-02
+          - reference-id: PR.A-05
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+          - reference-id: 152-725
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Branch-Protection
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: P3.2
+          - reference-id: P3.5
+          - reference-id: E1.5
+          - reference-id: E3.1
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-3
+          - reference-id: AC-5
+          - reference-id: CM-3
+          - reference-id: CM-3(2)
+          - reference-id: CM-5
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.1.4
+          - reference-id: Claim 2.2.2
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: GV.02      
+          - reference-id: QA.06      
+    assessment-requirements:
+      - id: OSPS-AC-03.01
+        text: |
+          When a direct commit is attempted on the project's primary branch,
+          an enforcement mechanism MUST prevent the change from being applied.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          If the VCS is centralized, set branch protection on the primary branch
+          in the project's VCS. Alternatively, use a decentralized approach,
+          like the Linux kernel's, where changes are first proposed in another
+          repository, and merging changes into the primary repository requires a
+          specific separate act.
+      - id: OSPS-AC-03.02
+        text: |
+          When an attempt is made to delete the project's primary branch,
+          the version control system MUST treat this as a sensitive activity
+          and require explicit confirmation of intent.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Set branch protection on the primary branch in the project's version
+          control system to prevent deletion.
+
+  - id: OSPS-AC-04
+    title: |
+      Enforce Least Privilege on CI/CD Pipelines
+    objective: |
+      Reduce the risk of unauthorized access to the project's build and release
+      processes by limiting the permissions granted to steps within the CI/CD
+      pipelines.
+    guideline-mappings:
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2d
+          - reference-id: 1.2e
+          - reference-id: 1.2f
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.2
+          - reference-id: PO.3.2
+          - reference-id: PS.1
+          - reference-id: PS.2
+      - reference-id: CSF
+        entries:
+          - reference-id: PR.AA-02
+          - reference-id: PR.AA-05
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+          - reference-id: 347-507
+          - reference-id: 263-284
+          - reference-id: 123-124
+      - reference-id: SLSA
+        entries:
+          - reference-id: Producer - Choose an appropriate build platform
+          - reference-id: Build platform - Isolation strength - Isolated
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: P3.2
+      - reference-id: SAMM
+        entries:
+          - reference-id: Operations -Environment Management -Configuration Hardening Lvl1
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.1
+          - reference-id: 8.2.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-3(8)
+          - reference-id: AC-4
+          - reference-id: AC-4(6)
+          - reference-id: AC-6
+          - reference-id: AC-20
+          - reference-id: AC-20(1)
+          - reference-id: CM-5
+          - reference-id: CM-7
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 2.1.1
+          - reference-id: Claim 2.1.3   
+          - reference-id: Claim 2.2.2   
+    assessment-requirements:
+      - id: OSPS-AC-04.01
+        text: |
+          When a CI/CD task is executed with no permissions specified, the
+          CI/CD system MUST default the task's permissions to the lowest
+          permissions granted in the pipeline.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Configure the project's settings to assign the lowest available
+          permissions to new pipelines by default, granting additional
+          permissions only when necessary for specific tasks.
+      - id: OSPS-AC-04.02
+        text: |
+          When a job is assigned permissions in a CI/CD pipeline, the source
+          code or configuration MUST only assign the minimum privileges
+          necessary for the corresponding activity.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Configure the project's CI/CD pipelines to assign the lowest available
+          permissions to users and services by default, elevating permissions
+          only when necessary for specific tasks. In some version control
+          systems, this may be possible at the organizational or repository
+          level. If not, set permissions at the top level of the pipeline.

--- a/tests/darnit_baseline/fixtures/osps-baseline/OSPS-BR.yaml
+++ b/tests/darnit_baseline/fixtures/osps-baseline/OSPS-BR.yaml
@@ -1,0 +1,553 @@
+title: Build and Release
+description: |
+  Build and Release focuses on the processes and
+  tools used to compile, package, and distribute the
+  project's software. These controls help ensure that the
+  project's build and release pipelines are secure,
+  consistent, and reliable, reducing the risk of
+  vulnerabilities or errors in the software distribution
+  process.
+controls:
+  - id: OSPS-BR-01
+    title: |
+      Prevent Untrusted Input When Building & Releasing
+    objective: |
+      Reduce the risk of code injection or other security vulnerabilities in the
+      project's build and release pipelines by preventing untrusted input from
+      accessing privileged resources.
+    guideline-mappings:
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2f
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+          - reference-id: PO.5.2
+          - reference-id: PS.1
+          - reference-id: PS.2
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Dangerous-Workflow
+      - reference-id: CSF
+        entries:
+          - reference-id: PR.AA-02
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+          - reference-id: 357-352
+      - reference-id: SLSA
+        entries:
+          - reference-id: Choose an appropriate build platform
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: P2.3
+          - reference-id: P3.2
+          - reference-id: P3.5
+          - reference-id: E2.4
+          - reference-id: E2.5
+          - reference-id: D2.2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.1
+          - reference-id: 6.4.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-3
+          - reference-id: AC-4
+          - reference-id: AC-4(21)
+          - reference-id: CM-5
+          - reference-id: CM-7
+          - reference-id: SI-7
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 2.1.2
+          - reference-id: Claim 2.2.2          
+    assessment-requirements:
+      - id: OSPS-BR-01.01
+        text: |
+          When a CI/CD pipeline operates on untrusted metadata, those
+          parameters MUST be sanitized and validated prior to use in the
+          pipeline.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          CI/CD pipelines should sanitize (quote, escape or exit on expected
+          values) all metadata inputs which correspond to untrusted sources.
+          This includes data such as branch names, commit messages, tags, pull request titles,
+          and author information.
+      - id: OSPS-BR-01.02
+        text: |
+          Retired in https://github.com/ossf/security-baseline/pull/443
+        applicability:
+          - retired
+      - id: OSPS-BR-01.03
+        text: |
+          When a CI/CD pipeline operates on untrusted code snapshots, it MUST
+          prevent access to privileged CI/CD credentials and assets.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          CI/CD pipelines should isolate untrusted code snapshots from
+          privileged credentials and assets. In particular, projects should be
+          careful to ensure that workflows which build or execute code prior
+          to review by a collaborator do not have access to CI/CD credentials.
+      - id: OSPS-BR-01.04
+        text: |
+          CI/CD pipelines which accept trusted collaborator input MUST sanitize and
+          validate that input prior to use in the pipeline.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          CI/CD pipelines should sanitize (quote, escape or exit on expected
+          values) all collaborator inputs on explicit workflow executions.
+          While collaborators are generally trusted, manual inputs to a
+          workflow cannot be reviewed and could be abused by an account
+          takeover or insider threat.
+
+  - id: OSPS-BR-02
+    title: |
+      Assign Unique Version Identifiers
+    objective: |
+      Ensure that each software asset produced by the project is uniquely
+      identified, enabling users to track changes and updates to the project
+      over time.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: CC-B-5
+          - reference-id: CC-B-6
+          - reference-id: CC-B-7
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2f
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+          - reference-id: PS.1
+          - reference-id: PS.2
+          - reference-id: PS.3
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+      - reference-id: SLSA
+        entries:
+          - reference-id: Follow a consistent build process
+          - reference-id: Provenance generation- Exists, Authentic
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G1.4
+          - reference-id: E1.2
+          - reference-id: E2.1
+          - reference-id: E2.6
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.4.3
+      - reference-id: 800-161
+        entries:
+          - reference-id: IA-4
+          - reference-id: SA-15
+          - reference-id: SI-7
+          - reference-id: SR-4
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.1.4
+          - reference-id: Claim 3.1.1  
+          - reference-id: Claim 3.4.2 
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: BR.02    
+    assessment-requirements:
+      - id: OSPS-BR-02.01
+        text: |
+          When an official release is created, that release MUST be assigned a
+          unique version identifier.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Assign a unique version identifier to each release produced by the
+          project, following a consistent naming convention or numbering scheme.
+          Examples include SemVer, CalVer, or git commit id.
+      - id: OSPS-BR-02.02
+        text: |
+          When an official release is created, all assets within that release
+          MUST be clearly associated with the release identifier or another
+          unique identifier for the asset.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Assign a unique version identifier to each software asset produced by
+          the project, following a consistent naming convention or numbering
+          scheme. Examples include SemVer, CalVer, or git commit id.
+
+  - id: OSPS-BR-03
+    title: | # TODO: These ARs need to be refined or split into two entries
+      Use Encrypted Channels for Development & Release Activity
+    objective: |
+      Protect the confidentiality and integrity of project source code during
+      development, reducing the risk of eavesdropping or data tampering.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-11
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2d
+          - reference-id: 1.2e
+          - reference-id: 1.2f
+          - reference-id: 1.2i
+          - reference-id: 1.2j
+          - reference-id: 1.2k
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+          - reference-id: PO.5.2
+          - reference-id: PS.1
+          - reference-id: PS.2
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 483-813
+          - reference-id: 124-564
+          - reference-id: 263-184
+      - reference-id: SLSA
+        entries:
+          - reference-id: Choose an appropriate build platform
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: E1.1
+          - reference-id: E2.2
+          - reference-id: E2.4
+          - reference-id: E2.5
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.1
+          - reference-id: 2.2.7
+          - reference-id: 4.2.1
+          - reference-id: 4.2.2
+          - reference-id: 6.4.1
+          - reference-id: 8.3.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-4
+          - reference-id: AC-4(21)
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 3.1.2  
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: BR.03             
+    assessment-requirements:
+      - id: OSPS-BR-03.01
+        text: |
+          When the project lists a URI as an official project channel, that URI
+          MUST be exclusively delivered using encrypted channels.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Configure the project's websites and version control systems to use
+          encrypted channels such as SSH or HTTPS for data transmission.
+          Ensure all tools and domains referenced in project documentation can
+          only be accessed via encrypted channels.
+      - id: OSPS-BR-03.02
+        text: |
+          When the project lists a URI as an official distribution channel,
+          that channel MUST be protected from adversary-in-the-middle
+          attacks using cryptographically authenticated channels.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Artifacts distributed by the project should be distributed through
+          channels which ensure integrity and authenticity. Use of HTTPS for
+          downloads, signed releases, or distribution through trusted package
+          managers are all acceptable methods to protect against
+          adversary-in-the-middle attacks.
+
+  - id: OSPS-BR-04
+    title: |
+      Publish Change Log With Release
+    objective: |
+      Provide transparency and accountability for changes made to the project's
+      software releases in such a way that users can understand the
+      modifications and improvements included in each release.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: CC-B-8
+          - reference-id: CC-B-9
+          - reference-id: Q-B-7
+          - reference-id: A-B-1
+          - reference-id: A-S-1
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2d
+          - reference-id: 1.2f
+          - reference-id: 1.2h
+          - reference-id: 1.2j
+          - reference-id: 1.2l
+          - reference-id: 2.5
+      - reference-id: SSDF
+        entries:
+          - reference-id: PS.1
+          - reference-id: PS.2
+          - reference-id: PS.3
+          - reference-id: PW.1.2
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 483-813
+          - reference-id: 068-486
+          - reference-id: 124-564
+          - reference-id: 757-271
+          - reference-id: 347-352
+          - reference-id: 263-184
+          - reference-id: 208-355
+          - reference-id: 745-356
+          - reference-id: 732-148
+      - reference-id: SLSA
+        entries:
+          - reference-id: Choose an appropriate build platform
+          - reference-id: Follow a consistent build process
+          - reference-id: Build platform - Isolation strength - isolated
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G1.4
+          - reference-id: E2.1
+          - reference-id: E2.4
+          - reference-id: E2.5
+          - reference-id: E3.1
+          - reference-id: E3.6
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.2.1
+          - reference-id: 6.4.1
+          - reference-id: 6.5.1
+          - reference-id: 6.5.2
+          - reference-id: 10.2.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: AU-2
+          - reference-id: AU-6
+          - reference-id: AU-10
+          - reference-id: CM-5
+          - reference-id: CM-6
+          - reference-id: MA-1
+          - reference-id: MA-8
+          - reference-id: SI-4
+          - reference-id: SI-5
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.1.4
+          - reference-id: Claim 2.2.3
+          - reference-id: Claim 3.1.1
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: BR.04         
+    assessment-requirements:
+      - id: OSPS-BR-04.01
+        text: |
+          When an official release is created, that release MUST contain
+          a descriptive log of functional and security
+          modifications.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Ensure that all releases include a descriptive change log. It is
+          recommended to ensure that the change log is human-readable and
+          includes details beyond commit messages, such as descriptions of the
+          security impact or relevance to different use cases. To ensure
+          machine readability, place the content under a markdown header
+          such as "## Changelog".
+
+  - id: OSPS-BR-05
+    title: |
+      Use Standardized Dependency Management Tools
+    objective: |
+      Ensure that the project's build and release pipelines use standardized tools
+      and processes to manage dependencies, reducing the risk of compatibility
+      issues or security vulnerabilities in the software.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: Q-B-2
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2b
+          - reference-id: 1.2d
+          - reference-id: 1.2f
+          - reference-id: 1.2h
+          - reference-id: 1.2j
+          - reference-id: 2.1
+          - reference-id: 2.2
+          - reference-id: 2.3
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+          - reference-id: PS.1
+          - reference-id: PS.2
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+          - reference-id: 347-352
+          - reference-id: 715-334
+      - reference-id: SLSA
+        entries:
+          - reference-id: Isolation strength - isolated
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: P3.1
+          - reference-id: P3.5
+          - reference-id: E2.2
+          - reference-id: E2.3
+          - reference-id: E2.4
+          - reference-id: E2.5
+      - reference-id: SAMM
+        entries:
+          - reference-id: Implementation -Secure Build -Build Process Lvl2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.4.3
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-4
+          - reference-id: CM-2
+          - reference-id: CM-7(4)
+          - reference-id: CM-7(5)
+          - reference-id: RA-5
+          - reference-id: SA-15
+          - reference-id: SR-3
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.2.1
+          - reference-id: Claim 1.2.5  
+    assessment-requirements:
+      - id: OSPS-BR-05.01
+        text: |
+          When a build and release pipeline ingests dependencies, it MUST
+          use standardized tooling where available.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Use a common tooling for your ecosystem, such as package managers or
+          dependency management tools to ingest dependencies at build time. This
+          may include using a dependency file, lock file, or manifest to specify
+          the required dependencies, which are then pulled in by the build
+          system.
+
+  - id: OSPS-BR-06
+    title: |
+      Include Signatures and Hashes With Release
+    objective: |
+      Ensure released software assets can be verified by users to ensure
+      integrity of each asset when it is used.
+    guideline-mappings:
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.5.2
+          - reference-id: PS.2
+          - reference-id: PS.2.1
+          - reference-id: PW.6.2
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Signed-Releases
+      - reference-id: SLSA
+        entries:
+          - reference-id: Distribute provenance - Exists
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: P1.2
+          - reference-id: P3.2
+          - reference-id: P3.3
+          - reference-id: E2.1
+          - reference-id: E2.2
+          - reference-id: E2.6
+      - reference-id: SAMM
+        entries:
+          - reference-id: Implementation -Secure Deployment -Deployment Process Lvl3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.1
+          - reference-id: 2.2.7
+          - reference-id: 3.5.1
+          - reference-id: 4.2.1
+          - reference-id: 4.2.2
+          - reference-id: 6.4.1
+          - reference-id: 8.3.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: AU-10
+          - reference-id: MP-1
+          - reference-id: SA-15
+          - reference-id: SI-7
+          - reference-id: SI-7(14)
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.2.2
+          - reference-id: Claim 3.1.1  
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: BR.03
+    assessment-requirements:
+      - id: OSPS-BR-06.01
+        text: |
+          When an official release is created, that release MUST be signed or
+          accounted for in a signed manifest including each asset's
+          cryptographic hashes.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Sign all released software assets at build time with a cryptographic
+          signature or attestations, such as GPG or PGP signature, Sigstore
+          signatures, SLSA provenance, or SLSA VSAs. Include the cryptographic
+          hashes of each asset in a signed manifest or metadata file.
+
+  - id: OSPS-BR-07
+    title: |
+      Secure Secrets and Credentials
+    objective: |
+      Ensure that data which can lead to security vulnerabilities or
+      supply chain compromise is not disclosed, compromised, or misused.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: S-B-5 # TODO: is this the right numbering for https://www.bestpractices.dev/en/criteria#0.no_leaked_credentials
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.1.1
+          - reference-id: P0.3.1
+          - reference-id: P0.4.2
+          - reference-id: PO.5.1
+          - reference-id: PW.1.2
+          - reference-id: PW.1.3
+          - reference-id: PW.5.1
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.4.3
+          - reference-id: Claim 1.4.5
+    assessment-requirements:
+      - id: OSPS-BR-07.01
+        text: |
+          The project MUST prevent the unintentional storage of unencrypted sensitive data, such as secrets and credentials, in the version control system.
+        applicability:
+          - Maturity Level 1
+        recommendation: |
+          Configure .gitignore or equivalent to exclude files that may contain sensitive information. Use pre-commit hooks and automated scanning tools to detect and prevent the inclusion of sensitive data in commits.
+      - id: OSPS-BR-07.02
+        text: |
+          The project MUST define a policy for managing secrets and credentials used by the project. The policy should include guidelines for storing, accessing, and rotating secrets and credentials.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Document how secrets and credentials are managed and used within the project. This should include details on how secrets are stored (e.g., using a secrets management tool), how access is controlled, and how secrets are rotated or updated. Ensure that sensitive information is not hard-coded in the source code or stored in version control systems.

--- a/tests/darnit_baseline/fixtures/osps-baseline/OSPS-DO.yaml
+++ b/tests/darnit_baseline/fixtures/osps-baseline/OSPS-DO.yaml
@@ -1,0 +1,495 @@
+title: Documentation
+description: |
+  Documentation focuses on the information
+  provided to users, contributors, and maintainers
+  of the project. These controls help ensure that
+  the project's documentation is comprehensive,
+  accurate, and up-to-date, enabling users to
+  understand the project's features and functionality, maintenance, support,
+  security and release practices.
+controls:
+  - id: OSPS-DO-01
+    title: |
+      Publish User Guides for Basic Functionality
+    objective: |
+      Ensure that users have a clear and comprehensive understanding of the
+      project's current features in order to prevent damage from misuse or
+      misconfiguration.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-1
+          - reference-id: B-B-9
+          - reference-id: B-S-7
+          - reference-id: B-S-9
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2b
+          - reference-id: 1.2j
+          - reference-id: 1.2k
+      - reference-id: SSDF
+        entries:
+          - reference-id: PW.1.2
+      - reference-id: CSF
+        entries:
+          - reference-id: GV.OC-04
+          - reference-id: GV.OC-05
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.4
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 036-275
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G5.1
+          - reference-id: E3.5
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.1.1
+          - reference-id: 2.2.1
+          - reference-id: 3.1.1
+          - reference-id: 4.1.1
+          - reference-id: 5.1.1
+          - reference-id: 6.1.1
+          - reference-id: 6.2.1
+          - reference-id: 7.1.1
+          - reference-id: 8.1.1
+          - reference-id: 11.1.1
+          - reference-id: 12.10.5
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 4.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: CM-2
+          - reference-id: PL-2
+          - reference-id: PL-8
+          - reference-id: SA-15
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: BR.01          
+    assessment-requirements:
+      - id: OSPS-DO-01.01
+        text: |
+          When the project has made a release, the project documentation MUST
+          include user guides for all basic functionality.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Create user guides or documentation for all basic functionality of the
+          project, explaining how to install, configure, and use the project's
+          features. If there are any known dangerous or destructive actions
+          available, include highly-visible warnings.
+
+  - id: OSPS-DO-02
+    title: |
+      Provide Mechanisms for Reporting Defects
+    objective: |
+      Enable users and contributors to report defects or issues with the
+      released software assets, facilitating communication and collaboration on
+      defect fixes and improvements.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-3
+          - reference-id: R-B-1+
+          - reference-id: R-B-1
+          - reference-id: R-B-2
+          - reference-id: R-S-2
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2c
+          - reference-id: 1.2l
+          - reference-id: 2.1
+          - reference-id: 2.2
+          - reference-id: 2.5
+          - reference-id: 2.6
+      - reference-id: SSDF
+        entries:
+          - reference-id: PW.1.2
+          - reference-id: RV.1.1
+          - reference-id: RV.2.1
+          - reference-id: RV.1.2
+      - reference-id: CSF
+        entries:
+          - reference-id: RS.MA-02
+          - reference-id: GV.RM-05
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.2.1
+      - reference-id: SAMM
+        entries:
+          - reference-id: Implementation -Defect Management -Defect Tracking Lvl1
+          - reference-id: Implementation -Defect Management -Defect Tracking Lvl2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.3.2
+          - reference-id: 6.3.3
+          - reference-id: 6.5.1
+          - reference-id: 6.5.2
+          - reference-id: 12.10.2
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 1.1
+          - reference-id: 1.3
+      - reference-id: 800-161
+        entries:
+          - reference-id: IR-6
+          - reference-id: SI-4
+          - reference-id: SI-5          
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: QA.03
+    assessment-requirements:
+      - id: OSPS-DO-02.01
+        text: |
+          When the project has made a release, the project documentation MUST
+          include a guide for reporting defects.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          It is recommended that projects use their VCS default issue tracker.
+          If an external source is used, ensure that the project documentation
+          and contributing guide clearly and visibly explain how to use the
+          reporting system. It is recommended that project documentation also
+          sets expectations for how defects will be triaged and resolved.
+
+  - id: OSPS-DO-03
+    title: |
+      Publish Provenance Verification Instructions
+    objective: |
+      Enable users to verify the authenticity and integrity of the project's
+      released software assets, reducing the risk of using tampered or
+      unauthorized versions of the software.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: CC-B-8
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2d
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.4.2
+          - reference-id: PS.2
+          - reference-id: PS.2.1
+          - reference-id: PS.3.1
+          - reference-id: RV.1.3
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 171-222
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G1.3
+          - reference-id: G2.5
+          - reference-id: P1.2
+          - reference-id: P3.1
+          - reference-id: P3.2
+          - reference-id: P3.3
+          - reference-id: E2.6
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 3.1.1
+          - reference-id: 3.5.1
+          - reference-id: 4.1.1
+          - reference-id: 5.1.1
+          - reference-id: 6.1.1
+          - reference-id: 6.2.1
+          - reference-id: 7.1.1
+          - reference-id: 8.1.1
+          - reference-id: 11.1.1
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 3.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: CM-2
+          - reference-id: IR-1
+          - reference-id: MP-1
+          - reference-id: SA-15
+          - reference-id: SI-7
+          - reference-id: SI-7(14)          
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: BR.01
+          - reference-id: BR.03          
+    assessment-requirements:
+      - id: OSPS-DO-03.01
+        text: |
+          When the project has made a release, the project documentation MUST
+          contain instructions to verify the integrity and authenticity of the
+          release assets.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Instructions in the project should contain information about the
+          technology used, the commands to run, and the expected output.
+          When possible, avoid storing this documentation in the same location
+          as the build and release pipeline to avoid a single breach
+          compromising both the software and the documentation for verifying the
+          integrity of the software.
+      - id: OSPS-DO-03.02
+        text: |
+          When the project has made a release, the project documentation MUST
+          contain instructions to verify the expected identity of the person or
+          process authoring the software release.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          The expected identity may be in the form of key IDs used to sign,
+          issuer and identity from a sigstore certificate, or other similar
+          forms.
+          When possible, avoid storing this documentation in the same location
+          as the build and release pipeline to avoid a single breach
+          compromising both the software and the documentation for verifying the
+          integrity of the software.
+
+  - id: OSPS-DO-04
+    title: |
+      Publish Support Scope and Duration
+    objective: |
+      Provide users with clear expectations regarding the project's support
+      lifecycle in such a way that enables downstream consumers to ensure the
+      continued functionality and security of their systems.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: R-B-3
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.4.2
+          - reference-id: PS.3.1
+          - reference-id: RV.1.3
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1
+          - reference-id: 4.3.1
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: E1.6
+      - reference-id: SAMM
+        entries:
+          - reference-id: Operations -Operational Management -System Decommissioning -Legacy Management Lvl1
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.1.1
+          - reference-id: 3.1.1
+          - reference-id: 3.2.1
+          - reference-id: 4.1.1
+          - reference-id: 5.1.1
+          - reference-id: 6.1.1
+          - reference-id: 6.3.3
+          - reference-id: 7.1.1
+          - reference-id: 8.1.1
+          - reference-id: 11.1.1
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 4.1
+          - reference-id: 4.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: PL-1
+          - reference-id: PL-2
+          - reference-id: SI-4          
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 4.1.1
+          - reference-id: Claim 4.1.2
+          - reference-id: Claim 4.2.1
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: DE.01       
+    assessment-requirements:
+      - id: OSPS-DO-04.01
+        text: |
+          When the project has made a release, the project documentation MUST
+          include a descriptive statement about the scope and duration of
+          support for each release.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          In order to communicate the scope and duration of support for the
+          project's released software assets, the project should have a
+          SUPPORT.md file, a "Support" section in SECURITY.md, or
+          other documentation explaining the support lifecycle,
+          including the expected duration of support for each release, the
+          types of support provided (e.g., bug fixes, security updates), and
+          any relevant policies or procedures for obtaining support.
+
+  - id: OSPS-DO-05
+    title: |
+      Document Security Update Scope and Duration
+    objective: |
+      Communicate when the project maintainers will no longer fix defects or
+      security vulnerabilities.
+    guideline-mappings:
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2c
+          - reference-id: 2.6
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.1
+          - reference-id: 4.3.1
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 673-475
+          - reference-id: 053-751
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: E1.6
+      - reference-id: SAMM
+        entries:
+          - reference-id: Operations -Operational Management -System Decommissioning -Legacy Management Lvl1
+          - reference-id: Operations -Operational Management -System Decommissioning -Legacy Management Lvl2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 3.1.1
+          - reference-id: 3.2.1
+          - reference-id: 4.1.1
+          - reference-id: 5.1.1
+          - reference-id: 6.1.1
+          - reference-id: 6.3.2
+          - reference-id: 7.1.1
+          - reference-id: 8.1.1
+          - reference-id: 11.1.1
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 3.5
+          - reference-id: 4.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: PL-1
+          - reference-id: PL-2
+          - reference-id: SI-4
+          - reference-id: SI-5          
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 4.1.1
+          - reference-id: Claim 4.2.1
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: DE.01        
+    assessment-requirements:
+      - id: OSPS-DO-05.01
+        text: |
+          When the project has made a release, the project documentation MUST
+          provide a descriptive statement when releases or versions will no
+          longer receive security updates.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          In order to communicate the scope and duration of support for security
+          fixes, the project should have a SUPPORT.md or other documentation
+          explaining the project's policy for security updates.
+
+  - id: OSPS-DO-06
+    title: |
+      Publish Dependency Management Policy
+    objective: |
+      Provide information about how the project selects, obtains, and tracks
+      third-party components that are required for the software to function.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: A-S-1
+      - reference-id: CRA
+        entries:
+          - reference-id: 2.1
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 613-286
+          - reference-id: 053-751
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Pinned-Dependencies
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G1.4
+          - reference-id: G2.4
+          - reference-id: P3.1
+          - reference-id: P3.2
+          - reference-id: P3.4
+      - reference-id: SAMM
+        entries:
+          - reference-id: Design -Security Requirements -Supplier Security Lvl2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.1.1
+          - reference-id: 3.1.1
+          - reference-id: 4.1.1
+          - reference-id: 5.1.1
+          - reference-id: 6.1.1
+          - reference-id: 6.3.2
+          - reference-id: 6.4.3
+          - reference-id: 7.1.1
+          - reference-id: 8.1.1
+          - reference-id: 11.1.1
+          - reference-id: 12.5.2
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 1.2
+          - reference-id: 3.3
+      - reference-id: 800-161
+        entries:
+          - reference-id: CA-7
+          - reference-id: CM-7(5)
+          - reference-id: CM-8
+          - reference-id: PM-30
+          - reference-id: RA-3(1)
+          - reference-id: SA-11
+          - reference-id: SI-4
+          - reference-id: SR-3
+          - reference-id: SR-5
+          - reference-id: SR-6
+          - reference-id: SR-7          
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.2.1
+          - reference-id: Claim 1.2.2
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: QA.01
+    assessment-requirements:
+      - id: OSPS-DO-06.01
+        text: |
+          When the project has made a release, the project documentation MUST
+          include a description of how the project selects, obtains, and tracks
+          its dependencies.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          It is recommended to publish this information alongside the project's
+          technical & design documentation on a publicly viewable resource such
+          as the source code repository, project website, or other channel.  
+        
+  - id: OSPS-DO-07
+    title: |
+      Provide Instructions on How to Build From Source
+    objective: |
+      Ensure that users have a clear and comprehensive instructions on how
+      to build the software from source code.
+    guideline-mappings:
+      - reference-id: 
+        entries:
+          - reference-id:
+    assessment-requirements:
+      - id: OSPS-DO-07.01
+        text: |
+          The project documentation MUST
+          include instructions on how to build the software, including required
+          libraries, frameworks, SDKs, and dependencies.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          It is recommended to publish this information alongside the project's
+          contributor documentation, such as in `CONTRIBUTING.md` or other
+          developer task documentation. This may also be documented using
+          `Makefile` targets or other automation scripts.

--- a/tests/darnit_baseline/fixtures/osps-baseline/OSPS-GV.yaml
+++ b/tests/darnit_baseline/fixtures/osps-baseline/OSPS-GV.yaml
@@ -1,0 +1,280 @@
+title: Governance
+description: |
+  Governance focuses on the policies and
+  procedures that guide the project's decision-making
+  and community interactions. These controls help ensure
+  that the project is well positioned to respond to
+  both threats and opportunities.
+controls:
+  - id: OSPS-GV-01
+    title: |
+      Publish Project Roles and Responsibilities
+    objective: |
+      Document project roles and responsibilities to help project participants,
+      potential contributors, and downstream consumers understand who is working
+      on the project and what areas of authority they may have.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-S-3
+          - reference-id: B-S-4
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 013-021
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G2.3
+          - reference-id: E3.1
+          - reference-id: E3.3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.1.2
+          - reference-id: 3.1.1
+          - reference-id: 3.1.2
+          - reference-id: 4.1.1
+          - reference-id: 4.1.2
+          - reference-id: 5.1.1
+          - reference-id: 5.1.2
+          - reference-id: 6.1.1
+          - reference-id: 6.1.2
+          - reference-id: 6.5.4
+          - reference-id: 7.1.1
+          - reference-id: 7.1.2
+          - reference-id: 8.1.1
+          - reference-id: 8.1.2
+          - reference-id: 11.1.1
+          - reference-id: 11.1.2
+          - reference-id: 12.1.3
+          - reference-id: 12.5.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-2
+          - reference-id: AC-3
+          - reference-id: IA-2
+          - reference-id: PL-1
+          - reference-id: PL-4
+          - reference-id: PM-30          
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 2.1.1
+    assessment-requirements:
+      - id: OSPS-GV-01.01
+        text: |
+          While active, the project documentation MUST include a list of
+          project members with access to sensitive resources.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Document project participants and their roles through such artifacts
+          as members.md, governance.md, maintainers.md, or similar file within
+          the source code repository of the project.
+          This may be as simple as including names or account handles in a list
+          of maintainers, or more complex depending on the project's governance.
+      - id: OSPS-GV-01.02
+        text: |
+          While active, the project documentation MUST include descriptions of
+          the roles and responsibilities for members of the project.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Document project participants and their roles through such artifacts
+          as members.md, governance.md, maintainers.md, or similar file within
+          the source code repository of the project.
+
+  - id: OSPS-GV-02
+    title: |
+      Provide Public Discussion Mechanisms
+    objective: |
+      Encourage open communication and collaboration within the project
+      community by enabling users to provide feedback and discuss proposed
+      changes or usage challenges.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-3
+          - reference-id: B-B-12
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2l
+          - reference-id: 2.3
+          - reference-id: 2.4
+          - reference-id: 2.6
+      - reference-id: SSDF
+        entries:
+          - reference-id: PS.3
+          - reference-id: PW.1.2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 12.5.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-21
+          - reference-id: AU-6
+          - reference-id: PL-1          
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: QA.03                 
+    assessment-requirements:
+      - id: OSPS-GV-02.01
+        text: |
+          While active, the project MUST have one or more mechanisms for public
+          discussions about proposed changes and usage obstacles.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Establish one or more mechanisms for public discussions within the
+          project, such as mailing lists, instant messaging, or issue trackers,
+          to facilitate open communication and feedback.
+
+  - id: OSPS-GV-03
+    title: |
+      Publish Contribution Guide
+    objective: |
+      Provide guidance on how to participate in the project, outlining the steps
+      required to submit changes or enhancements to the project's codebase.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-4
+          - reference-id: B-S-3
+          - reference-id: B-B-4+
+          - reference-id: R-B-1
+          - reference-id: Q-G-2
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2l
+          - reference-id: 2.4
+      - reference-id: SSDF
+        entries:
+          - reference-id: PW.1.2
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.2
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G2.4
+          - reference-id: P2.2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.1.1
+          - reference-id: 6.5.4
+          - reference-id: 8.2.1
+          - reference-id: 12.5.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-3
+          - reference-id: AC-20
+          - reference-id: PL-1          
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 2.1.1
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: GV.01
+          - reference-id: QA.04
+          - reference-id: QA.05       
+    assessment-requirements:
+      - id: OSPS-GV-03.01
+        text: |
+          While active, the project documentation MUST include an explanation
+          of the contribution process.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Create a CONTRIBUTING.md or CONTRIBUTING/ directory to outline the
+          contribution process including the steps for submitting changes, and
+          engaging with the project maintainers.
+      - id: OSPS-GV-03.02
+        text: |
+          While active, the project documentation MUST include a guide for code
+          contributors that includes requirements for acceptable contributions.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Extend the CONTRIBUTING.md or CONTRIBUTING/ contents in the project
+          documentation to outline the requirements for acceptable
+          contributions, including coding standards, testing requirements, and
+          submission guidelines for code contributors. It is recommended that
+          this guide is the source of truth for both contributors and approvers.
+
+  - id: OSPS-GV-04
+    title: |
+      Require Formal Review of Permission Grants
+    objective: |
+      Ensure that code contributors are vetted and reviewed before being granted
+      elevated permissions to sensitive resources within the project, reducing
+      the risk of unauthorized access or misuse.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-5
+          - reference-id: B-S-3
+          - reference-id: B-B-4+
+          - reference-id: Q-G-2
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2d
+          - reference-id: 1.2l
+          - reference-id: 2.1
+          - reference-id: 2.2
+          - reference-id: 2.5
+          - reference-id: 2.6
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.2
+          - reference-id: PO.3.2
+      - reference-id: CSF
+        entries:
+          - reference-id: PR.AA-02
+          - reference-id: PR.AA-05
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 123-124
+          - reference-id: 152-725
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.2
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: E3.1
+          - reference-id: E3.3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.1.1
+          - reference-id: 6.5.4
+          - reference-id: 8.2.1
+          - reference-id: 8.2.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-2
+          - reference-id: AC-3
+          - reference-id: AC-4(21)
+          - reference-id: AC-5
+          - reference-id: AC-6
+          - reference-id: AC-20
+          - reference-id: CM-7
+          - reference-id: IR-4(6)
+          - reference-id: PM-30
+          - reference-id: SI-4          
+    assessment-requirements:
+      - id: OSPS-GV-04.01
+        text: |
+          While active, the project documentation MUST have a policy that code
+          collaborators are reviewed prior to granting escalated permissions to
+          sensitive resources.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Publish an enforceable policy in the project documentation that
+          requires code collaborators to be reviewed and approved before being
+          granted escalated permissions to sensitive resources, such as merge
+          approval or access to secrets. It is recommended that vetting includes
+          establishing a justifiable lineage of identity such as confirming the
+          contributor's association with a known trusted organization.

--- a/tests/darnit_baseline/fixtures/osps-baseline/OSPS-LE.yaml
+++ b/tests/darnit_baseline/fixtures/osps-baseline/OSPS-LE.yaml
@@ -1,0 +1,197 @@
+title: Legal
+description: |
+  Legal focuses on the policies and
+  procedures that govern the project's licensing
+  and intellectual property. These controls help
+  ensure that the project's source code is
+  distributed under a recognized and legally
+  enforceable open source software license,
+  reducing the risk of intellectual property
+  disputes or licensing violations.
+controls:
+  - id: OSPS-LE-01
+    title: |
+      Require Code Contributors to Assert Right to Commit
+    objective: |
+      Ensure that code contributors are aware of and acknowledge their legal
+      responsibility for the contributions they make to the project, reducing
+      the risk of intellectual property disputes against the project.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-S-1
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2b
+          - reference-id: 1.2f
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+          - reference-id: PS.1
+          - reference-id: PW.1.2
+          - reference-id: PW.2.1
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: E3.1
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 12.8.5
+      - reference-id: 800-161
+        entries:
+          - reference-id: PL-4          
+    assessment-requirements:
+      - id: OSPS-LE-01.01
+        text: |
+          While active, the version control system MUST require all code
+          contributors to assert that they are legally authorized to make the
+          associated contributions on every commit.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Include a DCO in the project's repository, requiring code
+          contributors to assert that they are legally authorized to commit the
+          associated contributions on every commit. Use a status check to ensure
+          the assertion is made. A CLA also satisfies this requirement.
+          Some version control systems, such as GitHub, may include this in the
+          platform terms of service.
+
+          It is understood that projects with a lengthy history prior to
+          adopting OSPS Baseline may not be able to retroactively enforce this
+          requirement.
+
+  - id: OSPS-LE-02
+    title: |
+      Ensure Project Licenses are Fully Open Source
+    objective: |
+      Ensure that the project's source code is distributed under a recognized
+      and legally enforceable open source software license, providing clarity on
+      how the code can be used and shared by others.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-6
+          - reference-id: B-B-7
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2b
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+      - reference-id: CSF
+        entries:
+          - reference-id: GV.OC-03
+      - reference-id: Scorecard
+        entries:
+          - reference-id: License
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G1.2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 3.2.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: PL-4                 
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: LE.01
+    assessment-requirements:
+      - id: OSPS-LE-02.01
+        text: |
+          While active, the license for the source code MUST meet the OSI Open
+          Source Definition or the FSF Free Software Definition.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Add a LICENSE file to the project's repo with a license that is an
+          approved license by the Open Source Initiative (OSI), or a free
+          license as approved by the Free Software Foundation (FSF). Examples of
+          such licenses include the MIT, BSD 2-clause, BSD 3-clause revised,
+          Apache 2.0, Lesser GNU General Public License (LGPL), and the GNU
+          General Public License (GPL). Releasing to the public domain meets
+          this control if there are no other encumbrances such as patents.
+      - id: OSPS-LE-02.02
+        text: |
+          While active, the license for the released software assets MUST meet
+          the OSI Open Source Definition or the FSF Free Software Definition.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          If a different license is included with released software assets,
+          ensure it is an approved license by the Open Source Initiative (OSI),
+          or a free license as approved by the Free Software Foundation (FSF).
+          Examples of such licenses include the MIT, BSD 2-clause, BSD 3-clause
+          revised, Apache 2.0, Lesser GNU General Public License (LGPL), and the
+          GNU General Public License (GPL). Note that the license for the
+          released software assets may be different than the source code.
+
+  - id: OSPS-LE-03
+    title: |
+      Maintain and Release Licenses in a Well Known Location
+    objective: |
+      Ensure that the project's source code and released software assets are
+      distributed with the appropriate license terms, making it clear to users
+      and contributors how each can be used and shared.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-8
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2b
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+      - reference-id: Scorecard
+        entries:
+          - reference-id: License
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G1.2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 3.2.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: PL-4                 
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: LE.02
+    assessment-requirements:
+      - id: OSPS-LE-03.01
+        text: |
+          While active, the license for the source code MUST be maintained in
+          the corresponding repository's LICENSE file, COPYING file, or
+          LICENSE/ directory.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Include the project's source code license in the project's LICENSE
+          file, COPYING file, or LICENSE/ directory to provide visibility and
+          clarity on the licensing terms. The filename MAY have an extension.
+          If the project has multiple repositories, ensure that each repository
+          includes the license file.
+      - id: OSPS-LE-03.02
+        text: |
+          While active, the license for the released software assets MUST be
+          included in the released source code, or in a LICENSE file, COPYING
+          file, or LICENSE/ directory alongside the corresponding release
+          assets.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Include the project's released software assets license in the released
+          source code, or in a LICENSE file, COPYING file, or LICENSE/ directory
+          alongside the corresponding release assets to provide visibility and
+          clarity on the licensing terms. The filename MAY have an extension.
+          If the project has multiple repositories, ensure that each repository
+          includes the license file.

--- a/tests/darnit_baseline/fixtures/osps-baseline/OSPS-QA.yaml
+++ b/tests/darnit_baseline/fixtures/osps-baseline/OSPS-QA.yaml
@@ -1,0 +1,567 @@
+title: Quality
+description: |
+  Quality focuses on the processes and
+  practices used to ensure the quality and
+  reliability of the project's source code and
+  software assets. These controls help ensure
+  that the project's source code is well
+  maintained, secure, and reliable, reducing the
+  risk of defects or vulnerabilities in the
+  software.
+controls:
+  - id: OSPS-QA-01
+    title: |
+      Publish Source Code and Change History
+    objective: |
+      Enable users to access and review the project's source code and history,
+      promoting transparency and collaboration within the project community.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: CC-B-1
+          - reference-id: CC-B-2
+          - reference-id: CC-B-3
+          - reference-id: R-B-5
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2b
+          - reference-id: 1.2f
+          - reference-id: 1.2j
+      - reference-id: SSDF
+        entries:
+          - reference-id: PS.1
+          - reference-id: PS.2
+          - reference-id: PS.3
+          - reference-id: PW.1.2
+          - reference-id: PW.2.1
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+          - reference-id: 757-271
+      - reference-id: CSF
+        entries:
+          - reference-id: ID.AM-02
+          - reference-id: ID.RA-01
+          - reference-id: ID.RA-08
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.4
+      - reference-id: SLSA
+        entries:
+          - reference-id: Build platform - isolation strength - Isolated
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: P3.5
+          - reference-id: E2.2
+      - reference-id: SAMM
+        entries:
+          - reference-id: Implementation -Secure Build -Build Process Lvl1
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.1.1
+          - reference-id: 6.2.1
+          - reference-id: 6.5.1
+          - reference-id: 6.5.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: RA-5
+          - reference-id: SA-11
+          - reference-id: SA-15          
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 2.2.3
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: QA.02
+    assessment-requirements:
+      - id: OSPS-QA-01.01
+        text: |
+          While active, the project's source code repository MUST be publicly
+          readable at a static URL.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Use a common VCS such as GitHub, GitLab, or Bitbucket. Ensure the
+          repository is publicly readable. Avoid duplication or mirroring of
+          repositories unless highly visible documentation clarifies the primary
+          source. Avoid frequent changes to the repository that would impact the
+          repository URL. Ensure the repository is public.
+      - id: OSPS-QA-01.02
+        text: |
+          The version control system MUST contain a publicly readable record of
+          all changes made, who made the changes, and when the changes were
+          made.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Use a common VCS such as GitHub, GitLab, or Bitbucket to maintain a
+          publicly readable commit history. Avoid squashing or rewriting commits
+          in a way that would obscure the author of any commits.
+
+  - id: OSPS-QA-02
+    title: |
+      Publish Software Dependencies
+    objective: |
+      Provide transparency and accountability for the project's dependencies
+      while enabling users and contributors to understand the software's direct
+      dependencies.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: Q-S-8
+          - reference-id: Q-S-9
+      - reference-id: CRA
+        entries:
+          - reference-id: 2.1
+          - reference-id: 2.2
+          - reference-id: 2.3
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.3
+          - reference-id: PS.1
+          - reference-id: PS.2
+          - reference-id: PS.3.2
+          - reference-id: PW.4
+      - reference-id: CSF
+        entries:
+          - reference-id: ID.AM.01
+          - reference-id: ID.AM-02
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.5
+          - reference-id: 4.3.1
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+          - reference-id: 673-475
+          - reference-id: 863-521
+          - reference-id: 613-286
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G1.4
+          - reference-id: G1.5
+          - reference-id: G2.5
+          - reference-id: P3.1
+          - reference-id: P3.2
+          - reference-id: P5.1
+          - reference-id: P5.2
+          - reference-id: E2.1
+          - reference-id: E2.2
+      - reference-id: SAMM
+        entries:
+          - reference-id: Implementation -Secure Build -Software Dependencies Lvl1
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.3.2
+          - reference-id: 6.4.3
+          - reference-id: 12.5.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: CA-7
+          - reference-id: CM-2
+          - reference-id: CM-8
+          - reference-id: PL-8
+          - reference-id: RA-3(1)
+          - reference-id: RA-5
+          - reference-id: SA-11
+          - reference-id: SA-15
+          - reference-id: SR-3
+          - reference-id: SR-4                
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.2.1
+          - reference-id: Claim 1.2.2
+          - reference-id: Claim 3.1.1
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: QA.01
+    assessment-requirements:
+      - id: OSPS-QA-02.01
+        text: |
+          When the package management system supports it, the source code
+          repository MUST contain a dependency list that accounts for the direct
+          language dependencies.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          This may take the form of a package manager or language dependency file
+          that enumerates all direct dependencies such as package.json, Gemfile,
+          or go.mod.
+      - id: OSPS-QA-02.02
+        text: |
+          When the project has made a release, all compiled released software
+          assets MUST be delivered with a software bill of materials.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          It is recommended to auto-generate SBOMs at build time using a tool
+          that has been vetted for accuracy. This enables users to ingest this
+          data in a standardized approach alongside other projects in their
+          environment.
+
+  - id: OSPS-QA-03
+    title: |
+      Address Pass/Fail Checks Before Accepting Changes
+    objective: |
+      Ensure that the project's approvers do not become accustomed to tolerating
+      failing status checks, even if arbitrary, because it increases the risk of
+      overlooking security vulnerabilities or defects identified by automated
+      checks.
+    guideline-mappings:
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2f
+          - reference-id: 1.2k
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.4.1
+          - reference-id: PS.1
+          - reference-id: PS.2
+          - reference-id: RV.1.2
+      - reference-id: CSF
+        entries:
+          - reference-id: ID.IM-02
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.5
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 263-184
+          - reference-id: 253-452
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G2.2
+          - reference-id: G5.3
+          - reference-id: G5.4
+          - reference-id: P3.5
+          - reference-id: P4.1
+          - reference-id: P4.2
+      - reference-id: SAMM
+        entries:
+          - reference-id: Implementation -Secure Build -Build Process Lvl3
+          - reference-id: Implementation -Secure Build -Software Dependencies Lvl3
+          - reference-id: Verification -Requirements Testing -Control Verification Lvl1
+          - reference-id: Verification -Requirements Testing -Control Verification Lvl2
+          - reference-id: Verification -Requirements Testing -Control Verification Lvl3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.3.1
+          - reference-id: 6.3.2
+          - reference-id: 6.5.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: AU-6
+          - reference-id: CM-3
+          - reference-id: CM-6
+          - reference-id: PL-8
+          - reference-id: SA-11
+          - reference-id: SA-15
+          - reference-id: SR-3                
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.3.2
+          - reference-id: Claim 1.3.3
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: QA.04
+    assessment-requirements:
+      - id: OSPS-QA-03.01
+        text: |
+          When a commit is made to the primary branch, any automated status
+          checks for commits MUST pass or be manually bypassed.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Configure the project's version control system to require that all
+          automated status checks pass or require manual acknowledgement before a
+          commit can be merged into the primary branch. It is recommended that
+          any optional status checks are NOT configured as a pass or fail
+          requirement that approvers may be tempted to bypass.
+
+  - id: OSPS-QA-04
+    title: |
+      Enforce Security Requirements on All Codebases
+    objective: |
+      Ensure that all codebases produced by the project are well
+      documented and held to the same security standard.
+    guideline-mappings:
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2b
+          - reference-id: 1.2f
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.3.2
+          - reference-id: PO.4.1
+          - reference-id: PS.1
+          - reference-id: PS.2
+          - reference-id: RV.1.2
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+      - reference-id: SLSA
+        entries:
+          - reference-id: Build platform - isolation strength - Isolated
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Binary-Artifacts
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G2.2
+          - reference-id: G5.4
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.4.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: PL-8
+          - reference-id: SA-15                
+    assessment-requirements:
+      - id: OSPS-QA-04.01
+        text: |
+          Projects with multiple repositories MUST document a list of codebases
+          that are part of the project.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Document any additional subproject code repositories produced by the
+          project and compiled into a release. This documentation should include
+          the status and intent of the respective codebase.
+      - id: OSPS-QA-04.02
+        text: |
+          When the project has made a release comprising multiple source code
+          repositories, all subprojects MUST enforce security requirements that
+          are as strict or stricter than the primary codebase.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Any additional subproject code repositories produced by the project
+          and compiled into a release must enforce security requirements as
+          applicable to the status and intent of the respective codebase.
+          In addition to following the corresponding OSPS Baseline requirements,
+          this may include requiring a security review, ensuring that it is
+          free of vulnerabilities, and ensuring that it is free of known
+          security issues.
+
+  - id: OSPS-QA-05
+    title: |
+      Prevent Executables in the Codebase
+    objective: |
+      Reduce the risk of including generated executable artifacts in the
+      project's version control system, ensuring that only source code and
+      necessary files are stored in the repository.
+    guideline-mappings:
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2b
+      - reference-id: SSDF
+        entries:
+          - reference-id: PS.1
+          - reference-id: PS.2
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 486-813
+          - reference-id: 124-564
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.4.3
+      - reference-id: 800-161
+        entries:
+          - reference-id: PL-8
+          - reference-id: SA-15
+          - reference-id: SR-3                
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: BR.05
+    assessment-requirements:
+      - id: OSPS-QA-05.01
+        text: |
+          While active, the version control system MUST NOT contain generated
+          executable artifacts.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Remove generated executable artifacts in the project's version control
+          system. It is recommended that any scenario where a generated
+          executable artifact appears critical to a process such as testing, it
+          should be instead be generated at build time or stored separately and
+          fetched during a specific well-documented pipeline step.
+      - id: OSPS-QA-05.02
+        text: |
+          While active, the version control system MUST NOT contain unreviewable
+          binary artifacts.
+        applicability:
+          - Maturity Level 1
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Do not add any unreviewable binary artifacts to the project's version
+          control system. This includes executable application binaries, library
+          files, and similar artifacts. It does not include assets such as
+          graphical images, sound or music files, and similar content typically
+          stored in a binary format.
+
+  - id: OSPS-QA-06
+    title: |
+      Use Automated Testing in CI/CD Pipelines
+    objective: |
+      Ensure that the project uses at least one automated test suite for the
+      source code repository and clearly documents when and how tests are run.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: Q-B-4
+          - reference-id: Q-B-8
+          - reference-id: Q-B-9
+          - reference-id: Q-B-10
+          - reference-id: Q-S-2
+      - reference-id: CRA
+        entries:
+          - reference-id: 2.3
+      - reference-id: SSDF
+        entries:
+          - reference-id: PW.8.2
+      - reference-id: CSF
+        entries:
+          - reference-id: ID.AM-02
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.5
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 207-435
+          - reference-id: 088-377
+      - reference-id: Scorecard
+        entries:
+          - reference-id: CI-Tests
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: P4.1
+          - reference-id: P4.2
+          - reference-id: P4.3
+          - reference-id: P4.4
+          - reference-id: E2.4
+          - reference-id: E2.5
+      - reference-id: SAMM
+        entries:
+          - reference-id: Verification-Requirements -Testing -Control Verification Lvl1
+          - reference-id: Verification-Requirements -Testing -Control Verification Lvl2
+          - reference-id: Verification-Requirements -Testing -Control Verification Lvl3
+          - reference-id: Verification -Security Testing -Scalable Baseline Lvl3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.2.3
+          - reference-id: 6.3.1
+          - reference-id: 6.3.2
+          - reference-id: 6.4.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: SA-11
+          - reference-id: SA-15
+          - reference-id: SR-3                
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: QA.04
+          - reference-id: QA.05       
+    assessment-requirements:
+      - id: OSPS-QA-06.01
+        text: |
+          Prior to a commit being accepted, the project's CI/CD pipelines MUST
+          run at least one automated test suite to ensure the changes meet
+          expectations.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: | # give examples
+          Automated tests should be run prior to every merge into the primary
+          branch. The test suite should be run in a CI/CD pipeline and the
+          results should be visible to all contributors. The test suite should
+          be run in a consistent environment and should be run in a way that
+          allows contributors to run the tests locally.
+          Examples of test suites include unit tests, integration tests, and
+          end-to-end tests.
+      - id: OSPS-QA-06.02
+        text: |
+          While active, project's documentation MUST clearly document when and
+          how tests are run.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Add a section to the contributing documentation that explains how to
+          run the tests locally and how to run the tests in the CI/CD pipeline.
+          The documentation should explain what the tests are testing and how to
+          interpret the results.
+      - id: OSPS-QA-06.03
+        text: |
+          While active, the project's documentation MUST include a policy that
+          all major changes to the software produced by the project should add
+          or update tests of the functionality in an automated test suite.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Add a section to the contributing documentation that explains the
+          policy for adding or updating tests. The policy should explain what
+          constitutes a major change and what tests should be added or updated.
+
+  - id: OSPS-QA-07
+    title: |
+      Require Merge Approvals
+    objective: |
+      Ensure that the project's version control system requires at least one
+      non-author human approval of changes before merging into the release or
+      primary branch.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-G-3
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Code-Review
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G2.4
+          - reference-id: P3.3
+          - reference-id: P3.5
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.2.3.1
+          - reference-id: 6.4.2
+          - reference-id: 6.5.4
+      - reference-id: 800-161
+        entries:
+          - reference-id: AC-5
+          - reference-id: AU-6
+          - reference-id: PL-8
+          - reference-id: SA-15
+          - reference-id: SR-3                
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: QA.06
+    assessment-requirements:
+      - id: OSPS-QA-07.01
+        text: |
+          When a commit is made to the primary branch, the project's version
+          control system MUST require at least one non-author human approval of the
+          changes before merging.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Configure the project's version control system to require at least one
+          non-author human approval of changes before merging into the release or
+          primary branch. This can be achieved by requiring a pull request to be
+          reviewed and approved by at least one other collaborator before it can
+          be merged.

--- a/tests/darnit_baseline/fixtures/osps-baseline/OSPS-SA.yaml
+++ b/tests/darnit_baseline/fixtures/osps-baseline/OSPS-SA.yaml
@@ -1,0 +1,269 @@
+title: Security Assessment
+description: |
+  Security Assessment encourages practices that
+  help ensure that the project is well positioned
+  to identify and address security vulnerabilities
+  and threats in the software.
+controls:
+  - id: OSPS-SA-01
+    title: |
+      Publish Design Descriptions of System Actors and Actions
+    objective: |
+      Provide an overview of the project's design and architecture, illustrating
+      the interactions and components of the system to help contributors and
+      security reviewers understand the internal logic of the released software
+      assets.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-1
+          - reference-id: B-S-7
+          - reference-id: B-S-8
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2a
+          - reference-id: 1.2b
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.1
+          - reference-id: PO.2
+          - reference-id: PO.3.2
+      - reference-id: CSF
+        entries:
+          - reference-id: ID.AM-02
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 155-155
+          - reference-id: 326-704
+          - reference-id: 068-102
+          - reference-id: 036-275
+          - reference-id: 162-655
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G5.1
+          - reference-id: P1.1
+          - reference-id: E3.4
+          - reference-id: E3.7
+      - reference-id: SAMM
+        entries:
+          - reference-id: Operations -Operational Management -Data Protection Lvl2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.1
+          - reference-id: 2.2.3
+          - reference-id: 2.2.4
+          - reference-id: 2.2.5
+          - reference-id: 2.2.6
+          - reference-id: 3.1.1
+          - reference-id: 4.1.1
+          - reference-id: 5.1.1
+          - reference-id: 6.1.1
+          - reference-id: 6.2.1
+          - reference-id: 7.1.1
+          - reference-id: 8.1.1
+          - reference-id: 11.1.1
+          - reference-id: 12.3.1
+          - reference-id: 12.5.3
+      - reference-id: 800-161
+        entries:
+          - reference-id: CM-2
+          - reference-id: PL-8
+          - reference-id: RA-3
+          - reference-id: SA-15          
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.1.5
+    assessment-requirements:
+      - id: OSPS-SA-01.01
+        text: |
+          When the project has made a release, the project documentation MUST
+          include design documentation demonstrating all actions and actors
+          within the system.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Include designs in the project documentation that explains the actions
+          and actors. Actors include any subsystem or entity that can influence
+          another segment in the system.
+          Ensure this is updated for new features or breaking changes.
+
+  - id: OSPS-SA-02
+    title: |
+      Publish External Interface Descriptions
+    objective: |
+      Provide users and developers with an understanding of how to interact with
+      the project's software and integrate it with other systems, enabling them
+      to use the software effectively.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-B-10
+          - reference-id: B-S-7
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2a
+          - reference-id: 1.2b
+      - reference-id: SSDF
+        entries:
+          - reference-id: PW.1.2
+      - reference-id: CSF
+        entries:
+          - reference-id: GV.OC-05
+          - reference-id: ID.AM-01
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.4
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 155-155
+          - reference-id: 068-102
+          - reference-id: 072-713
+          - reference-id: 820-878
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: E3.4
+          - reference-id: E3.7
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.1
+          - reference-id: 2.2.3
+          - reference-id: 2.2.4
+          - reference-id: 2.2.5
+          - reference-id: 2.2.6
+          - reference-id: 6.2.1
+          - reference-id: 12.3.1
+          - reference-id: 12.8.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: CM-2
+          - reference-id: PL-2
+          - reference-id: PL-8
+          - reference-id: RA-3
+          - reference-id: SA-15           
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.1.5
+    assessment-requirements:
+      - id: OSPS-SA-02.01
+        text: |
+          When the project has made a release, the project documentation MUST
+          include descriptions of all external software interfaces of the
+          released software assets.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Document all software interfaces (APIs) of the released software
+          assets, explaining how users can interact with the software and what
+          data is expected or produced.
+          Ensure this is updated for new features or breaking changes.
+
+  - id: OSPS-SA-03
+    title: |
+      Maintain a Project Security Assessment
+    objective: |
+      Provide project maintainers an understanding of how the software can be
+      misused or broken, enabling them to plan mitigations accordingly.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-S-8
+          - reference-id: S-G-1
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.1
+          - reference-id: 1.2j
+          - reference-id: 1.2k
+          - reference-id: 2.2
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.5.1
+          - reference-id: PW.1.1
+      - reference-id: CSF
+        entries:
+          - reference-id: ID.RA-01
+          - reference-id: ID.RA-04
+          - reference-id: ID.RA-05
+          - reference-id: DE.AE-07
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.5
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 068-102
+          - reference-id: 154-031
+          - reference-id: 888-770
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G4.3
+          - reference-id: G5.2
+          - reference-id: P2.1
+      - reference-id: SAMM
+        entries:
+          - reference-id: Governance -Create and Promote Lvl1
+          - reference-id: Design -Threat Assessment -Application Risk Profile Lvl1
+          - reference-id: Design -Threat Assessment -Threat Modeling Lvl1
+          - reference-id: Verification -Architecture Assessment -Architecture Mitigation Lvl2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.2.4
+          - reference-id: 2.2.5
+          - reference-id: 2.2.6
+          - reference-id: 6.2.1
+          - reference-id: 6.2.3.1
+          - reference-id: 6.3.2
+          - reference-id: 6.4.2
+          - reference-id: 11.3.1
+          - reference-id: 12.3.1
+      - reference-id: 800-161
+        entries:
+          - reference-id: CA-2
+          - reference-id: CA-2(3)
+          - reference-id: PM-30
+          - reference-id: RA-3
+          - reference-id: SA-11
+          - reference-id: SA-15
+          - reference-id: SA-15(3)
+          - reference-id: SA-15(8)
+          - reference-id: SI-3
+          - reference-id: SR-3
+          - reference-id: SR-3(3)
+          - reference-id: SR-6
+          - reference-id: SR-7           
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.4.1
+    assessment-requirements:
+      - id: OSPS-SA-03.01
+        text: |
+          When the project has made a release, the project MUST perform a
+          security assessment to understand the most likely and impactful
+          potential security problems that could occur within the software.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Performing a security assessment informs both project members as well
+          as downstream consumers that the project understands what problems
+          could arise within the software. Understanding what threats could be
+          realized helps the project manage and address risk. This information
+          is useful to downstream consumers to demonstrate the security acumen
+          and practices of the project.
+          Ensure this is updated for new features or breaking changes.
+      - id: OSPS-SA-03.02
+        text: |
+          When the project has made a release, the project MUST perform a threat
+          modeling and attack surface analysis to understand and protect against
+          attacks on critical code paths, functions, and interactions within the
+          system.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Threat modeling is an activity where the project looks at the
+          codebase, associated processes and infrastructure, interfaces, key
+          components and "thinks like a hacker" and brainstorms how the system
+          be be broken or compromised. Each identified threat is listed out so
+          the project can then think about how to proactively avoid or close off
+          any gaps/vulnerabilities that could arise.
+          Ensure this is updated for new features or breaking changes.

--- a/tests/darnit_baseline/fixtures/osps-baseline/OSPS-VM.yaml
+++ b/tests/darnit_baseline/fixtures/osps-baseline/OSPS-VM.yaml
@@ -1,0 +1,573 @@
+title: Vulnerability Management
+description: |
+  Vulnerability Management focuses on the
+  processes and practices used to identify and
+  address security vulnerabilities in the project's
+  software dependencies. These controls help ensure
+  that the project is well positioned to respond to
+  security threats and vulnerabilities in the software.
+controls:
+  - id: OSPS-VM-01
+    title: |
+      Publish Coordinated Vulnerability Disclosure Policy
+    objective: |
+      Establish a process for reporting and addressing vulnerabilities in the
+      project, ensuring that security issues are handled promptly and
+      transparently.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: R-B-6
+          - reference-id: R-B-8
+          - reference-id: R-S-2
+          - reference-id: S-B-14
+          - reference-id: S-B-15
+      - reference-id: CRA
+        entries:
+          - reference-id: 2.1
+          - reference-id: 2.2
+          - reference-id: 2.3
+          - reference-id: 2.6
+          - reference-id: 2.7
+          - reference-id: 2.8
+      - reference-id: SSDF
+        entries:
+          - reference-id: RV.1.3
+      - reference-id: CSF
+        entries:
+          - reference-id: GV.PO-01
+          - reference-id: GV.PO-02
+          - reference-id: ID.RA-01
+          - reference-id: ID.RA-08
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.5
+          - reference-id: 4.2.1
+          - reference-id: 4.3.2
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 887-750
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Security-Policy
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: D1.1
+          - reference-id: D1.2
+          - reference-id: D1.3
+          - reference-id: D1.5
+      - reference-id: SAMM
+        entries:
+          - reference-id: Governance -Create and Promote Lvl2
+          - reference-id: Governance -Policy & Compliance -Policy & Standards Lvl1
+          - reference-id: Implementation -Defect Management -Defect Tracking Lvl1
+          - reference-id: Implementation -Defect Management -Defect Tracking Lvl2
+          - reference-id: Implementation -Defect Management -Defect Tracking Lvl3
+          - reference-id: Operations -Incident Management -Incident Response Lvl1
+          - reference-id: Operations -Incident Management -Incident Response Lvl2
+          - reference-id: Operations -Incident Management -Incident Response Lvl3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 2.1.1
+          - reference-id: 3.1.1
+          - reference-id: 4.1.1
+          - reference-id: 5.1.1
+          - reference-id: 6.1.1
+          - reference-id: 6.3.1
+          - reference-id: 6.3.2
+          - reference-id: 7.1.1
+          - reference-id: 8.1.1
+          - reference-id: 11.1.1
+          - reference-id: 11.2.1
+          - reference-id: 12.1.1
+          - reference-id: 12.1.3
+      - reference-id: 800-161
+        entries:
+          - reference-id: IR-1
+          - reference-id: IR-4
+          - reference-id: IR-6
+          - reference-id: IR-7(1)
+          - reference-id: IR-8
+          - reference-id: SI-2          
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 3.4.1
+          - reference-id: Claim 3.5.1
+          - reference-id: Claim 4.1.2
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: VM.01
+    assessment-requirements:
+      - id: OSPS-VM-01.01
+        text: |
+          While active, the project documentation MUST
+          include a policy for coordinated vulnerability disclosure (CVD), with a clear
+          timeframe for response.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Create a SECURITY.md file at the root of the directory, outlining the
+          project's policy for coordinated vulnerability disclosure. Include a
+          method for reporting vulnerabilities. Set expectations for how the
+          project will respond and address reported issues.
+
+  - id: OSPS-VM-02
+    title: |
+      Publish Contacts and Process for Reporting Vulnerabilities.
+    objective: |
+      Enable external parties, such as researchers, to easily understand who they 
+      should contact in the event that a vulnerability is found, and what process
+      they should follow.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-S-8
+      - reference-id: CRA
+        entries:
+          - reference-id: 2.5
+      - reference-id: SSDF
+        entries:
+          - reference-id: RV.1.3
+      - reference-id: CSF
+        entries:
+          - reference-id: GV.PO-01
+          - reference-id: GV.PO-02
+          - reference-id: ID.RA-01
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.1
+          - reference-id: 4.1.3
+          - reference-id: 4.1.5
+          - reference-id: 4.2.2
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 464-513
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Security-Policy
+      - reference-id: SAMM
+        entries:
+          - reference-id: Governance -Policy&Compliance -Policy&Standards Lvl2
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.3.3
+          - reference-id: 12.1.1
+          - reference-id: 12.10.2
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 3.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: IR-1
+          - reference-id: IR-4
+          - reference-id: IR-6
+          - reference-id: IR-8                
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: VM.01
+    assessment-requirements:
+      - id: OSPS-VM-02.01
+        text: |
+          While active, the project documentation MUST contain
+          security contacts.
+        applicability:
+          - Maturity Level 1
+        recommendation: |
+          Create a security.md (or similarly-named) file that contains security
+          contacts for the project.
+
+  - id: OSPS-VM-03
+    title: |
+      Maintain Private Vulnerability Reporting Process
+    objective: |
+      Provide a means for reporting privately to the security contacts within
+      the project so that security vulnerabilities are not be shared with the
+      public until the project has been provided time to analyze and prepare
+      remediations to protect users of the project.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: R-B-7
+      - reference-id: CRA
+        entries:
+          - reference-id: 2.5
+          - reference-id: 2.6
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 308-514
+      - reference-id: SAMM
+        entries:
+          - reference-id: Operations -Incident Management -Incident Response Lvl3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.3.1
+          - reference-id: 6.3.3
+          - reference-id: 12.10.2
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 3.2
+      - reference-id: 800-161
+        entries:
+          - reference-id: IR-6                
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: VM.01
+    assessment-requirements:
+      - id: OSPS-VM-03.01
+        text: |
+          While active, the project documentation MUST
+          provide a means for private vulnerability reporting directly to
+          the security contacts within the project.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Provide a means for security researchers to report vulnerabilities
+          privately to the project. This may be a dedicated email address, a
+          web form, VCS specialized tools, email addresses for security
+          contacts, or other methods.
+
+  - id: OSPS-VM-04
+    title: |
+      Publish Discovered Vulnerabilities
+    objective: |
+      Ensure that project end users have a well known mechanism to understand
+      vulnerabilities found within the project.
+    guideline-mappings:
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2a
+          - reference-id: 1.2b
+          - reference-id: 2.1
+          - reference-id: 2.4
+          - reference-id: 2.6
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.4.1
+          - reference-id: RV.2.1
+          - reference-id: RV.2.2
+      - reference-id: CSF
+        entries:
+          - reference-id: ID.RA-01
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.5
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G2.2
+          - reference-id: D1.1
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.2.3
+          - reference-id: 6.3.1
+          - reference-id: 6.3.2
+          - reference-id: 6.3.3
+          - reference-id: 11.3.1
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 3.4
+          - reference-id: 3.5
+          - reference-id: 4.3
+      - reference-id: 800-161
+        entries:
+          - reference-id: CA-7
+          - reference-id: CM-3
+          - reference-id: CM-8
+          - reference-id: IR-5
+          - reference-id: SI-2
+          - reference-id: SI-4
+          - reference-id: SI-5                
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: VM.02
+    assessment-requirements:
+      - id: OSPS-VM-04.01
+        text: |
+          While active, the project documentation MUST
+          publicly publish data about discovered vulnerabilities.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Provide information about known vulnerabilities in a predictable
+          public channel, such as a CVE entry, blog post, or other medium.
+          To the degree possible, this information should include affected
+          version(s), how a consumer can determine if they are vulnerable, and
+          instructions for mitigation or remediation.
+      - id: OSPS-VM-04.02
+        text: |
+          While active, any vulnerabilities in the
+          software components not affecting the project MUST be accounted for
+          in a VEX document, augmenting the vulnerability report with
+          non-exploitability details.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Establish a VEX feed communicating the exploitability status of
+          known vulnerabilities, including assessment details or any
+          mitigations in place preventing vulnerable code from being
+          executed.
+
+  - id: OSPS-VM-05
+    title: |
+      Publish and Enforce a Dependency Remediation Policy
+    objective: |
+      Identify and address defects and security weaknesses in the project's
+      imported code early in the development process, reducing the risk of
+      shipping insecure software.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-S-8
+          - reference-id: Q-B-12
+          - reference-id: Q-S-9
+          - reference-id: S-B-14
+          - reference-id: S-B-15
+          - reference-id: A-B-1
+          - reference-id: A-B-3
+          - reference-id: A-B-8
+          - reference-id: A-S-1
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2a
+          - reference-id: 1.2b
+          - reference-id: 1.2c
+          - reference-id: 2.1
+          - reference-id: 2.2
+          - reference-id: 2.3
+          - reference-id: 2.4
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.4
+          - reference-id: PW.1.2
+          - reference-id: PW.8.1
+          - reference-id: RV.1.2
+          - reference-id: RV.1.3
+          - reference-id: RV.2.1
+          - reference-id: RV.2.2
+      - reference-id: CSF
+        entries:
+          - reference-id: GV.RM-05
+          - reference-id: GV.RM-06
+          - reference-id: GV.PO-01
+          - reference-id: GV.PO-02
+          - reference-id: ID.RA-01
+          - reference-id: ID.RA-08
+          - reference-id: ID.IM-02
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.5
+          - reference-id: 4.2.1
+          - reference-id: 4.2.2
+          - reference-id: 4.3.2
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 155-155
+          - reference-id: 124-564
+          - reference-id: 757-271
+          - reference-id: 464-513
+          - reference-id: 611-158
+          - reference-id: 207-435
+          - reference-id: 088-377
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Security-Policy
+          - reference-id: Vulnerabilities
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G5.4
+          - reference-id: P4.1
+          - reference-id: P4.2
+          - reference-id: P4.3
+          - reference-id: P4.4
+          - reference-id: P4.5
+      - reference-id: SAMM
+        entries:
+          - reference-id: Implementation -Secure Build-Build Process Lvl3
+          - reference-id: Implementation -Software Dependencies Lvl3
+          - reference-id: Verification -Security Testing -Scalable Baseline Lvl1
+          - reference-id: Verification -Security Testing -Scalable Baseline Lvl3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.2.3
+          - reference-id: 6.3.1
+          - reference-id: 6.3.2
+          - reference-id: 6.4.1
+          - reference-id: 6.4.2
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 1.2
+          - reference-id: 3.3
+      - reference-id: 800-161
+        entries:
+          - reference-id: CA-7
+          - reference-id: RA-5
+          - reference-id: SA-11
+          - reference-id: SI-2
+          - reference-id: SI-3                
+    assessment-requirements:
+      - id: OSPS-VM-05.01
+        text: |
+          While active, the project documentation MUST include a policy that
+          defines a threshold for remediation of SCA findings related to
+          vulnerabilities and licenses.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Document a policy in the project that defines a threshold for
+          remediation of SCA findings related to vulnerabilities and licenses.
+          Include the process for identifying, prioritizing, and remediating
+          these findings.
+      - id: OSPS-VM-05.02
+        text: |
+          While active, the project documentation MUST include a policy to
+          address SCA violations prior to any release.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Document a policy in the project to address applicable Software
+          Composition Analysis results before any release, and add status checks
+          that verify compliance with that policy prior to release.
+      - id: OSPS-VM-05.03
+        text: |
+          While active, all changes to the project's codebase MUST be
+          automatically evaluated against a documented policy for malicious
+          dependencies and known vulnerabilities in dependencies, then blocked
+          in the event of violations, except when declared and suppressed as
+          non-exploitable.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Create a status check in the project's version control system that
+          runs a Software Composition Analysis tool on all changes
+          to the codebase. Require that the status check passes before changes
+          can be merged.
+
+  - id: OSPS-VM-06
+    title: |
+      Publish and Enforce an Application Security Testing Policy
+    objective: |
+      Identify and address defects and security weaknesses in the project's
+      codebase early in the development process, reducing the risk of shipping
+      insecure software.
+    guideline-mappings:
+      - reference-id: BPB
+        entries:
+          - reference-id: B-S-8
+          - reference-id: Q-B-12
+          - reference-id: Q-S-9
+          - reference-id: S-B-14
+          - reference-id: S-B-15
+          - reference-id: A-B-1
+          - reference-id: A-B-3
+          - reference-id: A-B-8
+          - reference-id: A-S-1
+      - reference-id: CRA
+        entries:
+          - reference-id: 1.2a
+          - reference-id: 1.2b
+          - reference-id: 1.2c
+          - reference-id: 2.1
+          - reference-id: 2.2
+          - reference-id: 2.3
+          - reference-id: 2.4
+      - reference-id: SSDF
+        entries:
+          - reference-id: PO.4
+          - reference-id: PW.1.2
+          - reference-id: PW.8.1
+          - reference-id: RV.1.2
+          - reference-id: RV.1.3
+          - reference-id: RV.2.1
+          - reference-id: RV 2.2
+      - reference-id: CSF
+        entries:
+          - reference-id: GV.RM-05
+          - reference-id: GV.RM-06
+          - reference-id: GV.PO-01
+          - reference-id: GV.PO-02
+          - reference-id: ID.RA-01
+          - reference-id: ID.RA-08
+          - reference-id: ID.IM-02
+      - reference-id: ISO-18974
+        entries:
+          - reference-id: 4.1.5
+          - reference-id: 4.2.1
+          - reference-id: 4.2.2
+          - reference-id: 4.3.2
+      - reference-id: OpenCRE
+        entries:
+          - reference-id: 155-155
+          - reference-id: 124-564
+          - reference-id: 757-271
+          - reference-id: 464-513
+          - reference-id: 611-158
+          - reference-id: 207-435
+          - reference-id: 088-377
+      - reference-id: Scorecard
+        entries:
+          - reference-id: Security-Policy
+          - reference-id: Vulnerabilities
+          - reference-id: SAST
+      - reference-id: PSSCRM
+        entries:
+          - reference-id: G5.4
+          - reference-id: P4.1
+          - reference-id: P4.2
+          - reference-id: P4.3
+          - reference-id: P4.4
+          - reference-id: P4.5
+      - reference-id: SAMM
+        entries:
+          - reference-id: Implementation -Secure Build-Build Process Lvl3
+          - reference-id: Implementation -Software Dependencies Lvl3
+          - reference-id: Verification -Security Testing -Scalable Baseline Lvl1
+          - reference-id: Verification -Security Testing -Scalable Baseline Lvl3
+      - reference-id: PCIDSS
+        entries:
+          - reference-id: 6.2.3
+          - reference-id: 6.3.1
+          - reference-id: 6.3.2
+          - reference-id: 6.4.1
+          - reference-id: 6.4.2
+          - reference-id: 6.5.2
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: 1.3
+          - reference-id: 1.4
+      - reference-id: 800-161
+        entries:
+          - reference-id: CA-7
+          - reference-id: RA-5
+          - reference-id: SA-11
+          - reference-id: SI-2
+          - reference-id: SI-3     
+      - reference-id: BSI-TR-03185-2
+        entries:
+          - reference-id: QA.05
+    assessment-requirements:
+      - id: OSPS-VM-06.01
+        text: |
+          While active, the project documentation MUST include a policy that
+          defines a threshold for remediation of SAST findings.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Document a policy in the project that defines a threshold for
+          remediation of Static Application Security Testing (SAST) findings.
+          Include the process for identifying, prioritizing, and remediating
+          these findings.
+      - id: OSPS-VM-06.02
+        text: |
+          While active, all changes to the project's codebase MUST be
+          automatically evaluated against a documented policy for security
+          weaknesses and blocked in the event of violations except when declared
+          and suppressed as non-exploitable.
+        applicability:
+          - Maturity Level 3
+        recommendation: |
+          Create a status check in the project's version control system that
+          runs a Static Application Security Testing (SAST) tool on all changes
+          to the codebase. Require that the status check passes before changes
+          can be merged.

--- a/tests/darnit_baseline/fixtures/osps-baseline/README.md
+++ b/tests/darnit_baseline/fixtures/osps-baseline/README.md
@@ -1,0 +1,29 @@
+# Vendored OSPS Baseline (source-of-truth for the per-level regression test)
+
+This directory contains an exact copy of the `baseline/OSPS-*.yaml` files from
+[ossf/security-baseline](https://github.com/ossf/security-baseline) at tag
+`v2026.02.19`.
+
+The per-level regression test at
+`tests/darnit_baseline/test_level_counts.py` parses these files as the
+authoritative applicability map for the `spec_version` pinned in the
+darnit-baseline implementation.
+
+## Bumping the pinned version
+
+1. Fetch new files: for each `OSPS-XX.yaml`, replace with the version at the
+   target upstream tag (`raw.githubusercontent.com/ossf/security-baseline/<TAG>/baseline/OSPS-XX.yaml`).
+2. Update `spec_version` in `packages/darnit-baseline/src/darnit_baseline/implementation.py`.
+3. Update the tag reference in this README.
+4. Run `uv run pytest tests/darnit_baseline/test_level_counts.py -v`. If it
+   fails, the diff will list the specific control-level drift; reconcile
+   `packages/darnit-baseline/openssf-baseline.toml` accordingly.
+5. Update the counts in `docs/USAGE_GUIDE.md`.
+
+## Vendored at
+
+- Upstream repo: https://github.com/ossf/security-baseline
+- Upstream tag: `v2026.02.19`
+- Vendored on: 2026-07-31
+- Files copied verbatim (no reformatting) so future bumps produce a
+  reviewable diff.

--- a/tests/darnit_baseline/test_implementation.py
+++ b/tests/darnit_baseline/test_implementation.py
@@ -22,7 +22,7 @@ class TestOSPSBaselineImplementation:
         assert impl.name == "openssf-baseline"
         assert impl.display_name == "OpenSSF Baseline"
         assert impl.version == "0.1.0"
-        assert impl.spec_version == "OSPS v2025.10.10"
+        assert impl.spec_version == "OSPS v2026.02.19"
 
     @pytest.mark.unit
     def test_is_compliance_implementation(self, impl):

--- a/tests/darnit_baseline/test_level_counts.py
+++ b/tests/darnit_baseline/test_level_counts.py
@@ -1,0 +1,209 @@
+"""Per-level control-count regression test.
+
+Compares darnit's `openssf-baseline.toml` level tags against the applicability
+lists in the vendored upstream OSPS Baseline YAML for the pinned spec_version.
+Blocks CI on drift.
+
+Convention: each upstream control is assigned to its *lowest* applicable
+maturity level. Darnit's single-integer `level` field mirrors that lowest
+level. Controls tagged `deprecated = true` or `darnit_specific = true` are
+excluded from the comparison (they are darnit-only annotations, not upstream
+controls).
+
+Bumping the pinned spec_version: update `spec_version` in
+`packages/darnit-baseline/src/darnit_baseline/implementation.py`, re-vendor
+the fixtures under `tests/darnit_baseline/fixtures/osps-baseline/`, and
+update the tag reference in that directory's README.
+"""
+
+from __future__ import annotations
+
+import glob
+import re
+import tomllib
+from collections import Counter
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "osps-baseline"
+BASELINE_TOML = REPO_ROOT / "packages" / "darnit-baseline" / "openssf-baseline.toml"
+
+# Bump alongside the vendored fixture files and the spec_version in
+# packages/darnit-baseline/src/darnit_baseline/implementation.py.
+EXPECTED_UPSTREAM_TAG = "v2026.02.19"
+
+# Runtime counts a user sees when running `darnit audit --level N`. Includes
+# darnit-retained controls that are deprecated upstream (e.g., BR-01.02).
+# Documented in docs/USAGE_GUIDE.md; update alongside a spec_version bump.
+EXPECTED_RUNTIME_COUNTS = {1: 25, 2: 19, 3: 21}
+
+# Upstream OSPS Baseline per-level counts under the lowest-applicable-level
+# convention. Excludes controls that darnit retains but upstream has retired.
+EXPECTED_UPSTREAM_COUNTS = {1: 24, 2: 19, 3: 21}
+
+# Matches "maturity-N" (slug) and "Maturity Level N" (human string).
+_LEVEL_RE = re.compile(r"maturity[-_ ]?(\d)|Maturity Level (\d)", re.IGNORECASE)
+
+
+def _parse_level(app: str) -> int | None:
+    match = _LEVEL_RE.search(app)
+    if not match:
+        return None
+    return int(match.group(1) or match.group(2))
+
+
+def _load_upstream_lowest_levels() -> dict[str, int]:
+    """Walk vendored YAML; return {control_id: lowest_maturity_level}.
+
+    Controls with only 'retired' applicability (no maturity levels) are omitted.
+    """
+    result: dict[str, int] = {}
+    for path in sorted(glob.glob(str(FIXTURE_DIR / "*.yaml"))):
+        with open(path) as fh:
+            doc = yaml.safe_load(fh)
+
+        def walk(node: object) -> None:
+            if isinstance(node, dict):
+                cid = node.get("id")
+                app = node.get("applicability")
+                if isinstance(cid, str) and cid.startswith("OSPS-") and isinstance(app, list):
+                    levels = sorted({lvl for a in app if isinstance(a, str) and (lvl := _parse_level(a)) is not None})
+                    if levels:
+                        result[cid] = levels[0]
+                for value in node.values():
+                    walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    walk(item)
+
+        walk(doc)
+    return result
+
+
+def _load_darnit_levels(exclude_deprecated: bool = False, exclude_darnit_specific: bool = False) -> dict[str, int]:
+    """Return {control_id: level} for every OSPS control in darnit's TOML.
+
+    Args:
+        exclude_deprecated: skip controls tagged `deprecated = true` (use when
+            comparing against upstream, which does not carry retired controls).
+        exclude_darnit_specific: skip controls tagged `darnit_specific = true`.
+    """
+    with open(BASELINE_TOML, "rb") as fh:
+        config = tomllib.load(fh)
+
+    result: dict[str, int] = {}
+    for cid, ctrl in config.get("controls", {}).items():
+        if not cid.startswith("OSPS-"):
+            continue
+        tags = ctrl.get("tags") or {}
+        if exclude_deprecated and tags.get("deprecated"):
+            continue
+        if exclude_darnit_specific and tags.get("darnit_specific"):
+            continue
+        level = ctrl.get("level") if ctrl.get("level") is not None else tags.get("level")
+        if level is None:
+            pytest.fail(f"Control {cid} has no level tag in openssf-baseline.toml")
+        result[cid] = level
+    return result
+
+
+@pytest.mark.unit
+def test_fixture_tag_matches_pinned_spec_version() -> None:
+    """The vendored fixture's README must reference the same upstream tag
+    the implementation pins via spec_version. A mismatch means someone
+    updated one without the other."""
+    readme = (FIXTURE_DIR / "README.md").read_text()
+    assert f"`{EXPECTED_UPSTREAM_TAG}`" in readme, (
+        f"Fixture README does not reference expected upstream tag {EXPECTED_UPSTREAM_TAG!r}. "
+        f"Update {FIXTURE_DIR / 'README.md'} to match the pinned spec_version."
+    )
+
+    from darnit_baseline.implementation import OSPSBaselineImplementation
+
+    impl = OSPSBaselineImplementation()
+    assert impl.spec_version.endswith(EXPECTED_UPSTREAM_TAG), (
+        f"Implementation spec_version {impl.spec_version!r} does not end with "
+        f"expected upstream tag {EXPECTED_UPSTREAM_TAG!r}. Bump one or the other."
+    )
+
+
+@pytest.mark.unit
+def test_darnit_level_tags_match_upstream_applicability() -> None:
+    """For each control that exists in BOTH darnit and upstream, darnit's
+    `level` tag must equal upstream's lowest maturity level. Darnit-retained
+    upstream-retired controls (deprecated=true) are excluded from this
+    comparison because upstream no longer has them."""
+    upstream = _load_upstream_lowest_levels()
+    darnit = _load_darnit_levels(exclude_deprecated=True)
+
+    common = set(upstream) & set(darnit)
+    mismatches = [
+        (cid, darnit[cid], upstream[cid])
+        for cid in sorted(common)
+        if darnit[cid] != upstream[cid]
+    ]
+
+    only_upstream = sorted(set(upstream) - set(darnit))
+    only_darnit = sorted(set(darnit) - set(upstream))
+
+    if mismatches or only_upstream or only_darnit:
+        lines = ["Darnit level tags drift from upstream OSPS Baseline:"]
+        if mismatches:
+            lines.append("  Level mismatches (control: darnit -> upstream_lowest):")
+            for cid, dl, ul in mismatches:
+                lines.append(f"    {cid}: L{dl} -> L{ul}")
+        if only_upstream:
+            lines.append("  Controls in upstream but missing in darnit:")
+            for cid in only_upstream:
+                lines.append(f"    {cid} (upstream lowest = L{upstream[cid]})")
+        if only_darnit:
+            lines.append("  Controls in darnit but not in upstream (mark as darnit_specific or deprecated):")
+            for cid in only_darnit:
+                lines.append(f"    {cid} (darnit level = L{darnit[cid]})")
+        pytest.fail("\n".join(lines))
+
+
+@pytest.mark.unit
+def test_runtime_per_level_counts_match_documented_values() -> None:
+    """User-facing counts: what `darnit audit --level N` will evaluate.
+    Includes all controls a user's audit will run against, including any
+    darnit-retained upstream-retired ones."""
+    darnit = _load_darnit_levels()
+    counts = Counter(darnit.values())
+    actual = {1: counts[1], 2: counts[2], 3: counts[3]}
+    assert actual == EXPECTED_RUNTIME_COUNTS, (
+        f"Runtime per-level counts drift from documented values.\n"
+        f"  Actual:     {actual}\n"
+        f"  Documented: {EXPECTED_RUNTIME_COUNTS}\n"
+        f"  Update docs/USAGE_GUIDE.md if the new counts are intentional, "
+        f"or reconcile openssf-baseline.toml."
+    )
+
+
+@pytest.mark.unit
+def test_upstream_parity_counts_match() -> None:
+    """Upstream-parity: darnit's per-level counts (excluding deprecated and
+    darnit_specific) equal the vendored upstream's lowest-level counts."""
+    upstream = _load_upstream_lowest_levels()
+    darnit = _load_darnit_levels(exclude_deprecated=True, exclude_darnit_specific=True)
+
+    up_counts = Counter(upstream.values())
+    d_counts = Counter(darnit.values())
+    up_actual = {1: up_counts[1], 2: up_counts[2], 3: up_counts[3]}
+    d_actual = {1: d_counts[1], 2: d_counts[2], 3: d_counts[3]}
+
+    assert up_actual == EXPECTED_UPSTREAM_COUNTS, (
+        f"Vendored upstream v2026.02.19 counts drift from EXPECTED_UPSTREAM_COUNTS.\n"
+        f"  From fixture: {up_actual}\n"
+        f"  Expected:     {EXPECTED_UPSTREAM_COUNTS}\n"
+        f"  Update EXPECTED_UPSTREAM_COUNTS in this test file."
+    )
+    assert d_actual == EXPECTED_UPSTREAM_COUNTS, (
+        f"Darnit's upstream-parity counts drift from expected.\n"
+        f"  Darnit (excluding deprecated/darnit_specific): {d_actual}\n"
+        f"  Expected (from upstream):                       {EXPECTED_UPSTREAM_COUNTS}\n"
+        f"  Reconcile openssf-baseline.toml level tags."
+    )


### PR DESCRIPTION
## Summary
- **Fixes issue #342**: OSPS-LE-01.01 was tagged L1 in darnit but is L2 upstream. Reclassified so Level 1 audits stop over-scoping. Docs' 24/L1 target now matches upstream applicability (subject to the caveats below).
- **Bumps `spec_version`** from `OSPS v2025.10.10` (a label that did not resolve to any upstream ref) to `OSPS v2026.02.19` (the real release tag on `ossf/security-baseline`).
- **Adds 3 controls that upstream v2026.02.19 defines but darnit lacked**: `OSPS-BR-01.03`, `OSPS-BR-01.04`, `OSPS-DO-07.01`. See caveats.
- **Marks `OSPS-BR-01.02` deprecated** (upstream retired it in `ossf/security-baseline#443`); retained because the underlying `github.head_ref` sanitization concern is still valid.
- **New regression test** at `tests/darnit_baseline/test_level_counts.py` vendors the upstream YAML fixtures and blocks CI on any per-level drift going forward.

## Scope note
The spec (`specs/019-verdict-correctness/spec.md`) originally scoped this as a one-line TOML fix + regression test. The scope expanded once we discovered that (a) the pinned spec version was a fictional label with no upstream ref, and (b) upstream had drifted since darnit's last vendor. Choice was made in-thread to bump to v2026.02.19 rather than retro-pin to a commit sha, which meant adding the 3 upstream controls. Issue #343 (branch-protection WARN vs FAIL) is bundled at spec level only and ships in a separate PR.

## Caveats
- **BR-01.03 and BR-01.04 ship with manual passes only.** Both require workflow parsing (understanding `pull_request_target` triggers, secrets scoping, input interpolation). Auto-verification is a separate follow-up.
- **DO-07.01** uses a broad regex to match common build-instruction section headers across README/CONTRIBUTING/BUILD/INSTALL variants; false negatives possible for projects that document builds without a recognizable section header.
- **Runtime L1 count is 25 (not 24)** because deprecated `BR-01.02` is still evaluated. Upstream-parity count (excluding deprecated) is 24. Both are asserted; docs explain the discrepancy.

## Test plan
- [x] `uv run pytest tests/darnit_baseline/test_level_counts.py -v` (4 passed)
- [x] `uv run pytest tests/ --ignore=tests/integration/ -m "not upstream" -q` (2258 passed, 6 skipped)
- [x] `uv run ruff check .` (clean)
- [x] `uv run python scripts/validate_sync.py --verbose` (65 controls, all validations pass)
- [x] Manual: `impl.get_controls_by_level(N)` returns expected sets; LE-01.01 not in L1, DO-07.01 in L2, BR-01.04 in L3
- [ ] Reviewer: check the 3 new-control TOML definitions for sensibility of pass definitions and remediation steps

## Follow-ups (out of scope for this PR)
- Auto-verification for BR-01.03 / BR-01.04 (workflow-parser needed)
- Semantic-content mismatch for LE-01.01: darnit implements it as a LICENSE-file check ("HasLicense") but upstream OSPS defines LE-01.01 as DCO/CLA contribution track (`research.md` R6)
- US2 in this feature: sieve orchestrator CEL post-step fix for definitive-negative branch-protection responses (issue #343)
- Modernize existing controls' `docs_url` from `.../versions/2025-10-10#...` to `.../versions/2026-02-19#...` (bulk find/replace, mechanical)

Refs: #342