### PR TITLE
fix(sieve): preserve handler-conclusive FAIL through CEL post-step (#343)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/019-verdict-correctness"}
+{"feature_directory": "specs/020-definitive-fail-verdict"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,5 +370,5 @@ else:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[`specs/019-verdict-correctness/plan.md`](specs/019-verdict-correctness/plan.md)
+[`specs/020-definitive-fail-verdict/plan.md`](specs/020-definitive-fail-verdict/plan.md)
 <!-- SPECKIT END -->

--- a/packages/darnit-baseline/openssf-baseline.toml
+++ b/packages/darnit-baseline/openssf-baseline.toml
@@ -768,15 +768,21 @@ output_format = "json"
 expr = '!output.json.exists(f, f.ident == "template-injection")'
 timeout = 60
 
-# Fallback: regex scan for common injection patterns (if zizmor not installed)
+# Fallback: grep scan for common injection patterns (used when zizmor is
+# not installed). We use `sh -c '! grep ...'` so the exec handler's exit
+# code directly encodes compliance: 0 means grep found no injection
+# patterns (clean, PASS); 1 means grep found at least one (unsafe, FAIL).
+# This avoids the CEL-inversion idiom (handler FAIL + CEL negation -> PASS)
+# that feature 020 no longer supports; see contracts/cel-post-step.md.
 [[controls."OSPS-BR-01.01".passes]]
-handler = "pattern"
-files = [".github/workflows/*.yml", ".github/workflows/*.yaml"]
-pass_if_any = false
-expr = '!(output.any_match)'
-
-[controls."OSPS-BR-01.01".passes.pattern.patterns]
-injection_risk = "\\$\\{\\{\\s*github\\.(event\\.issue|event\\.pull_request|head_ref)"
+handler = "exec"
+command = [
+    "sh", "-c",
+    "! grep -rEq --include='*.yml' --include='*.yaml' '\\$\\{\\{\\s*github\\.(event\\.issue|event\\.pull_request|head_ref)' .github/workflows 2>/dev/null",
+]
+pass_exit_codes = [0]
+fail_exit_codes = [1]
+timeout = 10
 
 [[controls."OSPS-BR-01.01".passes]]
 handler = "manual"
@@ -1430,11 +1436,13 @@ search_for = "bug report, issue template, report bugs"
 check_files = ["README.md", "CONTRIBUTING.md"]
 look_for_urls = false
 
-[[controls."OSPS-DO-02.01".passes]]
-handler = "file_exists"
-use_locator = true
-expr = 'has(output.found_file)'
-
+# Pass 1 (formerly file_exists + expr='has(output.found_file)') was removed
+# in feature 020: its FAIL-then-CEL-false chain relied on the pre-020
+# orchestrator behavior that demoted handler FAIL to INCONCLUSIVE on CEL
+# disagreement. That's no longer legal, and the file_exists pass was
+# redundant with the pattern pass below (which already scans the same
+# bug*.md/bug*.yml/bug*.yaml/ISSUE_TEMPLATE.md files, plus README and
+# CONTRIBUTING). See specs/020-definitive-fail-verdict/contracts/cel-post-step.md.
 [[controls."OSPS-DO-02.01".passes]]
 handler = "pattern"
 files = [

--- a/packages/darnit/src/darnit/sieve/orchestrator.py
+++ b/packages/darnit/src/darnit/sieve/orchestrator.py
@@ -30,15 +30,29 @@ def _apply_cel_expr(
     handler_config: dict[str, Any],
     handler_result: "HandlerResult",
 ) -> "HandlerResult":
-    """Evaluate a CEL ``expr`` against handler evidence, overriding the verdict.
+    """Evaluate a CEL ``expr`` against handler evidence, refining the verdict.
 
     Only runs when ``handler_config`` contains ``expr`` and the handler returned
-    PASS or FAIL.  Returns the original result unchanged if no ``expr`` is
+    PASS or FAIL. Returns the original result unchanged if no ``expr`` is
     present, the handler returned ERROR/INCONCLUSIVE, or CEL evaluation fails.
 
-    CEL true  → PASS
-    CEL false → INCONCLUSIVE (pipeline continues)
-    CEL error → fall through to handler's own verdict
+    Transition table (handler status x CEL result -> post-step status):
+
+    +-----------+----------+----------------------------------------------+
+    | Handler   | CEL true | CEL false                                    |
+    +===========+==========+==============================================+
+    | PASS      | PASS     | INCONCLUSIVE (handler and CEL disagree)      |
+    +-----------+----------+----------------------------------------------+
+    | FAIL      | INCONC.  | FAIL (both agree; conclusive non-compliance) |
+    +-----------+----------+----------------------------------------------+
+
+    Rationale: when the handler and CEL agree, keep the conclusion. When
+    they disagree, defer to INCONCLUSIVE so the pipeline continues to the
+    next pass. This restores the constitution's Principle V ("orchestrator
+    stops at first conclusive result") and closes issue #343 (definitive
+    "Branch not protected" API responses now resolve FAIL instead of WARN).
+
+    See ``specs/020-definitive-fail-verdict/contracts/cel-post-step.md``.
     """
     expr = handler_config.get("expr")
     if not expr:
@@ -57,25 +71,38 @@ def _apply_cel_expr(
         cel_context = {"output": handler_result.evidence or {}}
         cel_result = evaluate_cel(expr, cel_context)
 
-        if cel_result.success:
-            evidence = dict(handler_result.evidence or {})
-            evidence["expr"] = expr
-            if cel_result.value:
+        if not cel_result.success:
+            logger.warning("CEL evaluation failed for expr=%r: %s", expr, cel_result.error)
+            return handler_result
+
+        evidence = dict(handler_result.evidence or {})
+        evidence["expr"] = expr
+        agreement = (
+            (handler_result.status == HandlerResultStatus.PASS and bool(cel_result.value))
+            or (handler_result.status == HandlerResultStatus.FAIL and not cel_result.value)
+        )
+        if agreement:
+            # Both handler and CEL point at the same verdict — preserve it.
+            if handler_result.status == HandlerResultStatus.PASS:
                 return HandlerResult(
                     status=HandlerResultStatus.PASS,
-                    message="CEL expression passed",
+                    message="Handler and CEL agree: pass",
                     confidence=1.0,
                     evidence=evidence,
                 )
-            else:
-                return HandlerResult(
-                    status=HandlerResultStatus.INCONCLUSIVE,
-                    message="CEL expression evaluated to false",
-                    evidence=evidence,
-                )
-        else:
-            logger.warning("CEL evaluation failed for expr=%r: %s", expr, cel_result.error)
-            return handler_result
+            # Handler FAIL + CEL false: definitive non-compliance (issue #343).
+            return HandlerResult(
+                status=HandlerResultStatus.FAIL,
+                message="Handler and CEL agree: fail",
+                confidence=1.0,
+                evidence=evidence,
+            )
+        # Disagreement (PASS+false or FAIL+true) -> defer to next pass.
+        return HandlerResult(
+            status=HandlerResultStatus.INCONCLUSIVE,
+            message="Handler and CEL disagree, evaluation inconclusive",
+            evidence=evidence,
+        )
     except Exception as e:
         logger.warning("CEL evaluator unavailable for expr=%r: %s: %s", expr, type(e).__name__, e)
         return handler_result

--- a/specs/019-verdict-correctness/tasks.md
+++ b/specs/019-verdict-correctness/tasks.md
@@ -68,6 +68,12 @@ description: "Task list for feature 019: verdict correctness fixes (issues #342 
 
 ## Phase 4: User Story 2 - Definitive "not protected" is reported as failing (Priority: P1) MVP-B
 
+> **Superseded by feature 020.** US2 was lifted into its own feature
+> (`specs/020-definitive-fail-verdict/`) after US1 shipped as PR #349,
+> per the "one PR per feature" pattern that emerged during US1
+> implementation. See feature 020's spec/plan/tasks for the current work
+> plan; the tasks below are retained for historical context only.
+
 **Goal**: Branch-protection controls report FAIL (not WARN) when the GitHub API returns HTTP 404 with body "Branch not protected". The fix modifies the sieve orchestrator's CEL post-step so a handler-conclusive FAIL is preserved when the CEL expression also evaluates falsy (see `contracts/cel-post-step.md`).
 
 **Independent Test**: `uv run pytest tests/darnit_baseline/controls/test_branch_protection.py -v` passes; all four named controls (`OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`) resolve to FAIL against a stubbed 404 response (from `quickstart.md` US2 path b).

--- a/specs/020-definitive-fail-verdict/checklists/requirements.md
+++ b/specs/020-definitive-fail-verdict/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Preserve handler-conclusive FAIL through the CEL post-step
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Single user story (US1), P1. Framework-level fix (`orchestrator.py:60-75`) with 12 downstream controls affected; 4 named as acceptance bar.
+- FR-004/FR-005/FR-006/FR-009 are "unchanged from today" statements. These are intentional guards documented as requirements so the plan's constitution check can point at them.
+- SC-005 makes the nondeterministic path an explicit success criterion. This is a lesson from feature 019 US1 where deterministic unit tests told a different story than the actual product behavior.
+- Ready for `/speckit-plan`; contracts + research from feature 019 can be lifted and adapted.

--- a/specs/020-definitive-fail-verdict/contracts/cel-post-step.md
+++ b/specs/020-definitive-fail-verdict/contracts/cel-post-step.md
@@ -1,0 +1,65 @@
+# Contract: sieve orchestrator CEL post-step
+
+**Scope:** internal framework contract between `packages/darnit/src/darnit/sieve/orchestrator.py` and its callers (the sieve orchestrator itself). Not a public API. Not a plugin protocol.
+
+**Function:** `_apply_cel_expr(handler_config, handler_result) -> HandlerResult`.
+
+**Status:** the "New behavior" column below is what feature 020 (`specs/020-definitive-fail-verdict/`) implements. The "Current behavior" column is what ships as of PR #349 and is the root cause of issue #343. This contract file was originally drafted for feature 019 US2 and lifted into feature 020 when US2 was split into its own PR.
+
+## Current behavior (before this spec)
+
+Given a handler that returned PASS or FAIL (INCONCLUSIVE / ERROR are passed through unchanged) and a pass config carrying a CEL `expr`:
+
+| Handler status | CEL result | Post-step status |
+|----------------|------------|------------------|
+| PASS           | true       | PASS             |
+| PASS           | false      | INCONCLUSIVE     |
+| FAIL           | true       | **PASS**         |
+| FAIL           | false      | **INCONCLUSIVE** |
+
+The last two rows are the root cause of issue #343: a handler-conclusive FAIL is being overridden by the CEL post-step in both directions.
+
+## New behavior (after this spec)
+
+| Handler status | CEL result | Post-step status |
+|----------------|------------|------------------|
+| PASS           | true       | PASS             |
+| PASS           | false      | INCONCLUSIVE     |
+| FAIL           | true       | INCONCLUSIVE     |
+| FAIL           | false      | **FAIL**         |
+
+Interpretation:
+
+- Both entities (handler and CEL) agreeing on PASS -> conclusive PASS.
+- Both entities agreeing on FAIL -> conclusive FAIL.
+- Handler and CEL disagreeing (PASS+false or FAIL+true) -> INCONCLUSIVE, pipeline continues.
+
+Rationale: the two disagreement rows are ambiguous — one signal says compliant, the other says not — and INCONCLUSIVE correctly defers to the next pass. The two agreement rows are conclusive and preserve the handler's original conclusion; the CEL post-step confirms rather than contradicts.
+
+## Invariants preserved
+
+- ERROR and INCONCLUSIVE from the handler are passed through unchanged (no CEL evaluation attempted). Unchanged from today.
+- When `expr` is absent from the pass config, the handler's original result is returned unchanged. Unchanged from today.
+- When CEL evaluation raises or returns an error (not a boolean), the handler's original result is returned unchanged. Unchanged from today.
+- Confidence, message, and evidence handling remain the same: the returned `HandlerResult` may synthesize a new message ("CEL expression passed", "CEL expression evaluated to false") but must include the original evidence.
+
+## Test coverage required
+
+The unit test suite must exercise all eight cells of the transition table (four rows above, times "expr present" and "expr absent" -> but the "absent" case is trivially handled and can be covered once). At minimum:
+
+1. Handler PASS + CEL true + expr -> PASS
+2. Handler PASS + CEL false + expr -> INCONCLUSIVE
+3. Handler FAIL + CEL true + expr -> INCONCLUSIVE (new)
+4. Handler FAIL + CEL false + expr -> FAIL (new; this is issue #343)
+5. Handler INCONCLUSIVE + any CEL + expr -> INCONCLUSIVE (pass-through)
+6. Handler ERROR + any CEL + expr -> ERROR (pass-through)
+7. Any handler status + no expr -> unchanged
+8. Any handler status + CEL evaluation error -> unchanged
+
+Tests live at `tests/darnit/sieve/test_orchestrator_cel.py`.
+
+## Downstream effect on TOML controls
+
+Twelve controls in `packages/darnit-baseline/openssf-baseline.toml` combine `fail_exit_codes` + `expr` in the same pass (audit in `research.md` R5). All twelve get the new semantics automatically; no TOML change is required for the branch-protection fix beyond the LE-01.01 level tag.
+
+An integration test at `tests/darnit_baseline/controls/test_branch_protection.py` should exercise at least one of the four named branch-protection controls (`OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`) end-to-end with a stubbed `gh api` command that returns the exact "Branch not protected" 404 response documented in `research.md` R3.

--- a/specs/020-definitive-fail-verdict/data-model.md
+++ b/specs/020-definitive-fail-verdict/data-model.md
@@ -1,0 +1,59 @@
+# Data Model: preserve handler-conclusive FAIL through the CEL post-step
+
+No new entities. Same underlying framework types as feature 019 US2. This document exists to satisfy the plan artifact list and to record which existing types are touched.
+
+## Existing framework types used
+
+### `PassOutcome` (framework, `packages/darnit/src/darnit/sieve/models.py`)
+
+Four-valued enum: `PASS` / `FAIL` / `INCONCLUSIVE` / `ERROR`. Unchanged schema. This spec changes only the *transitions* the CEL post-step performs between these values. Transition table lives in `contracts/cel-post-step.md`.
+
+### `HandlerResult` (framework, `packages/darnit/src/darnit/sieve/models.py`)
+
+Handler return value carrying `status: PassOutcome`, `message: str`, `confidence: float`, and `evidence: dict[str, Any]`. `evidence` is the input to CEL evaluation. Unchanged schema.
+
+For exec handlers with `output_format = "json"`, the evidence shape is:
+
+```python
+evidence = {
+    "stdout": str,
+    "stderr": str,
+    "exit_code": int,
+    "json": dict | list,   # parsed body, absent if JSON decode fails
+}
+```
+
+For the 404 "Branch not protected" case specifically:
+
+```python
+evidence = {
+    "stdout": '{"message": "Branch not protected", "documentation_url": "...", "status": "404"}',
+    "stderr": "",  # or a gh warning
+    "exit_code": 1,
+    "json": {"message": "Branch not protected", "documentation_url": "...", "status": "404"},
+}
+```
+
+### `_apply_cel_expr` (framework, `packages/darnit/src/darnit/sieve/orchestrator.py:60-75`)
+
+The transformation this spec modifies. Signature unchanged; internal logic is the sole change. New behavior documented in `contracts/cel-post-step.md`.
+
+## Relationships (unchanged)
+
+```
+exec handler (proc.returncode) -> HandlerResult{status: PASS|FAIL|INCONCLUSIVE, evidence: {...}}
+        |
+        v (only if handler status is PASS or FAIL)
+CEL post-step evaluates pass_config["expr"] against evidence
+        |
+        v
+Final HandlerResult -> orchestrator picks next pass or stops at conclusive verdict
+```
+
+## State transitions
+
+The only behavioral change. See `contracts/cel-post-step.md` for the before/after transition tables.
+
+## No storage, no schema, no migrations
+
+Pure in-memory transformation change. Nothing persisted; nothing to migrate.

--- a/specs/020-definitive-fail-verdict/plan.md
+++ b/specs/020-definitive-fail-verdict/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Preserve handler-conclusive FAIL through the CEL post-step
+
+**Branch**: `020-definitive-fail-verdict` | **Date**: 2026-08-01 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/020-definitive-fail-verdict/spec.md`
+
+## Summary
+
+Change the sieve orchestrator's CEL post-step so a handler-conclusive FAIL is preserved when the CEL expression also evaluates falsy. Today `gh api /repos/.../branches/.../protection` returns exit 1 on 404 (exec handler -> FAIL), then the CEL expression `has(output.json.required_pull_request_reviews)` returns false against the `{"message": "Branch not protected"}` body, and the orchestrator demotes to INCONCLUSIVE, causing the pipeline to fall through to the manual handler and yield WARN. The fix keeps FAIL when both the handler and CEL agree there is no compliance.
+
+Scope: single framework file (`packages/darnit/src/darnit/sieve/orchestrator.py`), roughly a 15-line diff to `_apply_cel_expr`. Twelve controls that combine `fail_exit_codes` + `expr` benefit automatically; the four named branch-protection controls (`OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`) are the acceptance bar.
+
+## Technical Context
+
+**Language/Version**: Python 3.11/3.12 (unchanged).
+
+**Primary Dependencies**: `cel-python` (already used for CEL evaluation). No new deps.
+
+**Storage**: N/A. Pure code change with test coverage.
+
+**Testing**: `pytest` with existing marks (`unit`, `integration`). Unit tests for the orchestrator transition table (8 cells). Integration tests for the four named controls using patched subprocess return values for `gh api`.
+
+**Target Platform**: Cross-platform.
+
+**Project Type**: Library + CLI + MCP server (workspace layout, unchanged).
+
+**Performance Goals**: N/A - correctness fix.
+
+**Constraints**: (a) must not regress any currently-passing control; (b) must preserve WARN semantics (unknown); (c) must respect Principle I (no cross-package imports); (d) any existing test that relied on the buggy H=FAIL + CEL=truthy -> PASS transition needs an assertion update.
+
+**Scale/Scope**: ~15 lines of Python in `orchestrator.py`, ~200 lines of new/updated tests, no TOML changes, no docs changes required.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Plugin Separation:** the change is confined to `packages/darnit/src/darnit/sieve/orchestrator.py` (framework). No implementation-package import introduced. PASS.
+- **II. Conservative-by-Default:** this fix strengthens Principle II. Today a definitive negative is demoted to INCONCLUSIVE (then WARN); the fix restores FAIL. FR-008 explicitly guards that WARN semantics are preserved for genuinely-unknown cases. PASS.
+- **III. TOML-First:** no control definitions change. Orchestrator engine code is not a control. PASS.
+- **IV. Never Guess User Values:** N/A.
+- **V. Sieve Pipeline Integrity:** the change restores this principle. The constitution states "the orchestrator stops at the first conclusive result." Today's CEL post-step demotes a handler-conclusive FAIL to INCONCLUSIVE, which violates that guarantee. The new behavior preserves it. PASS (and clarifies §V's application to the CEL post-step).
+
+**All gates pass. No entries in Complexity Tracking.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/020-definitive-fail-verdict/
+├── plan.md              # This file
+├── spec.md              # Feature spec
+├── research.md          # Phase 0 output (lifted from feature 019 R1/R2/R3/R5)
+├── data-model.md        # Phase 1 output (no new entities; documents which types are touched)
+├── contracts/
+│   └── cel-post-step.md # Internal framework contract; lifted verbatim from feature 019
+├── quickstart.md        # Phase 1 output (verification commands, US2-only)
+└── tasks.md             # Phase 2 output (/speckit-tasks - NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+packages/darnit/
+├── src/darnit/sieve/
+│   └── orchestrator.py                          # Change target: _apply_cel_expr (lines 60-75)
+└── (no other framework changes)
+
+tests/
+├── darnit/sieve/
+│   └── test_orchestrator_cel.py                 # New: unit tests for the 8-cell transition table
+└── darnit_baseline/
+    └── controls/
+        └── test_branch_protection.py            # New: integration tests for the 4 named controls
+```
+
+**Structure Decision:** identical workspace layout to feature 019. Framework change lives in `packages/darnit/`. Integration tests exercise the four named branch-protection controls via `packages/darnit-baseline/` but do not modify any TOML there. No new packages.
+
+## Phase 0: Outline & Research
+
+Consolidated in [`research.md`](research.md). Lifted from feature 019's research with pointers back to the original for context. Key items:
+
+1. **Current CEL post-step semantics** and root cause (feature 019 R1).
+2. **exec handler exit-code classification** (feature 019 R2).
+3. **`gh api` 404 response shape** (feature 019 R3).
+4. **Regression risk audit for the 12 affected controls** (feature 019 R5).
+5. **New: testing the nondeterministic path** — this feature explicitly requires verification via the audit skills (`/darnit-audit` + MCP client), not just pytest. Lesson from feature 019 US1.
+
+No open unknowns. No `[NEEDS CLARIFICATION]` markers.
+
+## Phase 1: Design & Contracts
+
+### Data model
+
+No new entities. See [`data-model.md`](data-model.md) for which existing framework types this feature touches (`PassOutcome`, `HandlerResult`, the CEL post-step function).
+
+### Contracts
+
+Single internal contract modified: the CEL post-step transition table. Documented in [`contracts/cel-post-step.md`](contracts/cel-post-step.md) (lifted verbatim from feature 019 with adjusted references). No external contract changes (public API, CLI, MCP tool shapes unchanged).
+
+### Agent context update
+
+Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `CLAUDE.md` to point at `specs/020-definitive-fail-verdict/plan.md`.
+
+**Output**: [`data-model.md`](data-model.md), [`contracts/cel-post-step.md`](contracts/cel-post-step.md), [`quickstart.md`](quickstart.md), updated `CLAUDE.md`.
+
+## Complexity Tracking
+
+*No entries - Constitution Check has no violations.*

--- a/specs/020-definitive-fail-verdict/quickstart.md
+++ b/specs/020-definitive-fail-verdict/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart: preserve handler-conclusive FAIL through the CEL post-step
+
+Three verification layers, in order from smallest to fullest. Layer 3 is the actual product test per [[feedback_darnit_testing_framing]] and is mandatory for sign-off.
+
+## Layer 1: orchestrator unit tests (deterministic)
+
+**Command:**
+
+```sh
+uv run pytest tests/darnit/sieve/test_orchestrator_cel.py -v
+```
+
+**Expected:** all 8 transition-table cases pass. The two new-behavior cells are:
+
+- Handler FAIL + CEL true + expr present -> INCONCLUSIVE (new; was PASS)
+- Handler FAIL + CEL false + expr present -> FAIL (new; was INCONCLUSIVE)
+
+Old-behavior cells preserved:
+
+- Handler PASS + CEL true + expr -> PASS
+- Handler PASS + CEL false + expr -> INCONCLUSIVE
+- Handler INCONCLUSIVE + any CEL + expr -> INCONCLUSIVE (pass-through)
+- Handler ERROR + any CEL + expr -> ERROR (pass-through)
+- Any handler status + no expr -> unchanged
+- Any handler status + CEL evaluation error -> unchanged
+
+## Layer 2: branch-protection integration tests (deterministic, stubbed API)
+
+**Command:**
+
+```sh
+uv run pytest tests/darnit_baseline/controls/test_branch_protection.py -v
+```
+
+**Expected:** for each of `OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`:
+
+- **FAIL case:** subprocess stubbed to return `returncode=1` + `stdout=b'{"message": "Branch not protected", ...}'` -> control resolves FAIL with a message string containing "Branch not protected".
+- **PASS case:** subprocess stubbed to return `returncode=0` + a healthy branch-protection body -> control resolves PASS (regression guard).
+
+Also runs the full non-integration sweep to confirm no unrelated regressions:
+
+```sh
+uv run pytest tests/ --ignore=tests/integration/ -m "not upstream" -q
+```
+
+Any test that fails here should be one of the ones flagged by the R7 grep in `research.md` (i.e., testing the buggy behavior). Un-flagged failures mean a real regression.
+
+## Layer 3: audit skill against a real repo (nondeterministic, mandatory)
+
+**Setup:** use the test project created for feature 019 verification:
+
+```sh
+ls /tmp/darnit-test-repo   # created previously; recreate if gone
+```
+
+Point `/tmp/darnit-test-repo` at itself (it has no branch protection since it is a local scratch repo, but the audit tool queries GitHub via `gh api` which will fail cleanly with 404 or auth-scoped error). For a real 404 signal, point at any pushed GitHub repo you own whose default branch is unprotected.
+
+**Command via the skill:**
+
+Invoke `/darnit-audit` from within Claude Code, targeted at the repo, at each level. Compare the reported verdict for the four named branch-protection controls (`OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`) against the following expectation:
+
+- With no branch protection: all four MUST report FAIL, with a message referencing "Branch not protected".
+- With authenticated `gh` but unreachable network: WARN (unchanged).
+- With branch protection enabled and healthy: PASS.
+
+**Comparison against previous behavior:**
+
+Before this feature ships, `/darnit-audit` on an unprotected repo reports the four controls as WARN ("needs verification"). After, they report FAIL. This qualitative shift is the entire user-visible outcome of the feature and is what the reader will see in an audit report.
+
+## Layer 4 (optional): live GitHub audit
+
+If you have a GitHub repo whose default branch is unprotected AND you have `gh auth status` returning authenticated:
+
+```sh
+uv run darnit audit /path/to/unprotected-repo -t level=1 --show-all --no-fail -o json | \
+  jq '[.controls[] | select(.id | test("OSPS-AC-03|OSPS-QA-03.01|OSPS-QA-07.01")) | {id, status}]'
+```
+
+Expected: all four report `"status": "FAIL"`.
+
+Note: the CLI `darnit audit` runs deterministically without LLM consultation (per its own docstring). This layer exercises the real `gh api` path but not the LLM-mediated report interpretation — that is layer 3's job.

--- a/specs/020-definitive-fail-verdict/research.md
+++ b/specs/020-definitive-fail-verdict/research.md
@@ -1,0 +1,66 @@
+# Research: preserve handler-conclusive FAIL through the CEL post-step
+
+This feature inherits R1-R5 from feature 019's [`research.md`](../019-verdict-correctness/research.md). Rather than duplicate, the entries below reference back and add only the delta relevant to shipping US2 on its own.
+
+## R1: Current CEL post-step semantics (root cause)
+
+**See:** feature 019 `research.md` R1.
+
+**Summary:** `packages/darnit/src/darnit/sieve/orchestrator.py:60-75` maps CEL true -> PASS and CEL false -> INCONCLUSIVE regardless of the handler's original status. When the exec handler returns FAIL via `fail_exit_codes` and the CEL expression evaluates false against an incomplete evidence dict (e.g., `has(output.json.required_pull_request_reviews)` on a 404 body), the handler's FAIL is demoted to INCONCLUSIVE. The pipeline falls through to the manual handler and yields WARN. This is the root cause of issue #343.
+
+## R2: exec handler exit-code classification
+
+**See:** feature 019 `research.md` R2.
+
+**Summary:** confirmed at `packages/darnit/src/darnit/sieve/builtin_handlers.py:247-266`. `pass_exit_codes` -> PASS, `fail_exit_codes` -> FAIL, else INCONCLUSIVE. No change required to the exec handler; the downstream CEL post-step is what corrupts the verdict.
+
+## R3: `gh api` 404 response shape
+
+**See:** feature 019 `research.md` R3.
+
+**Summary:** for a branch with no protection, `gh api /repos/{owner}/{repo}/branches/{branch}/protection` returns HTTP 404 with body `{"message": "Branch not protected", "documentation_url": "...", "status": "404"}` and exit code 1. The exec handler's `output_format = "json"` parses this into `output.json`. Tests should stub the subprocess call with exactly this shape.
+
+## R4: Test source of truth
+
+Not applicable for this feature (no vendored external fixture required). The two test files needed:
+
+- `tests/darnit/sieve/test_orchestrator_cel.py`: unit tests for the 8-cell transition table.
+- `tests/darnit_baseline/controls/test_branch_protection.py`: integration tests for the 4 named branch-protection controls with patched subprocess return values.
+
+Both are `pytest.mark.unit` (offline, no network).
+
+## R5: Regression audit for the 12 affected controls
+
+**See:** feature 019 `research.md` R5.
+
+**Summary:** twelve controls combine `fail_exit_codes` + `expr` in the same pass and are affected by the orchestrator change:
+
+```
+OSPS-AC-01.01, OSPS-AC-02.01, OSPS-AC-03.01, OSPS-AC-03.02, OSPS-BR-03.01,
+OSPS-GV-02.01, OSPS-LE-02.01, OSPS-QA-01.01, OSPS-QA-03.01, OSPS-QA-07.01,
+OSPS-VM-03.01, OSPS-VM-04.01
+```
+
+New behavior for all twelve:
+- H=FAIL + CEL=true -> INCONCLUSIVE (handler and CEL disagree; safer to be inconclusive). Was PASS today.
+- H=FAIL + CEL=false -> FAIL (both agree; conclusive). Was INCONCLUSIVE today.
+
+**Regression risk:** low. A test that expected PASS from H=FAIL + CEL=true would be exercising an ambiguous state that is not a coherent PASS signal. Any such test is asserting buggy behavior. The tasks phase includes an audit pass (grep the existing test suite) before applying the orchestrator change.
+
+## R6: Nondeterministic verification path (new for this feature)
+
+**Decision:** verification of this feature includes a mandatory `/darnit-audit` run against a repository whose default branch has no protection, or against `/tmp/darnit-test-repo` (the scratch repo created during feature 019 verification), to observe the four named controls report FAIL through the full MCP pipeline including any LLM eval steps that may consume the verdict downstream.
+
+**Rationale:** feature 019 US1 shipped after passing 2258 unit tests but had a real bug (TOML `spec_version` not updated) that was only surfaced by running the audit skill and reading the report. Deterministic tests cover the transition table; only the audit skill exercises the product path a user actually sees. Lesson recorded in memory as `feedback_darnit_testing_framing`.
+
+**Alternatives considered:** rely on unit tests alone (rejected: does not cover the audit-report-rendering path or any LLM-consumed follow-up steps); require a live repo with real API responses (rejected: too flaky for CI, still worthwhile for maintainer verification).
+
+## R7: Test discovery — existing controls that combine `fail_exit_codes` + `expr`
+
+Before applying the orchestrator change, run the following grep to identify existing tests that assert behavior for the 12 affected controls. Any hit that asserts PASS from a `fail_exit_codes` + `expr` handler needs an assertion update.
+
+```sh
+grep -rn "fail_exit_codes\|HandlerResultStatus.FAIL" tests/ | grep -E "(orchestrator|cel|branch_protection|AC-0[123]|BR-0[13]|GV-02|LE-02|QA-0[137]|VM-0[34])"
+```
+
+Findings from this grep are recorded in the tasks-phase task T-audit (see `tasks.md`).

--- a/specs/020-definitive-fail-verdict/spec.md
+++ b/specs/020-definitive-fail-verdict/spec.md
@@ -1,0 +1,78 @@
+# Feature Specification: Preserve handler-conclusive FAIL through the CEL post-step
+
+**Feature Branch**: `020-definitive-fail-verdict`
+
+**Created**: 2026-08-01
+
+**Status**: Draft
+
+**Input**: User description: "us2" (implement US2 from feature 019: fix branch-protection controls returning WARN on a definitive HTTP 404 "Branch not protected" response instead of FAIL)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Definitive "not protected" is reported as failing (Priority: P1)
+
+An operator running a live audit against a repository whose default branch has no branch protection expects the branch-protection controls to be reported as FAIL. Today they are reported as WARN ("could not automatically verify"), which under the conservative-by-default rules still counts against compliance but obscures the fact that darnit has a definitive answer.
+
+**Why this priority**: WARN semantically means "the framework does not know." Emitting WARN when the framework does know (the GitHub API returned a definitive "Branch not protected" response, exit code 1, JSON body with `message == "Branch not protected"`) trains users to distrust WARN, blurs the compliance report, and hides an actionable finding. Framework-level fix; benefits 12 downstream controls that combine `fail_exit_codes` with `expr` (research.md R5 from feature 019). Constitutional principle II (Conservative-by-default) and V (Sieve Pipeline Integrity) both call for this correction.
+
+**Independent Test**: Point a live audit at a repository whose default branch has no branch protection (or use the integration test's stubbed `gh api`), then observe the verdicts for `OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`. All four MUST be FAIL, not WARN. The verification path is the same as feature 019 US2's `quickstart.md`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository whose default branch has no branch protection and the framework has authenticated access to the GitHub API, **When** any branch-protection control runs, **Then** the control resolves as FAIL with a reason that states the branch is not protected.
+2. **Given** the same repository but the framework cannot reach the GitHub API (network error, rate-limit exhaustion, or unauthenticated request), **When** any branch-protection control runs, **Then** the control resolves as WARN because the answer is genuinely unknown.
+3. **Given** a repository whose default branch IS protected but with weak settings, **When** a branch-protection control runs, **Then** the control's normal per-setting evaluation applies unchanged.
+4. **Given** a control (any of the 12 in scope) whose exec handler returns FAIL via `fail_exit_codes` AND whose CEL expression also evaluates falsy, **When** the sieve orchestrator runs, **Then** the control resolves as FAIL (not INCONCLUSIVE, which is today's behavior).
+5. **Given** a control whose exec handler returns FAIL AND whose CEL expression evaluates truthy (the ambiguous case), **When** the sieve orchestrator runs, **Then** the control resolves as INCONCLUSIVE (was PASS today; the ambiguous case now defers).
+
+---
+
+### Edge Cases
+
+- What happens when the branch-protection API returns a 4xx that is NOT the specific "Branch not protected" 404 (e.g., 403 permission denied, 401 unauthenticated, 404 with a different body such as "Not Found")? The response is not definitive; the control remains WARN. This spec only sharpens the FAIL boundary; it does not touch WARN handling.
+- What happens when a branch other than the default is queried and returns "Branch not protected"? Same rule applies: the response is definitive for that branch and resolves FAIL. Any control that scopes to a non-default branch inherits this behavior.
+- What happens for controls outside the branch-protection family that today return WARN on a definitive negative? The orchestrator change benefits ANY control combining `fail_exit_codes` + `expr` (11 non-branch-protection controls listed in feature 019's `research.md` R5). The acceptance bar is the four named branch-protection controls; the broader benefit is a side effect and is expected, not a regression.
+- What happens when a control's exec handler returns FAIL and CEL evaluates truthy? Today: PASS. New: INCONCLUSIVE. This is the "ambiguous" cell of the transition table (handler and CEL disagree in favor of the handler's original verdict). Any existing test that relied on this PASS is exercising buggy behavior and must be updated to reflect the new (correct) semantics.
+- What happens for controls that use `expr` WITHOUT `fail_exit_codes`? Unchanged. Handler PASS is the only conclusive input; PASS + truthy CEL -> PASS, PASS + falsy CEL -> INCONCLUSIVE (today's behavior, preserved).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When the sieve orchestrator's CEL post-step evaluates on a handler result of FAIL and the CEL expression returns falsy, the control MUST resolve to FAIL. (Today: INCONCLUSIVE, which is the root cause of issue #343.)
+- **FR-002**: When the sieve orchestrator's CEL post-step evaluates on a handler result of FAIL and the CEL expression returns truthy (the ambiguous case — handler and CEL disagree, with the handler saying fail and the CEL saying pass), the control MUST resolve to INCONCLUSIVE. (Today: PASS, which is a latent bug; see feature 019 `research.md` R5.)
+- **FR-003**: Handler results of PASS with a CEL expression MUST continue to behave as today: PASS + truthy -> PASS, PASS + falsy -> INCONCLUSIVE. This spec does not alter the pass-boundary semantics.
+- **FR-004**: Handler results of INCONCLUSIVE or ERROR MUST continue to pass through the CEL post-step unchanged. Same as today.
+- **FR-005**: When the CEL expression is absent from a pass configuration, the handler's result MUST pass through unchanged. Same as today.
+- **FR-006**: When the CEL expression evaluator raises or returns an error (not a boolean), the handler's original result MUST pass through unchanged. Same as today.
+- **FR-007**: The framework's four named branch-protection controls (`OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`) MUST report FAIL when the GitHub API returns HTTP 404 with body containing `message == "Branch not protected"` (exit code 1 from `gh api`).
+- **FR-008**: WARN semantics MUST be preserved: WARN continues to mean "the framework could not determine compliance" (network failure, missing authentication, ambiguous API response). This spec strengthens FAIL by removing one class of false WARN; it does not weaken WARN.
+- **FR-009**: The change MUST NOT alter the behavior of any control that today returns PASS on a healthy branch-protection response (200 with expected fields). Regression coverage required.
+
+### Key Entities
+
+- **`PassOutcome`** (framework, `packages/darnit/src/darnit/sieve/models.py`): the four-valued enum (PASS / FAIL / INCONCLUSIVE / ERROR). Unchanged by this spec; only the transitions between them shift.
+- **`HandlerResult`** (framework): the handler's return value carrying `status`, `message`, `confidence`, and `evidence`. `evidence` is the input to CEL evaluation. Unchanged.
+- **CEL post-step** (framework, `packages/darnit/src/darnit/sieve/orchestrator.py:60-75`): the transformation this spec modifies. Documented as a contract in `contracts/cel-post-step.md` (lifted from feature 019).
+- **Twelve affected controls** in `packages/darnit-baseline/openssf-baseline.toml` (from feature 019 `research.md` R5): `OSPS-AC-01.01`, `OSPS-AC-02.01`, `OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-BR-03.01`, `OSPS-GV-02.01`, `OSPS-LE-02.01`, `OSPS-QA-01.01`, `OSPS-QA-03.01`, `OSPS-QA-07.01`, `OSPS-VM-03.01`, `OSPS-VM-04.01`. Acceptance bar is the four named branch-protection controls; the remaining eight benefit automatically.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A live audit against a repository whose default branch has no branch protection reports FAIL (not WARN) for all four named branch-protection controls.
+- **SC-002**: The full eight-cell CEL post-step transition table is covered by unit tests, with the two new-behavior cells (H=FAIL+CEL=truthy -> INCONCLUSIVE, H=FAIL+CEL=falsy -> FAIL) explicitly asserted.
+- **SC-003**: No control that today returns PASS on a healthy input changes verdict. The regression sweep runs all pre-existing tests and none fail unrelated to the transition-table change (any that fail are documented as testing buggy behavior).
+- **SC-004**: An audit report reader can distinguish "we know this fails" (FAIL) from "we could not verify" (WARN) for the four named branch-protection controls without consulting external documentation.
+- **SC-005**: The nondeterministic verification path (running the audit via the darnit MCP server + a coding-agent client) produces the same qualitative story for the four named controls as the deterministic unit tests.
+
+## Assumptions
+
+- Constitutional reference: this work strengthens Principle II (Conservative-by-default) and clarifies Principle V (Sieve Pipeline Integrity, "orchestrator stops at first conclusive result"). Today's CEL post-step arguably violates V by demoting a handler-conclusive FAIL to INCONCLUSIVE.
+- WARN vs FAIL semantics: WARN counts the same as FAIL for compliance math today; this spec does not change that math, only the reported label. Users reading reports get sharper information.
+- Feature 019 US1 (issue #342) has already shipped as PR #349. This spec is the second half of that feature bundle, lifted into its own feature per the "one PR per feature" pattern that emerged during US1's implementation.
+- The regression risk audit and mitigations from feature 019 `research.md` R5 remain valid; the twelve controls listed there are the correct scope of "affected by this change."
+- Definitive "not protected" signal: HTTP status 404 AND body containing `message == "Branch not protected"`. Other 4xx / other 404 bodies remain ambiguous (WARN).
+- Testing framing: the deterministic verification (unit tests, integration tests with stubbed `gh api`) is necessary but not sufficient. The audit skills (`/darnit-audit` invoking `darnit serve` + MCP client) exercise the LLM-mediated path and are the actual product test.
+- The relevant contracts and research are already written under `specs/019-verdict-correctness/`. This feature's planning phase should lift and adapt those artifacts rather than rewriting them.

--- a/specs/020-definitive-fail-verdict/tasks.md
+++ b/specs/020-definitive-fail-verdict/tasks.md
@@ -1,0 +1,164 @@
+---
+
+description: "Task list for feature 020: preserve handler-conclusive FAIL through the CEL post-step (issue #343)"
+---
+
+# Tasks: Preserve handler-conclusive FAIL through the CEL post-step
+
+**Input**: Design documents from `/specs/020-definitive-fail-verdict/`
+
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/cel-post-step.md`, `quickstart.md`
+
+**Tests**: Included and TDD-ordered. The orchestrator change affects 12 downstream controls (research.md R5); tests must be written first and confirmed failing before the implementation change, both to prevent regression and to make the buggy-behavior audit surgical.
+
+**Organization**: single P1 user story. All work maps to US1.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no shared state).
+- **[Story]**: US1 for user-story tasks.
+- File paths are absolute-from-repo-root.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Test-suite discovery before we start writing new tests, so we know what existing assertions need updating.
+
+- [X] T001 Run the grep from `research.md` R7 to identify existing tests that assert behavior for the 12 affected controls. Command: `grep -rn "fail_exit_codes\|HandlerResultStatus.FAIL" tests/ | grep -E "(orchestrator|cel|branch_protection|AC-0[123]|BR-0[13]|GV-02|LE-02|QA-0[137]|VM-0[34])"`. Record the hits in this task's completion note. Categorize each hit as either (a) exercising the buggy `H=FAIL + CEL=true -> PASS` transition (must update in T009 after implementation), (b) exercising the correct-and-preserved behavior (no action needed), or (c) unrelated. Do NOT modify any test yet.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: None. Single user story with no shared prerequisites beyond T001.
+
+**Checkpoint**: T001 complete; audit findings recorded. Ready to write tests.
+
+---
+
+## Phase 3: User Story 1 - Preserve handler-conclusive FAIL (Priority: P1)
+
+**Goal**: The sieve orchestrator's CEL post-step preserves a handler-conclusive FAIL when the CEL expression also evaluates falsy. The four named branch-protection controls (`OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`) report FAIL (not WARN) on a GitHub API 404 "Branch not protected" response.
+
+**Independent Test**: `uv run pytest tests/darnit/sieve/test_orchestrator_cel.py tests/darnit_baseline/controls/test_branch_protection.py -v` passes; `/darnit-audit` against `/tmp/darnit-test-repo` reports the four controls as FAIL (verified per `quickstart.md` Layer 3).
+
+**Ships as one PR.**
+
+### Tests for User Story 1 (write first, must FAIL before implementation)
+
+- [X] T002 [P] [US1] Write orchestrator CEL post-step unit tests at `tests/darnit/sieve/test_orchestrator_cel.py`. Cover all eight cells of the transition table in `contracts/cel-post-step.md` (test coverage section, items 1-8). Each test constructs a `HandlerResult` with an explicit `status` and `evidence`, invokes `_apply_cel_expr(handler_config, handler_result)` from `packages/darnit/src/darnit/sieve/orchestrator.py`, and asserts the resulting `PassOutcome`. Mark all with `@pytest.mark.unit`. Confirm tests 3 and 4 (Handler FAIL + CEL true -> INCONCLUSIVE; Handler FAIL + CEL false -> FAIL) FAIL on `main` before T008.
+
+- [X] T003 [P] [US1] Write branch-protection FAIL-case integration tests at `tests/darnit_baseline/controls/test_branch_protection.py`. For each of `OSPS-AC-03.01`, `OSPS-AC-03.02`, `OSPS-QA-03.01`, `OSPS-QA-07.01`: patch the exec handler's subprocess invocation (e.g., via `unittest.mock.patch` on `subprocess.run`) to return `returncode=1` and `stdout=b'{"message": "Branch not protected", "documentation_url": "...", "status": "404"}'`; assert the control's final `PassOutcome` is `FAIL` (not `INCONCLUSIVE`); assert the resulting message string contains `Branch not protected`. Mark with `@pytest.mark.unit`. Confirm all four assertions FAIL on `main` before T008.
+
+- [X] T004 [P] [US1] Write branch-protection PASS-case regression-guard tests at `tests/darnit_baseline/controls/test_branch_protection.py` (same file as T003). For the same four controls: patch subprocess to return `returncode=0` with a healthy JSON body containing `required_pull_request_reviews`, `required_status_checks`, and (for `OSPS-QA-07.01`'s `--jq` command) an integer >= 1; assert the final outcome is `PASS`. Confirms no PASS-path regression.
+
+- [X] T005 [P] [US1] Write orchestrator pass-through tests at `tests/darnit/sieve/test_orchestrator_cel.py` (same file as T002) for the invariants FR-004, FR-005, FR-006, FR-008: handler INCONCLUSIVE/ERROR passes through unchanged; handler status with no expr passes through unchanged; CEL evaluation error passes through the handler's original result. Add an explicit WARN-preservation case for FR-008: patch subprocess to return an exit code that is in neither `pass_exit_codes` nor `fail_exit_codes` (e.g., 2 or 127, simulating network failure or command-not-found); assert the exec handler returns INCONCLUSIVE and the CEL post-step passes it through unchanged. These should all PASS on main today (guards against accidental regression).
+
+### Audit before implementation
+
+- [X] T006 [US1] Cross-reference the T001 audit findings against the new orchestrator behavior. For each test in category (a) from T001 (relies on buggy `H=FAIL + CEL=true -> PASS`), document in this task's completion note the exact assertion that needs updating and the new expected value. Do NOT edit tests yet; that happens in T009.
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Read `specs/020-definitive-fail-verdict/contracts/cel-post-step.md` and internalize the new transition table. This is a read-only prep step; no code change.
+
+- [X] T008 [US1] Modify `_apply_cel_expr` in `packages/darnit/src/darnit/sieve/orchestrator.py` (lines 60-75) to implement the new transition table. Specifically: when the handler status is FAIL, CEL true yields INCONCLUSIVE (was PASS); CEL false yields the original FAIL preserved (was INCONCLUSIVE). Preserve all invariants: pass-through of ERROR/INCONCLUSIVE handler statuses (lines 47-52 unchanged), pass-through when `expr` absent (lines 43-45 unchanged), pass-through on CEL evaluation error (lines 76-81 unchanged). Update the docstring at lines 33-42 to reflect the new table with a two-column before/after summary. Do NOT introduce new config knobs; the semantics change is the correct default.
+
+- [X] T009 [US1] Update each test flagged in T006 to match the new (correct) semantics. Add a one-line comment on each updated assertion referencing `specs/020-definitive-fail-verdict/contracts/cel-post-step.md`. If T006 found zero flagged tests, this task is a no-op; note that in the completion.
+
+### Verification (deterministic layers)
+
+- [X] T010 [US1] Run `uv run pytest tests/darnit/sieve/test_orchestrator_cel.py -v` and confirm all eight transition-table cases plus the pass-through invariants pass. Per `quickstart.md` Layer 1.
+
+- [X] T011 [US1] Run `uv run pytest tests/darnit_baseline/controls/test_branch_protection.py -v` and confirm the four FAIL assertions (T003) and four PASS assertions (T004) all pass. Per `quickstart.md` Layer 2.
+
+- [X] T012 [US1] Run `uv run pytest tests/ --ignore=tests/integration/ -m "not upstream" -q` and confirm no unrelated regression. Any failure not accounted for by T009's updates is a real regression; stop and diagnose.
+
+- [X] T013 [US1] Run `uv run ruff check .` and `uv run python scripts/validate_sync.py --verbose` and confirm both pass.
+
+### Verification (nondeterministic layer — mandatory)
+
+- [X] T014 [US1] Re-install darnit as editable so the audit skill uses the branch's code: `uv tool install --reinstall --editable ./packages/darnit --with-editable ./packages/darnit-baseline --with-editable ./packages/darnit-gittuf --with-editable ./packages/darnit-reproducibility`. Confirm `darnit list` reports the framework loaded successfully. (Non-editable install is broken today per the note in feature 019 verification; issue #350-adjacent packaging bug.)
+
+- [X] T015 [US1] Invoke `/darnit-audit` from within Claude Code targeted at `/tmp/darnit-test-repo` (created during feature 019 verification; recreate per `quickstart.md` if missing) at Level 1. Capture the output; confirm the four named branch-protection controls resolve to FAIL with a message referencing "Branch not protected". If the test repo is not authenticated to GitHub, the response may be a 401/403 rather than 404 "Branch not protected"; in that case, either (a) authenticate with `gh auth login` and re-run, or (b) confirm the audit still returns WARN (not FAIL) for the ambiguous non-404 case, which validates FR-008 (WARN preserved for ambiguous responses).
+
+- [ ] T016 [US1] Optional live-repo layer (per `quickstart.md` Layer 4): if you have a GitHub repo whose default branch is unprotected AND authenticated `gh`, run `uv run darnit audit /path/to/repo -t level=1 --show-all --no-fail -o json | jq '[.controls[] | select(.id | test("OSPS-AC-03|OSPS-QA-03.01|OSPS-QA-07.01")) | {id, status}]'`. Expected: all four report `"status": "FAIL"`. Skip if no such repo is available; T015 is sufficient for feature acceptance.
+
+**Checkpoint**: US1 is complete and shippable. Framework orchestrator behavior is correct; 12 downstream controls benefit automatically; the four named branch-protection controls report FAIL on definitive 404.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+- [X] T017 [P] Draft a one-line release-notes bullet for the next tagged release's GitHub Release description: "Branch-protection controls now report FAIL (not WARN) on definitive `Branch not protected` responses from the GitHub API (fixes #343)." Repo has no `CHANGELOG.md` today; when the packaging release runbook needs a change summary, this is where the bullet lands.
+
+- [X] T018 [P] Update `specs/019-verdict-correctness/tasks.md` to mark T008-T017 as superseded by feature 020, since 019 was originally scoped to bundle US2 but US1 shipped alone in PR #349. Add a note at the top of that file pointing readers here.
+
+- [X] T019 Run the full `quickstart.md` end-to-end after T008-T015 complete, confirming every command produces the documented output.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: T001 is a discovery task; blocks T006 (which reads its output) and T008 (which relies on knowing which tests to update).
+- **Foundational (Phase 2)**: empty.
+- **US1 (Phase 3)**: depends on T001. Internal ordering per TDD: T002-T005 (tests) -> T006 (audit) -> T007-T008 (implementation) -> T009 (test updates) -> T010-T016 (verification).
+- **Polish (Phase 4)**: depends on US1 checkpoint.
+
+### Task-level dependencies
+
+- T002-T005 all `[P]` — different test files, no shared state, all read-only against unfixed codebase.
+- T006 blocked by T001 (needs the audit findings).
+- T008 blocked by T002 and T003 (must confirm they FAIL before implementing).
+- T009 blocked by T006 and T008 (need both the audit and the implementation before touching flagged tests).
+- T010-T013 all sequential after T008 and T009 (share the same repo state).
+- T014 blocked by T008 (want to install the fixed code).
+- T015 blocked by T014.
+
+### Parallel opportunities
+
+- All of T002, T003, T004, T005 can be spawned in parallel after Phase 1.
+- Polish tasks T017 and T018 can run in parallel with each other.
+
+---
+
+## Parallel Example: Phase 3 test writing
+
+```bash
+# Spawn concurrently after T001 completes:
+Task: "Write orchestrator CEL post-step unit tests at tests/darnit/sieve/test_orchestrator_cel.py"
+Task: "Write branch-protection FAIL-case integration tests at tests/darnit_baseline/controls/test_branch_protection.py"
+Task: "Write branch-protection PASS-case regression-guard tests at tests/darnit_baseline/controls/test_branch_protection.py"
+Task: "Write orchestrator pass-through invariant tests at tests/darnit/sieve/test_orchestrator_cel.py"
+```
+
+Note: T002 and T005 both edit `test_orchestrator_cel.py`, and T003 and T004 both edit `test_branch_protection.py`. If executed as separate agents, coordinate on file boundaries (or fold T005 into T002 and T004 into T003 as single writer tasks).
+
+---
+
+## Implementation Strategy
+
+### MVP scope
+
+The single P1 user story IS the MVP. There is no smaller shippable increment; a partial fix (e.g., handling only the 4 branch-protection controls without touching the orchestrator) would leave the underlying bug in the other 8 controls. Do the full orchestrator change.
+
+### Ordering rationale
+
+TDD is important here specifically because the orchestrator change is a semantic shift with 12 downstream consumers. Writing tests first + auditing existing assertions first + confirming the new tests fail on main first gives us a mechanical safety net: if T012's regression sweep produces an un-audited failure, we know something is wrong.
+
+### Sequential single-contributor path
+
+For one contributor: T001 (5 min) -> T002+T005 folded (30 min) -> T003+T004 folded (30 min) -> T006 (10 min) -> T007-T008 (20 min) -> T009 (variable, likely zero-to-small) -> T010-T013 (5 min) -> T014-T015 (15 min) -> T017-T019 (10 min). Total: roughly 2 hours of focused work.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no shared state.
+- Every task cites the exact file path it edits or the exact command it runs.
+- TDD enforced: T002 and T003's new-behavior assertions MUST fail on main before T008 is begun.
+- T014 is the fix for the packaging bug discovered during feature 019 verification (source-tree layout required for path-based TOML resolution). If the packaging fix (issue #350-adjacent) lands separately before this work starts, T014 becomes a no-op.
+- Constitution reminder: this feature strengthens Principles II and V. Any code review comment that would move a "we know it fails" case back to WARN should be rejected on constitutional grounds.

--- a/tests/darnit/sieve/test_builtin_handlers.py
+++ b/tests/darnit/sieve/test_builtin_handlers.py
@@ -303,7 +303,7 @@ class TestExecHandler:
         handler_result = exec_handler(config, ctx)
         result = _apply_cel_expr(config, handler_result)
         assert result.status == HandlerResultStatus.INCONCLUSIVE
-        assert "false" in result.message.lower()
+        assert "disagree" in result.message.lower() or "inconclusive" in result.message.lower()
 
     def test_stdout_truncated_in_evidence(self, ctx):
         """Long stdout is truncated to 2000 chars in evidence."""
@@ -350,13 +350,22 @@ class TestRegexHandler:
         )
         assert result.status == HandlerResultStatus.FAIL
 
-    def test_cel_not_any_match_pass_when_absent(self, tmp_path, ctx):
-        """expr = '!(output.any_match)' → PASS when pattern not found."""
+    def test_cel_not_any_match_inconclusive_when_absent(self, tmp_path, ctx):
+        """expr = '!(output.any_match)' with handler FAIL -> INCONCLUSIVE.
+
+        Feature 020 (issue #343) narrowed CEL semantics: handler and CEL
+        must agree for a conclusive verdict. Handler FAIL + CEL truthy is
+        now INCONCLUSIVE (was PASS). Controls that used this idiom to
+        express "PASS when the bad thing is absent" should be rewritten
+        to have the handler produce PASS directly (see BR-01.01's
+        inverted-grep exec pattern in openssf-baseline.toml). See
+        specs/020-definitive-fail-verdict/contracts/cel-post-step.md.
+        """
         (tmp_path / "clean.py").write_text("print('hello')\n")
         config = {"file": "clean.py", "pattern": r"TODO|FIXME|HACK", "expr": "!(output.any_match)"}
         handler_result = regex_handler(config, ctx)
         result = _apply_cel_expr(config, handler_result)
-        assert result.status == HandlerResultStatus.PASS
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
 
     def test_cel_not_any_match_inconclusive_when_present(self, tmp_path, ctx):
         """expr = '!(output.any_match)' → INCONCLUSIVE when pattern found (handler PASS overridden)."""
@@ -530,8 +539,15 @@ class TestRegexHandler:
         assert result.status == HandlerResultStatus.PASS
         assert result.evidence["files_found"] == 0
 
-    def test_exclude_inconclusive_when_files_found(self, tmp_path, ctx):
-        """exclude_files + expr: INCONCLUSIVE when excluded files exist."""
+    def test_exclude_fail_when_files_found(self, tmp_path, ctx):
+        """exclude_files + expr: FAIL when excluded files exist.
+
+        Feature 020 (issue #343): when the handler returns FAIL and the
+        CEL expression also evaluates falsy, the pair agrees on non-
+        compliance and the verdict is preserved as FAIL (was INCONCLUSIVE
+        pre-020, which fell through to manual and reported WARN). See
+        specs/020-definitive-fail-verdict/contracts/cel-post-step.md.
+        """
         (tmp_path / "binary.exe").write_bytes(b"\x00\x01")
         config = {
             "exclude_files": ["**/*.exe"],
@@ -539,7 +555,7 @@ class TestRegexHandler:
         }
         handler_result = regex_handler(config, ctx)
         result = _apply_cel_expr(config, handler_result)
-        assert result.status == HandlerResultStatus.INCONCLUSIVE
+        assert result.status == HandlerResultStatus.FAIL
         assert handler_result.evidence["files_found"] >= 1
 
     # --- Recursive glob support ---
@@ -608,15 +624,21 @@ class TestApplyCelExpr:
         result = _apply_cel_expr({"expr": "true"}, original)
         assert result is original
 
-    def test_cel_true_overrides_fail_to_pass(self):
-        """CEL true + handler FAIL → result is PASS."""
+    def test_cel_true_with_handler_fail_becomes_inconclusive(self):
+        """CEL true + handler FAIL -> INCONCLUSIVE (feature 020, issue #343).
+
+        Was PASS in the pre-feature-020 orchestrator. The new semantics
+        require handler and CEL to agree for a conclusive verdict;
+        disagreement defers to the next pass. See
+        specs/020-definitive-fail-verdict/contracts/cel-post-step.md.
+        """
         original = HandlerResult(
             status=HandlerResultStatus.FAIL,
             message="Pattern not found",
             evidence={"any_match": False, "files_checked": 1},
         )
         result = _apply_cel_expr({"expr": "!(output.any_match)"}, original)
-        assert result.status == HandlerResultStatus.PASS
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
 
     def test_cel_false_overrides_pass_to_inconclusive(self):
         """CEL false + handler PASS → result is INCONCLUSIVE."""

--- a/tests/darnit/sieve/test_orchestrator_cel.py
+++ b/tests/darnit/sieve/test_orchestrator_cel.py
@@ -1,0 +1,158 @@
+"""Unit tests for the sieve orchestrator's CEL post-step (`_apply_cel_expr`).
+
+Covers all cells of the transition table documented at
+`specs/020-definitive-fail-verdict/contracts/cel-post-step.md`.
+
+Feature 020 (issue #343) changes two cells of this table:
+- Handler FAIL + CEL truthy: was PASS, now INCONCLUSIVE
+- Handler FAIL + CEL falsy: was INCONCLUSIVE, now FAIL (the fix)
+
+These changes preserve the constitution's Principle V ("orchestrator stops
+at first conclusive result") by keeping the handler's conclusive FAIL when
+CEL agrees, and by deferring to INCONCLUSIVE when handler and CEL disagree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from darnit.sieve.handler_registry import (
+    HandlerResult,
+    HandlerResultStatus,
+)
+from darnit.sieve.orchestrator import _apply_cel_expr
+
+
+def _mk(status: HandlerResultStatus, evidence: dict | None = None, message: str = "") -> HandlerResult:
+    """Build a minimal HandlerResult for transition-table testing."""
+    return HandlerResult(
+        status=status,
+        message=message or f"handler returned {status.value}",
+        evidence=evidence or {"any_match": False, "files_checked": 1},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Transition table: eight cells from contracts/cel-post-step.md
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionTable:
+    """Exhaustive coverage of the CEL post-step transition table."""
+
+    @pytest.mark.unit
+    def test_pass_and_cel_true_stays_pass(self):
+        original = _mk(HandlerResultStatus.PASS, {"any_match": True})
+        result = _apply_cel_expr({"expr": "output.any_match"}, original)
+        assert result.status == HandlerResultStatus.PASS
+
+    @pytest.mark.unit
+    def test_pass_and_cel_false_becomes_inconclusive(self):
+        original = _mk(HandlerResultStatus.PASS, {"any_match": False})
+        result = _apply_cel_expr({"expr": "output.any_match"}, original)
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
+
+    @pytest.mark.unit
+    def test_fail_and_cel_true_becomes_inconclusive(self):
+        """Feature 020 change: handler+CEL disagree -> defer, not PASS.
+
+        See specs/020-definitive-fail-verdict/contracts/cel-post-step.md.
+        """
+        original = _mk(HandlerResultStatus.FAIL, {"any_match": False})
+        result = _apply_cel_expr({"expr": "!(output.any_match)"}, original)
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
+
+    @pytest.mark.unit
+    def test_fail_and_cel_false_preserves_fail(self):
+        """Feature 020 fix (issue #343): handler+CEL agree on fail -> preserve FAIL.
+
+        Previously this was demoted to INCONCLUSIVE, causing the pipeline
+        to fall through to manual and report WARN. See spec FR-001.
+        """
+        original = _mk(
+            HandlerResultStatus.FAIL,
+            {
+                "exit_code": 1,
+                "json": {"message": "Branch not protected", "status": "404"},
+            },
+            message="Command failed (exit code 1)",
+        )
+        result = _apply_cel_expr(
+            {"expr": "has(output.json.required_pull_request_reviews)"},
+            original,
+        )
+        assert result.status == HandlerResultStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# Invariants: pass-through cases (FR-004, FR-005, FR-006, FR-008)
+# ---------------------------------------------------------------------------
+
+
+class TestPassThroughInvariants:
+    """Cases where _apply_cel_expr must return the handler result unchanged."""
+
+    @pytest.mark.unit
+    def test_inconclusive_passes_through(self):
+        """FR-004: handler INCONCLUSIVE -> CEL is not evaluated."""
+        original = _mk(HandlerResultStatus.INCONCLUSIVE, {})
+        result = _apply_cel_expr({"expr": "true"}, original)
+        assert result is original
+        assert result.status == HandlerResultStatus.INCONCLUSIVE
+
+    @pytest.mark.unit
+    def test_error_passes_through(self):
+        """FR-004: handler ERROR -> CEL is not evaluated."""
+        original = _mk(HandlerResultStatus.ERROR, {})
+        result = _apply_cel_expr({"expr": "true"}, original)
+        assert result is original
+        assert result.status == HandlerResultStatus.ERROR
+
+    @pytest.mark.unit
+    def test_no_expr_passes_through(self):
+        """FR-005: config without an expr -> handler result unchanged."""
+        original = _mk(HandlerResultStatus.PASS, {"any_match": True})
+        result = _apply_cel_expr({"handler": "pattern"}, original)
+        assert result is original
+
+    @pytest.mark.unit
+    def test_cel_syntax_error_passes_through(self):
+        """FR-006: CEL evaluation error -> handler result unchanged."""
+        original = _mk(HandlerResultStatus.PASS, {"any_match": True})
+        result = _apply_cel_expr({"expr": "not valid CEL !!"}, original)
+        assert result.status == HandlerResultStatus.PASS
+        assert result is original
+
+    @pytest.mark.unit
+    def test_unknown_exec_exit_code_returns_inconclusive_and_passes_through(self):
+        """FR-008: WARN preservation for network/auth errors.
+
+        When the exec handler encounters an exit code that is neither in
+        `pass_exit_codes` nor `fail_exit_codes` (e.g., 127 for command not
+        found, or 2 for a network-adjacent failure), the handler returns
+        INCONCLUSIVE. The CEL post-step must pass that through unchanged,
+        preserving WARN semantics downstream.
+        """
+        from darnit.sieve.builtin_handlers import exec_handler
+        from darnit.sieve.handler_registry import HandlerContext
+
+        ctx = HandlerContext(
+            local_path="/tmp",
+            owner="testorg",
+            repo="testrepo",
+            default_branch="main",
+            gathered_evidence={},
+            project_context={},
+        )
+        # exit code 42 matches neither pass_exit_codes=[0] nor fail_exit_codes=[1]
+        config = {
+            "command": ["sh", "-c", "exit 42"],
+            "pass_exit_codes": [0],
+            "fail_exit_codes": [1],
+            "expr": "true",  # would flip to PASS if the CEL step ran on non-INCONCLUSIVE
+        }
+        handler_result = exec_handler(config, ctx)
+        assert handler_result.status == HandlerResultStatus.INCONCLUSIVE
+        result = _apply_cel_expr(config, handler_result)
+        assert result is handler_result
+        assert result.status == HandlerResultStatus.INCONCLUSIVE

--- a/tests/darnit_baseline/controls/test_branch_protection.py
+++ b/tests/darnit_baseline/controls/test_branch_protection.py
@@ -1,0 +1,196 @@
+"""Integration tests for the four branch-protection controls (feature 020, issue #343).
+
+Verifies that when the GitHub API returns a definitive 404 "Branch not
+protected" response, each of the following controls resolves to FAIL
+(not WARN, not INCONCLUSIVE):
+
+- OSPS-AC-03.01 (PreventDirectCommits)
+- OSPS-AC-03.02 (PreventBranchDeletion)
+- OSPS-QA-03.01 (RequiredStatusChecks)
+- OSPS-QA-07.01 (RequiredApprovals)
+
+Also verifies the happy path (200 with healthy branch-protection body ->
+PASS) does not regress.
+
+Tests patch `subprocess.run` in the exec handler's module so the test
+does not require `gh` on PATH or network access.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from darnit.config.merger import load_framework_by_name
+from darnit.core.plugin import ControlSpec
+from darnit.sieve.handler_registry import HandlerContext  # noqa: F401 (documentation)
+from darnit.sieve.models import CheckContext
+from darnit.sieve.orchestrator import SieveOrchestrator
+
+NAMED_CONTROLS = (
+    "OSPS-AC-03.01",
+    "OSPS-AC-03.02",
+    "OSPS-QA-03.01",
+    "OSPS-QA-07.01",
+)
+
+BRANCH_NOT_PROTECTED_BODY = json.dumps({
+    "message": "Branch not protected",
+    "documentation_url": "https://docs.github.com/rest/branches/branch-protection#get-branch-protection",
+    "status": "404",
+})
+
+HEALTHY_PROTECTION_BODY = json.dumps({
+    "required_pull_request_reviews": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews": True,
+    },
+    "required_status_checks": {
+        "strict": True,
+        "contexts": ["ci/build"],
+    },
+    "enforce_admins": {"enabled": True},
+    "allow_deletions": {"enabled": False},
+    "allow_force_pushes": {"enabled": False},
+    "restrictions": None,
+    "url": "https://api.github.com/repos/testorg/testrepo/branches/main/protection",
+})
+
+
+def _load_control(control_id: str) -> ControlSpec:
+    """Load a real ControlSpec from openssf-baseline.toml.
+
+    Uses the framework's own loader so we exercise the exact metadata
+    (passes, handler_invocations, etc.) that ships in the TOML.
+    """
+    config = load_framework_by_name("openssf-baseline")
+    control = config.controls[control_id]
+
+    # Build a ControlSpec that carries the handler_invocations metadata
+    # the orchestrator expects. This mirrors how darnit-baseline's
+    # implementation.get_all_controls() constructs its ControlSpecs.
+    tags = control.tags or {}
+    level = control.level if control.level is not None else tags.get("level", 1)
+    domain = control.domain if control.domain is not None else tags.get("domain", "UNKNOWN")
+
+    return ControlSpec(
+        control_id=control_id,
+        name=control.name,
+        description=control.description or "",
+        level=level,
+        domain=domain,
+        metadata={
+            "handler_invocations": control.passes,
+            "when": control.when,
+        },
+    )
+
+
+def _make_context(control_id: str) -> CheckContext:
+    return CheckContext(
+        owner="testorg",
+        repo="testrepo",
+        local_path="/tmp/test-branch-protection",
+        default_branch="main",
+        control_id=control_id,
+        project_context={"platform": "github", "ci_provider": "github"},
+    )
+
+
+class _FakeSubprocessResult:
+    """Minimal stand-in for subprocess.CompletedProcess."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+@pytest.fixture()
+def patched_gh_404():
+    """Patch subprocess.run so `gh api` returns HTTP 404 'Branch not protected'."""
+    def _fake_run(*args, **kwargs):
+        return _FakeSubprocessResult(
+            returncode=1,
+            stdout=BRANCH_NOT_PROTECTED_BODY,
+            stderr="",
+        )
+
+    with patch("darnit.sieve.builtin_handlers.subprocess.run", side_effect=_fake_run):
+        yield
+
+
+@pytest.fixture()
+def patched_gh_200_healthy():
+    """Patch subprocess.run so `gh api` returns HTTP 200 with a healthy protection body.
+
+    For OSPS-QA-07.01 the command adds `--jq
+    '.required_pull_request_reviews.required_approving_review_count >= 1'`,
+    so its stdout should be the string `true`. Other three controls receive
+    the full JSON.
+    """
+    def _fake_run(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args", [])
+        if any("--jq" in str(a) for a in cmd):
+            return _FakeSubprocessResult(returncode=0, stdout="true\n", stderr="")
+        return _FakeSubprocessResult(
+            returncode=0,
+            stdout=HEALTHY_PROTECTION_BODY,
+            stderr="",
+        )
+
+    with patch("darnit.sieve.builtin_handlers.subprocess.run", side_effect=_fake_run):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# FR-007 acceptance: definitive 404 -> FAIL
+# ---------------------------------------------------------------------------
+
+
+class TestDefinitive404ReportsFail:
+    """The four named branch-protection controls MUST report FAIL on 404
+    'Branch not protected' after feature 020 lands."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("control_id", NAMED_CONTROLS)
+    def test_control_resolves_fail_on_branch_not_protected(self, control_id, patched_gh_404):
+        spec = _load_control(control_id)
+        context = _make_context(control_id)
+        orchestrator = SieveOrchestrator(stop_on_llm=True)
+
+        result = orchestrator.verify(spec, context)
+        legacy = result.to_legacy_dict()
+
+        assert legacy["status"] == "FAIL", (
+            f"{control_id}: expected FAIL on 404 'Branch not protected', "
+            f"got {legacy['status']!r}. Message: {legacy.get('message')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# FR-009 regression guard: healthy 200 -> PASS
+# ---------------------------------------------------------------------------
+
+
+class TestHealthyResponsePasses:
+    """Regression guard: when branch protection IS enabled with the expected
+    fields, the four named controls MUST still resolve to PASS. Feature 020's
+    orchestrator change must not affect this path."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("control_id", NAMED_CONTROLS)
+    def test_control_resolves_pass_on_healthy_body(self, control_id, patched_gh_200_healthy):
+        spec = _load_control(control_id)
+        context = _make_context(control_id)
+        orchestrator = SieveOrchestrator(stop_on_llm=True)
+
+        result = orchestrator.verify(spec, context)
+        legacy = result.to_legacy_dict()
+
+        assert legacy["status"] == "PASS", (
+            f"{control_id}: expected PASS on healthy branch-protection body, "
+            f"got {legacy['status']!r}. Message: {legacy.get('message')!r}"
+        )

--- a/tests/darnit_baseline/test_handler_dispatch_integration.py
+++ b/tests/darnit_baseline/test_handler_dispatch_integration.py
@@ -461,7 +461,13 @@ class TestUseLocatorEffectivePath:
 
     @pytest.mark.unit
     def test_osps_do_02_01_effective_config_uses_bug_globs(self):
-        """OSPS-DO-02.01 should resolve explicit bug-template glob patterns."""
+        """OSPS-DO-02.01's pattern pass resolves explicit bug-template glob patterns.
+
+        Feature 020 removed the file_exists pass that was previously present
+        at the head of this control (see openssf-baseline.toml). The pattern
+        pass now carries the full glob list including the bug*.* variants
+        that used to be split between file_exists and pattern.
+        """
         from pathlib import Path
 
         from darnit.config import load_controls_from_effective, load_effective_config_by_name
@@ -470,15 +476,6 @@ class TestUseLocatorEffectivePath:
         controls = load_controls_from_effective(config)
         control = next(ctrl for ctrl in controls if ctrl.control_id == "OSPS-DO-02.01")
         invocations = control.metadata["handler_invocations"]
-
-        file_exists_inv = next((inv for inv in invocations if inv.handler == "file_exists"), None)
-        assert file_exists_inv is not None
-        assert file_exists_inv.files == [
-            ".github/ISSUE_TEMPLATE/bug*.md",
-            ".github/ISSUE_TEMPLATE/bug*.yml",
-            ".github/ISSUE_TEMPLATE/bug*.yaml",
-            ".github/ISSUE_TEMPLATE.md",
-        ]
 
         pattern_inv = next((inv for inv in invocations if inv.handler == "pattern"), None)
         assert pattern_inv is not None
@@ -546,11 +543,28 @@ body:
         result = orchestrator.verify(control, context)
 
         assert result.status == "PASS"
-        assert result.evidence.get("relative_path") == f".github/ISSUE_TEMPLATE/{template_filename}"
+        # After feature 020, DO-02.01's file_exists pass was removed as
+        # redundant with the pattern pass (see openssf-baseline.toml
+        # comment above the DO-02.01 pattern pass). Evidence is now
+        # pattern-handler shape: results[].file rather than relative_path.
+        matched_files = [r["file"] for r in result.evidence.get("results", []) if r.get("matched")]
+        assert any(f.endswith(f".github/ISSUE_TEMPLATE/{template_filename}") for f in matched_files), (
+            f"Expected {template_filename} to be among matched files, got {matched_files}"
+        )
 
     @pytest.mark.unit
     def test_osps_do_02_01_warns_for_feature_only_template(self, tmp_path):
-        """OSPS-DO-02.01 should warn (manual fallback) when only a feature template exists."""
+        """OSPS-DO-02.01 should warn when only a feature template exists.
+
+        End-to-end result is unchanged by feature 020 (still WARN), but the
+        internal path differs: pre-020 pass 1 (file_exists) returned FAIL,
+        the buggy orchestrator demoted it to INCONCLUSIVE, then pass 2
+        (pattern) returned INCONCLUSIVE (no files matched), then pass 3
+        (manual) returned WARN. Post-020 pass 1 was removed (it relied on
+        the demote-FAIL-to-INCONCLUSIVE idiom); pass 2 still returns
+        INCONCLUSIVE for the no-matching-files case, and pass 3 still
+        returns WARN. See specs/020-definitive-fail-verdict/.
+        """
         from pathlib import Path
 
         from darnit.config import load_controls_from_effective, load_effective_config_by_name


### PR DESCRIPTION
## Summary
- **Fixes issue #343.** Branch-protection controls now report FAIL (not WARN) when the GitHub API returns HTTP 404 "Branch not protected." The bug was in the sieve orchestrator's CEL post-step demoting a handler-conclusive FAIL to INCONCLUSIVE when CEL disagreed, causing the pipeline to fall through to the manual pass and yield WARN.
- **Framework change:** `packages/darnit/src/darnit/sieve/orchestrator.py` `_apply_cel_expr` now preserves the conclusion when handler and CEL agree, and defers to INCONCLUSIVE when they disagree. Restores constitutional Principle V (`orchestrator stops at first conclusive result`).
- **Refactored two TOML controls** that relied on the old buggy demote-FAIL-to-INCONCLUSIVE idiom as an implicit "try next pass": OSPS-BR-01.01 (fallback) and OSPS-DO-02.01 (removed a redundant file_exists pass). End-to-end behavior preserved for the tested scenarios.

## New transition table
See `specs/020-definitive-fail-verdict/contracts/cel-post-step.md` for the full documentation.

| Handler | CEL true | CEL false |
|---------|----------|-----------|
| PASS    | PASS     | INCONCLUSIVE (unchanged) |
| FAIL    | INCONCLUSIVE (was PASS) | **FAIL** (was INCONCLUSIVE - this is the fix) |

## Scope note

The `H=FAIL + CEL=true -> PASS` change (top-right cell) is broader than issue #343 strictly requires. During implementation an alternative was considered where only the bottom-right cell would change; that would have been a smaller diff but would have left the framework's other cell semantically inconsistent. The broader change was chosen with the understanding that two TOML controls needed refactoring to compensate.

Twelve controls that combine `fail_exit_codes` + `expr` benefit from the change automatically (see `specs/019-verdict-correctness/research.md` R5). The four named branch-protection controls are the acceptance bar and are covered by new integration tests.

## Test plan
- [x] New: `uv run pytest tests/darnit/sieve/test_orchestrator_cel.py -v` (9 pass, covers full 8-cell transition table + FR-008 WARN preservation)
- [x] New: `uv run pytest tests/darnit_baseline/controls/test_branch_protection.py -v` (8 pass: 4 FAIL cases on 404, 4 PASS regression guards on healthy body)
- [x] `uv run pytest tests/ --ignore=tests/integration/ -m "not upstream" -q` (2275 passed, 6 skipped, 0 failed)
- [x] `uv run ruff check .` (clean)
- [x] `uv run python scripts/validate_sync.py --verbose` (clean, 65 controls)
- [x] Deterministic CLI: `darnit audit /tmp/darnit-test-repo -t level=1` reports FAIL for `OSPS-AC-03.01` and `OSPS-AC-03.02` (previously WARN)
- [x] Nondeterministic: `/darnit-audit` skill invocation reports the same qualitative story (SC-005; verified by @mlieberman85)

## Follow-ups (out of scope for this PR)
- The four remaining justaugustus issues (#341 CLI SARIF/Markdown, #344 audit prints resolved repo, #345 prerequisite-docs consolidation, #346 plugin verification WARN noise). US2 completes the response to #342/#343 pair; other issues remain triaged.
- Bulk-modernize existing controls' `docs_url` from `versions/2025-10-10` to `versions/2026-02-19` (mechanical, deferred).
- RFC-0001 Stage 1 (extract pipeline loop, add `authority` field, expose over MCP). Feature 020 closes the pre-Stage-1 verdict-correctness backlog.

Refs: #343