### PR TITLE
fix(baseline): update TOML spec_version to v2026.02.19 (follow-up to #349)

### DIFF
--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -1,7 +1,7 @@
 # OpenSSF Baseline Framework Definition
-# Declarative configuration for OSPS v2025.10.10 compliance controls
+# Declarative configuration for OSPS v2026.02.19 compliance controls
 #
-# This file defines all 62 controls across 3 maturity levels.
+# This file defines all 65 controls across 3 maturity levels.
 # Users can override settings via .baseline.toml in their repository.
 
 [metadata]
@@ -9,7 +9,7 @@ name = "openssf-baseline"
 display_name = "OpenSSF Baseline"
 version = "0.1.0"
 schema_version = "0.1.0-alpha"  # TOML config format version - expect breaking changes
-spec_version = "OSPS v2025.10.10"
+spec_version = "OSPS v2026.02.19"
 description = "OpenSSF Baseline security controls for open source projects"
 url = "https://baseline.openssf.org/"
 


### PR DESCRIPTION
## Summary
- PR #349 bumped ``OSPSBaselineImplementation.spec_version`` in Python to ``OSPS v2026.02.19`` but missed the two matching strings inside ``packages/darnit-baseline/openssf-baseline.toml`` itself: the file-header comment (line 2) and the ``[metadata].spec_version`` field (line 12).
- ``darnit list`` reads from the TOML, so after #349 it still reported ``OSPS v2025.10.10`` even though every other surface said v2026.02.19. Same bug class #349 was meant to eliminate (a version label that does not resolve to anything real), just at a different layer of the stack.
- Also updates the header comment's control count from ``62`` to ``65`` to match the post-#349 inventory.

## How this was missed
The regression test asserts against ``impl.spec_version`` (the Python property), not against the TOML ``[metadata].spec_version``. The two are independent variables; nothing enforces they agree. Follow-up worth considering: add an assertion in ``tests/darnit_baseline/test_level_counts.py::test_fixture_tag_matches_pinned_spec_version`` that both fields point to the same tag. Filed here as a note rather than as part of this PR to keep the diff minimal.

## Test plan
- [x] ``darnit list`` reports ``Spec: OSPS v2026.02.19``
- [x] ``uv run pytest tests/darnit_baseline/test_level_counts.py -v`` still passes (4 tests)
- [x] ``uv run python scripts/validate_sync.py --verbose`` passes

Refs: #349, #342