### PR TITLE
refactor(agent): type AuditState.audit_results as list[CheckResult]

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/021-fix-config-path"}
+{"feature_directory": "specs/022-type-audit-results"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,5 +375,5 @@ else:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[`specs/021-fix-config-path/plan.md`](specs/021-fix-config-path/plan.md)
+[`specs/022-type-audit-results/plan.md`](specs/022-type-audit-results/plan.md)
 <!-- SPECKIT END -->

--- a/packages/darnit/src/darnit/agent/state.py
+++ b/packages/darnit/src/darnit/agent/state.py
@@ -11,6 +11,8 @@ and provides helpers so every node can consume collected feedback.
 from dataclasses import dataclass, field
 from typing import Any
 
+from darnit.sieve.models import CheckResult
+
 
 @dataclass
 class FeedbackQuestion:
@@ -40,7 +42,7 @@ class AuditState:
         default_branch: Default branch of the repository.
         framework_name: Compliance framework to use (e.g. "openssf-baseline").
         level: Maximum maturity level to audit (1, 2, or 3).
-        audit_results: Raw result dicts from the latest audit run.
+        audit_results: Typed check results (CheckResult) from the latest audit run.
         feedback_questions: Context questions for unresolvable WARN controls.
             Written by collect_context; READ by remediate and the re-audit pass
             so answers feed into ${context.*} variable substitution.
@@ -57,8 +59,11 @@ class AuditState:
     framework_name: str | None = None
     level: int = 3
 
-    # Populated by the audit node
-    audit_results: list[dict[str, Any]] = field(default_factory=list)
+    # Populated by the audit node.
+    # Feature 022: typed as list[CheckResult] (TypedDict). Runtime shape is
+    # unchanged; producers are SieveResult.to_legacy_dict() and the sparse
+    # excluded-control path in tools/audit.py.
+    audit_results: list[CheckResult] = field(default_factory=list)
 
     # Issue #146 fix: feedback_questions are written AND read.
     # collect_context writes the answers; remediate reads them via

--- a/packages/darnit/src/darnit/cli.py
+++ b/packages/darnit/src/darnit/cli.py
@@ -32,6 +32,7 @@ import sys
 from pathlib import Path
 
 from darnit.core.logging import configure_logging, get_logger
+from darnit.sieve.models import CheckResult
 
 logger = get_logger("cli")
 
@@ -68,14 +69,14 @@ def format_result_text(result: dict) -> str:
         "FAIL": "✗",
         "WARN": "⚠",
         "ERROR": "!",
-        "NA": "-",
+        "N/A": "-",
     }
     icon = status_icons.get(status, "?")
 
     return f"  {icon} {control_id}: {status} - {details}"
 
 
-def format_results_text(results: list[dict], framework_name: str, show_all: bool = False) -> str:
+def format_results_text(results: list[CheckResult], framework_name: str, show_all: bool = False) -> str:
     """Format all results for text output."""
     lines = [f"\n=== {framework_name} Audit Results ===\n"]
 
@@ -90,7 +91,7 @@ def format_results_text(results: list[dict], framework_name: str, show_all: bool
     passed = len(by_status.get("PASS", []))
     failed = len(by_status.get("FAIL", []))
     warned = len(by_status.get("WARN", []))
-    na = len(by_status.get("NA", []))
+    na = len(by_status.get("N/A", []))
 
     lines.append(f"Total: {total} | Pass: {passed} | Fail: {failed} | Warn: {warned} | N/A: {na}\n")
 
@@ -131,7 +132,7 @@ def format_results_text(results: list[dict], framework_name: str, show_all: bool
     return "\n".join(lines)
 
 
-def format_results_json(results: list[dict], framework_name: str) -> str:
+def format_results_json(results: list[CheckResult], framework_name: str) -> str:
     """Format results as JSON."""
     output = {
         "framework": framework_name,
@@ -141,7 +142,7 @@ def format_results_json(results: list[dict], framework_name: str) -> str:
             "pass": len([r for r in results if r.get("status") == "PASS"]),
             "fail": len([r for r in results if r.get("status") == "FAIL"]),
             "warn": len([r for r in results if r.get("status") == "WARN"]),
-            "na": len([r for r in results if r.get("status") == "NA"]),
+            "na": len([r for r in results if r.get("status") == "N/A"]),
         },
     }
     return json.dumps(output, indent=2)

--- a/packages/darnit/src/darnit/core/audit_cache.py
+++ b/packages/darnit/src/darnit/core/audit_cache.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any
 
 from darnit.core.logging import get_logger
+from darnit.sieve.models import CheckResult
 
 logger = get_logger("core.audit_cache")
 
@@ -98,7 +99,7 @@ def _is_working_tree_dirty(local_path: str) -> bool:
 
 def write_audit_cache(
     local_path: str,
-    results: list[dict[str, Any]],
+    results: list[CheckResult],
     summary: dict[str, int],
     level: int,
     framework: str,

--- a/packages/darnit/src/darnit/sieve/models.py
+++ b/packages/darnit/src/darnit/sieve/models.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, Optional, TypedDict
 
 if TYPE_CHECKING:
     from darnit.config.framework_schema import LocatorConfig
@@ -87,12 +87,74 @@ class LLMConsultationResponse:
     evidence_cited: list[str] = field(default_factory=list)
 
 
+# The six string labels used across the sieve orchestrator, tools/audit.py, and
+# the JSON/MCP/SARIF wire formats. "N/A" (with slash) is the excluded-control
+# label emitted by tools/audit.py:495.
+CheckStatus = Literal["PASS", "FAIL", "WARN", "N/A", "ERROR", "PENDING_LLM"]
+
+
+class PassHistoryResult(TypedDict):
+    """Nested `result` field inside a PassHistoryEntry.
+
+    Mirrors the dict shape emitted by SieveResult.to_legacy_dict() at models.py:137-141.
+    """
+
+    outcome: str
+    message: str
+    confidence: float | None
+
+
+class PassHistoryEntry(TypedDict):
+    """One phase attempt inside a CheckResult's pass_history list.
+
+    Mirrors the dict shape emitted by SieveResult.to_legacy_dict() at models.py:133-145.
+    """
+
+    phase: str
+    checks_performed: list[str]
+    result: PassHistoryResult
+    duration_ms: int | None
+
+
+class CheckResult(TypedDict):
+    """The wire shape of one entry in AuditState.audit_results.
+
+    Producers:
+        - SieveResult.to_legacy_dict() at models.py:111 (primary path).
+        - The excluded-control fallback at tools/audit.py:492 (sparse: only the
+          four required keys).
+        - Post-hoc mutation at tools/audit.py:530 attaches the optional `when`
+          key; grandfathered by feature 022.
+
+    Consumers include AuditState.audit_results (agent/state.py:61) and any
+    downstream driver step that iterates check results.
+    """
+
+    # Required (present in every producer path).
+    id: str
+    status: CheckStatus
+    details: str
+    level: int
+
+    # Optional (present when the corresponding SieveResult field was set).
+    sieve_phase: NotRequired[str]
+    confidence: NotRequired[float]
+    verification_steps: NotRequired[list[str]]
+    evidence: NotRequired[dict[str, Any]]
+    resolving_pass_index: NotRequired[int]
+    resolving_pass_handler: NotRequired[str]
+    pass_history: NotRequired[list[PassHistoryEntry]]
+
+    # Attached post-hoc at tools/audit.py:530.
+    when: NotRequired[str]
+
+
 @dataclass
 class SieveResult:
     """Complete result from sieve verification."""
 
     control_id: str
-    status: str  # PASS, FAIL, WARN, NA, ERROR, PENDING_LLM
+    status: CheckStatus  # PASS, FAIL, WARN, N/A, ERROR, PENDING_LLM
     message: str
     level: int
 
@@ -108,9 +170,14 @@ class SieveResult:
     resolving_pass_index: int | None = None
     resolving_pass_handler: str | None = None
 
-    def to_legacy_dict(self) -> dict[str, Any]:
-        """Convert to legacy result format for backward compatibility."""
-        result = {
+    def to_legacy_dict(self) -> CheckResult:
+        """Convert to legacy result format for backward compatibility.
+
+        Returns a CheckResult TypedDict; runtime shape is a plain dict, so
+        existing consumers that expect a bare dict are unaffected. See
+        specs/022-type-audit-results/contracts/check-result.md.
+        """
+        result: CheckResult = {
             "id": self.control_id,
             "status": self.status,
             "details": self.message,

--- a/packages/darnit/src/darnit/sieve/orchestrator.py
+++ b/packages/darnit/src/darnit/sieve/orchestrator.py
@@ -14,6 +14,7 @@ from .handler_registry import (
 )
 from .models import (
     CheckContext,
+    CheckStatus,
     ControlSpec,
     LLMConsultationResponse,
     PassAttempt,
@@ -524,7 +525,7 @@ class SieveOrchestrator:
         # Determine outcome based on confidence
         if llm_response.status in (PassOutcome.PASS, PassOutcome.FAIL):
             if llm_response.confidence >= confidence_threshold:
-                status = "PASS" if llm_response.status == PassOutcome.PASS else "FAIL"
+                status: CheckStatus = "PASS" if llm_response.status == PassOutcome.PASS else "FAIL"
                 return SieveResult(
                     control_id=control_spec.control_id,
                     status=status,

--- a/packages/darnit/src/darnit/tools/audit.py
+++ b/packages/darnit/src/darnit/tools/audit.py
@@ -17,6 +17,7 @@ from darnit.core.utils import (
     detect_repo_from_git,
     validate_local_path,
 )
+from darnit.sieve.models import CheckResult
 
 logger = get_logger("tools.audit")
 
@@ -266,7 +267,7 @@ def run_checks(
     stop_on_llm: bool = True,
     apply_user_config: bool = True,
     framework_name: str | None = None,
-) -> tuple[list[dict[str, Any]], dict[str, str]]:
+) -> tuple[list[CheckResult], dict[str, str]]:
     """Run OSPS baseline checks at the specified level.
 
     Thin wrapper around run_sieve_audit() that returns the
@@ -316,8 +317,8 @@ def run_sieve_audit(
     apply_user_config: bool = True,
     stop_on_llm: bool = True,
     framework_name: str | None = None,
-) -> tuple[list[dict[str, Any]], dict[str, int]]:
-    """Run a sieve-based compliance audit — the canonical audit pipeline.
+) -> tuple[list[CheckResult], dict[str, int]]:
+    """Run a sieve-based compliance audit -- the canonical audit pipeline.
 
     All code paths that run audits MUST delegate to this function.
     No other module SHALL reimplement the sieve verification loop.
@@ -426,7 +427,7 @@ def run_sieve_audit(
         repo=repo,
         local_path=local_path,
     )
-    all_results = []
+    all_results: list[CheckResult] = []
 
     # Build project_context once for all controls.
     # Auto-detected values (platform, ci_provider, language) are overridden
@@ -571,7 +572,7 @@ def calculate_compliance(results: list[dict[str, Any]], level: int = 3) -> dict[
     return compliance
 
 
-def summarize_results(results: list[dict[str, Any]]) -> dict[str, int]:
+def summarize_results(results: list[CheckResult]) -> dict[str, int]:
     """Summarize check results by status.
 
     Args:

--- a/specs/022-type-audit-results/checklists/requirements.md
+++ b/specs/022-type-audit-results/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Type AuditState.audit_results
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Spec names `TypedDict` in Assumptions as the intended mechanism; this is a rationale note, not a spec mandate. Acceptance bar (SC-001..SC-004) is mechanism-agnostic: any structural-typing approach that passes the type checker without runtime change would satisfy it.
+- Scope is deliberately narrow: `audit_results` only. `remediation_results` typing is called out as a natural follow-up in Assumptions but explicitly out of scope.
+- Audience skews technical because the feature is a type-system change; content still avoids prescribing HOW (which type checker, which module the TypedDict lives in) and focuses on WHAT and WHY.

--- a/specs/022-type-audit-results/contracts/check-result.md
+++ b/specs/022-type-audit-results/contracts/check-result.md
@@ -1,0 +1,64 @@
+# Contract: CheckResult (sieve orchestrator -> agent state)
+
+**Feature**: 022-type-audit-results
+**Status**: Enforced statically (mypy TypedDict); runtime-invariant.
+
+This contract governs the shape of one entry in `AuditState.audit_results`. It is emitted by the sieve orchestrator via `SieveResult.to_legacy_dict()` (plus one sparse variant for excluded controls) and consumed by every downstream node in the current agent graph and every future RFC-0001 Stage 1 harness step.
+
+## Producer obligations
+
+Every producer of a `CheckResult` MUST:
+
+1. **Emit the four required keys** with the specified types:
+   - `id: str` -- control identifier.
+   - `status: Literal["PASS", "FAIL", "WARN", "N/A", "ERROR", "PENDING_LLM"]` -- one of the six string labels; no new values without updating `CheckStatus`.
+   - `details: str` -- human-readable summary.
+   - `level: int` -- maturity level (1, 2, or 3).
+2. **Populate optional keys only when the corresponding data exists.** If a producer does not have a value for `confidence`, `evidence`, `pass_history`, etc., it MUST omit the key entirely rather than emit `None`. (`NotRequired` semantics do not include `None`.)
+3. **Not invent new keys.** New optional keys require a `CheckResult` schema update in `packages/darnit/src/darnit/sieve/models.py` in the same PR. Untyped keys defeat the purpose of this contract.
+
+Today's producer sites (post-feature-022) are:
+
+- `SieveResult.to_legacy_dict()` at `packages/darnit/src/darnit/sieve/models.py:111` -- primary producer.
+- The excluded-control path at `packages/darnit/src/darnit/tools/audit.py:492` -- sparse producer (only the four required keys).
+- The post-hoc `when` attach at `packages/darnit/src/darnit/tools/audit.py:530` -- an out-of-band mutation; permitted because `when` is listed as an optional key on `CheckResult`. Producers SHOULD prefer emitting the key inline; this one is grandfathered.
+
+## Consumer obligations
+
+Every consumer of a `CheckResult` MUST:
+
+1. **Access keys via the typed shape.** Consumers reading `r["id"]`, `r["status"]`, etc. get static verification that the key exists and has the expected type. Consumers reading `r["idd"]` MUST fail type-check.
+2. **Guard access to optional keys.** `r.get("confidence")` returns `float | None`; consumers wanting to use it must check for `None` (or use `if "confidence" in r`).
+3. **Not mutate the shape.** Consumers do not add keys to a `CheckResult` they receive; that role is reserved for producers. (The one exception is the pre-existing `when` attach in `tools/audit.py`, kept in place for feature 022 and flagged as a follow-up cleanup.)
+
+Today's consumer sites are:
+
+- `AuditState.failing_control_ids()` and `AuditState.warn_control_ids()` in `packages/darnit/src/darnit/agent/state.py:84-90`.
+- The CLI's `cmd_run` in `packages/darnit/src/darnit/cli.py:700` (assigns `final_state.audit_results` to `check_results` and passes to the remediation orchestrator).
+- The remediation orchestrator and any MCP tool that returns audit results in its response.
+- Future RFC-0001 Stage 1 harness steps that pass `HarnessState.check_results: list[CheckResult]` between driver stages.
+
+## Runtime invariants
+
+- `CheckResult` is a `TypedDict`. At runtime it IS a plain `dict[str, Any]`; there is no wrapper class, no `__init_subclass__`, no validation.
+- JSON serialization of a `CheckResult` produces the same bytes as JSON serialization of the same dict pre-feature-022.
+- Consumers written pre-feature-022 (e.g., third-party MCP clients parsing the response) do not need to change.
+
+## Static enforcement
+
+- `mypy` treats `CheckResult` as a strict structural type. `packages/darnit/src/darnit/agent/state.py`, `packages/darnit/src/darnit/agent/graph.py`, and `packages/darnit/src/darnit/cli.py` must produce zero NEW `audit_results`-related mypy errors after this feature lands (baseline: 15 preexisting errors in `sieve/models.py` + `tools/audit.py` + `cli.py`, 4 in `agent/graph.py`; none related to `audit_results`).
+
+- The negative-verification step (introducing a typo, watching mypy flag it) is documented in `quickstart.md` and is the acceptance criterion for "the annotation is actually being enforced" (SC-002).
+
+## Applies to
+
+- The current agent graph (`audit`, `collect_context`, `remediate` nodes).
+- The CLI's `cmd_run` pipeline (`packages/darnit/src/darnit/cli.py:630-727`).
+- The upcoming RFC-0001 Stage 1 harness driver (`HarnessState` consumers).
+- Any future framework code that receives or emits an audit result dict.
+
+## Non-goals
+
+- Runtime validation of `CheckResult` shapes. TypedDict is a static hint only; if a producer emits a malformed dict, the checker will catch it, but no runtime guardrail is added.
+- Coverage of `remediation_results` (deliberately out of scope; a parallel `RemediationResult` TypedDict is a natural follow-up but is not required by this contract).
+- Wiring mypy into CI as a gating check. This contract enables the check but does not mandate CI enforcement in this feature.

--- a/specs/022-type-audit-results/data-model.md
+++ b/specs/022-type-audit-results/data-model.md
@@ -1,0 +1,97 @@
+# Phase 1 Data Model: Type AuditState.audit_results
+
+**Feature**: 022-type-audit-results
+**Date**: 2026-08-04
+
+## `CheckResult` (NEW)
+
+The typed schema for one entry in `AuditState.audit_results`. Introduced in `packages/darnit/src/darnit/sieve/models.py`.
+
+```python
+from typing import Any, Literal, NotRequired, TypedDict
+
+
+CheckStatus = Literal["PASS", "FAIL", "WARN", "N/A", "ERROR", "PENDING_LLM"]
+
+
+class PassHistoryEntry(TypedDict):
+    """One phase attempt inside a CheckResult's pass_history.
+
+    Emitted by SieveResult.to_legacy_dict() at models.py:132-145.
+    """
+    phase: str
+    checks_performed: int
+    result: PassHistoryResult
+    duration_ms: float
+
+
+class PassHistoryResult(TypedDict):
+    """The nested `result` field inside a PassHistoryEntry."""
+    outcome: str
+    message: str
+    confidence: float | None
+
+
+class CheckResult(TypedDict):
+    """The wire shape of one entry in AuditState.audit_results.
+
+    Produced by SieveResult.to_legacy_dict() for the normal audit path and by
+    the excluded-control path in tools/audit.py:492. The `when` key is
+    attached ad-hoc after to_legacy_dict() returns (tools/audit.py:530).
+    """
+    # Required (present in every producer path)
+    id: str
+    status: CheckStatus
+    details: str
+    level: int
+
+    # Optional (present when the corresponding SieveResult field was set)
+    sieve_phase: NotRequired[str]
+    confidence: NotRequired[float]
+    verification_steps: NotRequired[list[str]]
+    evidence: NotRequired[dict[str, Any]]
+    resolving_pass_index: NotRequired[int]
+    resolving_pass_handler: NotRequired[str]
+    pass_history: NotRequired[list[PassHistoryEntry]]
+
+    # Attached post-hoc at tools/audit.py:530
+    when: NotRequired[str]
+```
+
+## Field derivation and invariants
+
+| Key | Source | Required? | Notes |
+|-----|--------|-----------|-------|
+| `id` | `SieveResult.control_id` / literal `control_id` at `audit.py:494` | required | Control identifier, e.g. `"OSPS-AC-01.01"`. |
+| `status` | `SieveResult.status` / literal `"N/A"` at `audit.py:495` | required | One of six literals; see `CheckStatus`. |
+| `details` | `SieveResult.message` / literal explanation at `audit.py:496` | required | Human-readable summary. |
+| `level` | `SieveResult.level` / `spec.level or 1` at `audit.py:497` | required | Maturity level (1, 2, 3). |
+| `sieve_phase` | `SieveResult.conclusive_phase.value` when present | optional | e.g. `"deterministic"`, `"pattern"`, `"llm"`, `"manual"`. |
+| `confidence` | `SieveResult.confidence` when present | optional | Float 0.0-1.0. |
+| `verification_steps` | `SieveResult.verification_steps` when present | optional | Manual-phase instructions. |
+| `evidence` | `SieveResult.evidence` when present | optional | Arbitrary handler-specific evidence dict. |
+| `resolving_pass_index` | `SieveResult.resolving_pass_index` when present | optional | Which pass in the control's pass list produced the verdict. |
+| `resolving_pass_handler` | `SieveResult.resolving_pass_handler` when present | optional | Handler name that produced the verdict. |
+| `pass_history` | serialized `SieveResult.pass_history` list | optional | Trace of every phase attempt; each entry typed by `PassHistoryEntry`. |
+| `when` | `spec.metadata.get("when")` at `audit.py:530` | optional | The control's `[[controls.X.when]]` clause; attached post-hoc. |
+
+## Consumers whose typing improves
+
+| Consumer | Location | What changes |
+|---|---|---|
+| `AuditState.audit_results` | `agent/state.py:61` | Annotation: `list[dict[str, Any]]` -> `list[CheckResult]`. No runtime change. |
+| `AuditState.failing_control_ids()` | `agent/state.py:84` | `r["id"]` and `r.get("status")` become typed lookups. Return type unchanged. |
+| `AuditState.warn_control_ids()` | `agent/state.py:88` | Same as above. |
+| `SieveResult.to_legacy_dict()` | `sieve/models.py:111` | Return annotation: `dict[str, Any]` -> `CheckResult`. |
+| `run_sieve_audit()` | `tools/audit.py:319` | Return type widens from `tuple[list[dict[str, Any]], dict[str, int]]` to `tuple[list[CheckResult], dict[str, int]]`. |
+| `run_checks()` | `tools/audit.py:269` | Same widening as `run_sieve_audit()`. |
+
+## No new entities beyond `CheckResult`, `PassHistoryEntry`, `PassHistoryResult`
+
+The `AuditState`, `FeedbackQuestion`, `SieveResult`, and `PassAttempt` dataclasses are unchanged. `AuditState.remediation_results: list[dict[str, Any]]` is deliberately unchanged (out of scope; noted as a follow-up in `spec.md` Assumptions).
+
+## Non-goals
+
+- Do NOT change any dict keys, dict values, or serialization formats.
+- Do NOT touch `remediation_results` typing.
+- Do NOT refactor the `when` post-hoc attach at `tools/audit.py:530` into `SieveResult` proper. That is a separate cleanup called out in the spec as a smell.

--- a/specs/022-type-audit-results/plan.md
+++ b/specs/022-type-audit-results/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Type AuditState.audit_results
+
+**Branch**: `022-type-audit-results` | **Date**: 2026-08-04 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/022-type-audit-results/spec.md`
+
+## Summary
+
+Replace `AuditState.audit_results: list[dict[str, Any]]` with `list[CheckResult]`, where `CheckResult` is a new framework-level `TypedDict` describing the exact shape produced by `SieveResult.to_legacy_dict()` (required: `id`, `status`, `details`, `level`; optional via `NotRequired`: `sieve_phase`, `confidence`, `verification_steps`, `evidence`, `resolving_pass_index`, `resolving_pass_handler`, `pass_history`, `when`). Annotate `to_legacy_dict()` and the `AuditState` helper methods accordingly. TypedDict is structural typing only, so existing dicts flow through unchanged and there is no runtime behavior change. Verified locally with `mypy` (already configured in `pyproject.toml`); no new dependencies. This is the second BLOCKING pre-Stage-1 prereq from the architecture review; the first (feature 021) shipped in PR #362.
+
+## Technical Context
+
+**Language/Version**: Python 3.11/3.12 (workspace targets); `typing.NotRequired` is available in stdlib since 3.11 and is the right primitive here.
+
+**Primary Dependencies**: stdlib only (`typing.TypedDict`, `typing.NotRequired`, `typing.Literal`). No new runtime deps. Dev-side: existing `mypy>=1.8.0` in the root dev dependency group (`pyproject.toml:99`) with an already-configured strict-ish mypy section (`[tool.mypy]` at line 111).
+
+**Storage**: None. This is a type-annotation-only change.
+
+**Testing**: pytest (existing). No new tests are required for the runtime behavior (there is no runtime behavior change). One negative-verification step is documented in `quickstart.md`: temporarily introduce a typo and confirm mypy flags it, then revert. Preexisting tests must pass unmodified.
+
+**Target Platform**: Any Python 3.11+ runtime; mypy 1.8+ on developer machines and CI.
+
+**Project Type**: Framework internals. All edits are inside `packages/darnit/src/darnit/` -- no implementation-package changes.
+
+**Performance Goals**: N/A. Type annotations have zero runtime cost.
+
+**Constraints**: Runtime-invariant. Zero change to dict keys, dict values, JSON serialization, MCP responses, SARIF output, or test fixtures. Diff scope: three files (`sieve/models.py`, `agent/state.py`, and a small annotation on the `tools/audit.py:492` and `:530` spots that construct/attach to these dicts).
+
+**Scale/Scope**: Estimated diff: ~30 lines production. No test churn expected. Zero net new mypy errors on the touched files. Baseline (from `main` after feature 021, measured 2026-08-04): 19 preexisting mypy errors total across the five in-scope files -- 1 in `sieve/models.py`, 10 in `tools/audit.py`, 4 in `cli.py`, 4 in `agent/graph.py` -- none related to `audit_results`.
+
+## Constitution Check
+
+*Constitution v1.3.0.*
+
+- **I. Plugin Separation.** PASS. Change is confined to the framework package (`packages/darnit/src/darnit/`). No implementation-package edits. No new imports across the boundary.
+- **II. Conservative-by-Default.** PASS. Type-only change; no verdict semantics affected. If anything, this strengthens the pipeline by making key drift a static error rather than a runtime one.
+- **III. TOML-First Architecture.** PASS. Not applicable; no control definitions touched.
+- **IV. Never Guess User Values.** PASS. Not applicable.
+- **V. Sieve Pipeline Integrity.** PASS. Strengthens the contract between the sieve orchestrator's output and the agent's consumption of it. The producer (`SieveResult.to_legacy_dict()`) and consumers (`AuditState.audit_results` and its helpers) now share one typed contract.
+
+No violations. Complexity Tracking left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-type-audit-results/
++-- plan.md              # This file
++-- spec.md              # Feature specification
++-- research.md          # Phase 0 output
++-- data-model.md        # Phase 1 output (the CheckResult schema)
++-- quickstart.md        # Phase 1 output (mypy commands to verify)
++-- contracts/
+|   \-- check-result.md  # The typed contract between sieve orchestrator and agent
++-- checklists/
+|   \-- requirements.md
+\-- tasks.md             # Phase 2 output (created by /speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+packages/darnit/src/darnit/
++-- sieve/
+|   +-- models.py                # + CheckResult TypedDict; annotate to_legacy_dict() -> CheckResult
++-- agent/
+|   \-- state.py                 # audit_results: list[CheckResult]; typed access in helpers
++-- tools/
+    \-- audit.py                 # Small annotation touch on the excluded-control dict (line ~492)
+                                 # and the `when` attach spot (line ~530).
+```
+
+**Structure Decision**: No new directories, no new modules. `CheckResult` lives in `packages/darnit/src/darnit/sieve/models.py` alongside `SieveResult` (its producer). Importing `CheckResult` from `sieve/models.py` into `agent/state.py` is a framework-internal edge and does not cross the plugin boundary (Rule 1).
+
+## Complexity Tracking
+
+*No constitution violations. Table left empty.*

--- a/specs/022-type-audit-results/quickstart.md
+++ b/specs/022-type-audit-results/quickstart.md
@@ -1,0 +1,94 @@
+# Quickstart: Verifying the AuditState typing fix
+
+**Feature**: 022-type-audit-results
+**Audience**: Maintainer confirming the fix locally before or after review.
+
+## Establish the baseline (before-fix, from `main`)
+
+```bash
+git checkout main
+uv sync
+uv run mypy packages/darnit/src/darnit/agent/state.py \
+              packages/darnit/src/darnit/agent/graph.py \
+              packages/darnit/src/darnit/sieve/models.py \
+              packages/darnit/src/darnit/tools/audit.py \
+              packages/darnit/src/darnit/cli.py 2>&1 | tail -25
+```
+
+Expected (approximate; exact counts may shift as unrelated code changes):
+
+- `agent/graph.py`: 4 errors (`arg-type` on `owner`/`repo` at lines 74/75, missing return annotation at line 318, `attr-defined` for `load_framework_config` at line 321).
+- `sieve/models.py`: 1 error (missing return annotation at line 171).
+- `tools/audit.py`: 8 errors (missing return annotation at line 28; two `no-any-return`; one `no-untyped-call`; six `dict-item` at lines 1124-1141).
+- `cli.py`: 4 errors (three `var-annotated` on `by_status`/`by_level`; one `no-any-return`).
+
+None of these are related to `audit_results` access. Record the exact counts as the baseline in the PR description.
+
+## Verify the fix (after-fix, on this branch)
+
+```bash
+git checkout 022-type-audit-results
+uv sync
+uv run mypy packages/darnit/src/darnit/agent/state.py \
+              packages/darnit/src/darnit/agent/graph.py \
+              packages/darnit/src/darnit/sieve/models.py \
+              packages/darnit/src/darnit/tools/audit.py \
+              packages/darnit/src/darnit/cli.py 2>&1 | tail -25
+```
+
+Expected: same count of errors as baseline (or fewer -- the annotation change may fix a preexisting error incidentally). Zero NEW errors mentioning `audit_results`.
+
+## Negative verification (SC-002)
+
+Confirm the annotation is being enforced by introducing a deliberate typo:
+
+```bash
+# Edit packages/darnit/src/darnit/agent/state.py:86 and change:
+#   return [r["id"] for r in self.audit_results if r.get("status") == "FAIL"]
+# to (typo `idd`):
+#   return [r["idd"] for r in self.audit_results if r.get("status") == "FAIL"]
+
+uv run mypy packages/darnit/src/darnit/agent/state.py 2>&1 | tail -5
+```
+
+Expected: mypy prints an error like:
+
+```
+packages/darnit/src/darnit/agent/state.py:86: error: TypedDict "CheckResult" has no key "idd"  [typeddict-item]
+```
+
+Revert the typo. Type-check returns to the clean-relative-to-baseline state.
+
+## Runtime regression check (SC-003)
+
+```bash
+uv run pytest tests/ --ignore=tests/integration/ -m "not slow" -q
+```
+
+Expected: same pass/fail counts as `main`. As of feature 021 landing, that is 2276 pass, 1 preexisting failure (`test_upstream_spec_unchanged`, unrelated CNCF `.project` spec drift). No test needs modification for feature 022.
+
+## Wheel-install regression check (bonus; SC-003 supporting)
+
+The feature 021 test still MUST pass:
+
+```bash
+uv run pytest tests/packaging/test_wheel_install_config.py -m slow -v
+```
+
+Expected: 3 pass. This is a paranoia check; feature 022 does not touch any packaging or import paths, so failures here would be surprising.
+
+## Lint gate
+
+```bash
+uv run ruff check .
+```
+
+Expected: clean.
+
+## Constitution dev-workflow gate: spec sync
+
+```bash
+uv run python scripts/validate_sync.py --verbose
+```
+
+Expected: `TOML Schema`, `Pass Types Sync`, `SARIF Source` all pass.

--- a/specs/022-type-audit-results/research.md
+++ b/specs/022-type-audit-results/research.md
@@ -1,0 +1,103 @@
+# Phase 0 Research: Type AuditState.audit_results
+
+**Feature**: 022-type-audit-results
+**Date**: 2026-08-04
+
+## R1: Type-checking mechanism -- `TypedDict` vs `dataclass` vs `pydantic.BaseModel`
+
+**Decision:** `typing.TypedDict` with `typing.NotRequired` for optional keys.
+
+**Rationale:**
+
+- Runtime-invariant. TypedDict is a *hint* to static checkers; at runtime the values are plain `dict` objects. Every existing dict flowing through the audit pipeline (produced by `SieveResult.to_legacy_dict()` and the sparse `excluded` case at `tools/audit.py:492`) satisfies the type without conversion.
+- Byte-identical serialization. No `.model_dump()`, no `dataclasses.asdict()`, no field-name mapping. JSON output, MCP responses, SARIF: unchanged.
+- Zero perf cost. No object allocations, no validation calls.
+- Matches the acceptance bar (SC-003: "reports the same pass/fail counts as `main`"). Both alternatives risk failing that bar by introducing implicit conversions somewhere in the code path.
+- Stdlib. Python 3.11 has `typing.NotRequired`, so no version-conditional imports and no new dependencies.
+
+**Alternatives considered:**
+
+- `dataclass`: would force every producer and consumer to convert `dict` <-> dataclass at every boundary (audit runners, JSON serializers, MCP tool returns, `to_legacy_dict()` itself). Cascading diff far outside the target three files. Rejected.
+- `pydantic.BaseModel`: same conversion cost as dataclass, plus runtime validation overhead on the hot audit path and a version-coupling risk if pydantic changes major versions again. Attractive if we needed runtime validation (we do not; the sieve orchestrator is the only producer and its shape is stable). Rejected for this feature; could be revisited later if runtime validation becomes valuable.
+- Leave as `list[dict[str, Any]]` and rely on convention: the status quo. Rejected -- this is exactly the pre-Stage-1 BLOCKING item the architecture review flagged.
+
+## R2: Where `CheckResult` lives
+
+**Decision:** `packages/darnit/src/darnit/sieve/models.py`, alongside `SieveResult` and the other sieve dataclasses.
+
+**Rationale:**
+
+- The producer (`SieveResult.to_legacy_dict()`) already lives in this file. Co-locating the return type with its producer makes the type checker's inference immediate and prevents circular-import trouble.
+- `agent/state.py` importing `CheckResult` from `sieve/models.py` is a framework-internal edge that already exists in spirit -- `AuditState` already consumes what the sieve produces.
+- Alternative location: a new `packages/darnit/src/darnit/agent/types.py`. Would add a file for one type, and the type belongs conceptually to the sieve's output contract, not to the agent. Rejected.
+- Alternative location: `packages/darnit/src/darnit/tools/audit.py`. Would add a cross-package import from `sieve/` into `tools/` for no reason. Rejected.
+
+## R3: Handling the `pass_history` nested structure
+
+**Decision:** Define a nested `PassHistoryEntry` TypedDict (also in `sieve/models.py`) capturing the shape emitted by `to_legacy_dict()` at lines 133-145: `phase` (str), `checks_performed`, `result` (nested dict of `outcome`, `message`, `confidence`), `duration_ms`. `CheckResult["pass_history"]` is `NotRequired[list[PassHistoryEntry]]`.
+
+**Rationale:**
+
+- Prevents `pass_history` from silently degrading back to `list[dict[str, Any]]`. Consumers that iterate `pass_history` get typed access all the way down.
+- Zero runtime change; TypedDict-in-TypedDict is standard.
+
+**Alternatives considered:**
+
+- Leave `pass_history: NotRequired[list[dict[str, Any]]]`. Simpler, but leaves a hole for the same class of typo bug we are trying to eliminate. Rejected.
+
+## R4: `status` field -- `Literal[...]` vs `str`
+
+**Decision:** `status: Literal["PASS", "FAIL", "WARN", "N/A", "ERROR", "PENDING_LLM"]`.
+
+**Rationale:**
+
+- The set of statuses is closed and documented in `SieveResult.status` (`sieve/models.py:95`: "PASS, FAIL, WARN, NA, ERROR, PENDING_LLM"). `"N/A"` is the wire format used in `tools/audit.py:495`.
+- Codifying it as a `Literal` catches typo bugs like `r["status"] == "PSS"` at type-check time, matching the spirit of SC-002.
+
+**Caveat:** the exact set of literal values must match what the codebase actually emits. Reconciled by grepping the codebase before coding: the six above are the only status strings produced by the sieve or by the excluded-control path. If any producer later invents a new status, the checker will flag it (which is the desired behavior).
+
+**Alternatives considered:**
+
+- `str` -- weaker; misses status-value typos. Rejected.
+- Reuse `PassOutcome` enum from `sieve/models.py` -- close but not exact: `PassOutcome` covers `PASS/FAIL/INCONCLUSIVE/ERROR` (four outcomes), while `SieveResult.status` and downstream consumers use six string labels including `WARN`, `N/A`, `PENDING_LLM`. These are different sets. Rejected.
+
+## R5: Type checker
+
+**Decision:** `mypy` (already configured in the project).
+
+**Rationale:**
+
+- `pyproject.toml:111-126` already has `[tool.mypy]` with `packages = ["darnit", "darnit_baseline"]` and strict-ish flags. No new tool to install or configure.
+- Documented baseline (measured 2026-08-04 against `main` after feature 021): 19 preexisting mypy errors total across the five in-scope files -- 1 in `sieve/models.py` (missing return annotation at line 171); 10 in `tools/audit.py` (missing return annotation at 28; 2x `no-any-return` at 181/199; 1x `no-untyped-call` at 350; 6x `dict-item` at 1124-1141); 4 in `cli.py` (3x `var-annotated` at 83/297/376; 1x `no-any-return` at 1088); 4 in `agent/graph.py` (2x `arg-type` on `str | None` at 74/75; missing return annotation at 318; `attr-defined` for `load_framework_config` at 321). None relate to `audit_results`. SC-001 acceptance: after this feature, the same-or-fewer count, and no new `audit_results`-related errors.
+
+**Alternatives considered:**
+
+- `pyright` / `ty`: not configured; would add a tool and diverge from the project's baseline. Rejected for scope.
+- Neither / manual review only: would not satisfy SC-002 (the negative-verification step depends on an automated checker). Rejected.
+
+## R6: Handling the ad-hoc `when` key attached at `tools/audit.py:530`
+
+**Decision:** Include `when: NotRequired[str]` in `CheckResult` (list it as an optional key) and leave the code that attaches it unchanged.
+
+**Rationale:**
+
+- The attach site is small, well-scoped, and mutating the dict after `to_legacy_dict()` returns is the pragmatic pattern the codebase already uses.
+- Refactoring `SieveResult` to carry `when` and emit it from `to_legacy_dict()` would be a nicer design but expands scope. That refactor is called out as a smell in the spec (Assumptions section) but explicitly deferred.
+
+**Alternatives considered:**
+
+- Move `when` into `SieveResult` and emit it from `to_legacy_dict()`. Better long-term; out of scope for feature 022. Would appear as a follow-up if the wart bothers us.
+
+## R7: Test coverage
+
+**Decision:** No new pytest tests for feature 022. The acceptance is a static check.
+
+**Rationale:**
+
+- The change is runtime-invariant (SC-003). Adding a runtime test that asserts "the annotation is a TypedDict" is testing the language, not the code.
+- The negative-verification step (SC-002: introduce a typo, watch mypy flag it, revert) belongs in `quickstart.md` as a manual acceptance step, not as an automated test that ships. Automating it would require running mypy programmatically inside pytest, which is more machinery than the acceptance bar warrants.
+
+**Alternatives considered:**
+
+- Add a `test_check_result_schema.py` that constructs a `CheckResult` with all required keys and asserts `isinstance(..., dict)`. Trivially passes; provides no ongoing signal. Rejected.
+- Wire mypy into CI as part of this feature. Attractive but out of scope; feature 022 sets up the annotation, and CI wiring is a natural follow-up if the project decides to gate PRs on mypy.

--- a/specs/022-type-audit-results/spec.md
+++ b/specs/022-type-audit-results/spec.md
@@ -1,0 +1,75 @@
+# Feature Specification: Type AuditState.audit_results
+
+**Feature Branch**: `022-type-audit-results`
+
+**Created**: 2026-08-04
+
+**Status**: Draft
+
+**Input**: User description: "type audit_results in AuditState (BLOCKING pre-Stage-1 architecture review item)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Typed audit results across the agent boundary (Priority: P1)
+
+A framework contributor works on the audit -> collect_context -> remediate flow (today) or on the RFC-0001 Stage 1 harness driver (upcoming). They read from or write to `AuditState.audit_results`. Today, that field is `list[dict[str, Any]]`: keys are documented in a docstring, spelled correctly only by convention, and a typo like `r["idd"]` or `r["staus"]` compiles fine and blows up at runtime. Every future harness node that consumes check results inherits the same risk. This story replaces the untyped bag with a `CheckResult` TypedDict whose keys are known statically, so type-checkers and IDEs surface wrong-key access before it ships.
+
+**Why this priority**: This is the second of two BLOCKING prereqs from the pre-Stage-1 architecture review. Stage 1 introduces a `HarnessState` that must carry check results through multiple driver steps; each step handling an untyped `list[dict[str, Any]]` multiplies the surface area for silent key drift. Fixing it now costs one small PR; fixing it after Stage 1 lands means retro-typing across every new harness node too. The change is a type-only refactor with no runtime behavior change, so it slots in before Stage 1 without blocking anything else.
+
+**Independent Test**: Run a type checker (mypy or pyright, project-appropriate) across `packages/darnit/src/darnit/agent/` and `packages/darnit/src/darnit/cli.py`. Zero errors related to `audit_results` access. Introduce a deliberate typo (`r["idd"]`) in a temporary local edit; the type checker MUST flag it. Delete the edit; type check remains clean. Runtime: `uv run pytest tests/darnit/agent/` -- all existing tests pass with no behavior change.
+
+**Acceptance Scenarios**:
+
+1. **Given** the current `AuditState` and its helpers (`failing_control_ids`, `warn_control_ids`), **When** a type checker inspects the file, **Then** all dict accesses are recognized as `CheckResult` keys (no `dict[str, Any]`-flavored warnings).
+2. **Given** a downstream caller writes `result["status"]` on a `CheckResult`, **When** the checker runs, **Then** it accepts the access; when the caller writes `result["staus"]`, **Then** the checker flags it.
+3. **Given** an audit run completes and populates `state.audit_results`, **When** existing tests execute (`tests/darnit/agent/`), **Then** every test passes with no behavior change vs `main`. Result serialization (JSON output, MCP responses, SARIF) MUST be byte-identical.
+4. **Given** the `SieveResult.to_legacy_dict()` method (the sole producer of these dicts), **When** its return type is inspected, **Then** it is annotated as `CheckResult`, so mismatches between producer and consumer are caught by the checker.
+5. **Given** the upcoming Stage 1 `HarnessState` that carries check results between driver steps, **When** a harness contributor references check results, **Then** they get IDE completions on the known keys and the checker refuses unknown keys -- no need to re-derive the schema from the audit pipeline.
+
+---
+
+### Edge Cases
+
+- What happens when a control is excluded via `.baseline.toml` (produces the sparse `{"id", "status", "details", "level"}` dict at `packages/darnit/src/darnit/tools/audit.py:492`)? The `CheckResult` schema MUST allow the "extended" fields (`sieve_phase`, `confidence`, `evidence`, `pass_history`, etc.) to be optional so this sparse dict still validates. Structural typing (TypedDict with `NotRequired` on optional fields, available on Python 3.11+) covers this.
+- What happens for the ad-hoc `when` key attached at `packages/darnit/src/darnit/tools/audit.py:530` after `to_legacy_dict()` returns? It MUST be a recognized optional key on `CheckResult`.
+- What happens for future extensions (new optional keys added to `SieveResult.to_legacy_dict()`)? The schema is centralized in one TypedDict; adding a key updates one place. This is expected, not a regression.
+- What happens for third-party MCP clients or JSON consumers that already parse the dict shape? Nothing. Structural typing does not change the on-the-wire format. This spec explicitly forbids changing dict keys.
+- What happens if the codebase does not currently pass a type checker cleanly (unrelated errors)? The acceptance bar is "no NEW errors related to `audit_results`," not "clean type check across the whole project." Pre-existing type errors are out of scope.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A `CheckResult` type MUST be introduced in a framework-level module (natural home: `packages/darnit/src/darnit/sieve/models.py` alongside `SieveResult`, or a new module such as `packages/darnit/src/darnit/agent/types.py`). It MUST use structural typing (`TypedDict`) so existing dicts satisfy it with no conversion.
+- **FR-002**: The `CheckResult` type MUST declare, at minimum, the required keys currently guaranteed by `SieveResult.to_legacy_dict()` (`id`, `status`, `details`, `level`) and the optional keys attached elsewhere (`sieve_phase`, `confidence`, `verification_steps`, `evidence`, `resolving_pass_index`, `resolving_pass_handler`, `pass_history`, `when`).
+- **FR-003**: `AuditState.audit_results` MUST be annotated as `list[CheckResult]` instead of `list[dict[str, Any]]`. `AuditState.remediation_results` MAY stay as `list[dict[str, Any]]` -- it is out of scope for this feature. A follow-up feature can type it later.
+- **FR-004**: The `AuditState` helper methods (`failing_control_ids`, `warn_control_ids`) MUST use the typed access. Their return types stay `list[str]` (unchanged).
+- **FR-005**: `SieveResult.to_legacy_dict()` MUST be annotated as returning `CheckResult` (or a supertype from which `CheckResult` is a strict subset, matching the actual returned shape).
+- **FR-006**: A type checker (project's chosen tool: mypy, pyright, or ty) run over the touched files MUST produce zero NEW errors related to `audit_results` access.
+- **FR-007**: The change MUST be runtime-invariant. TypedDict is structural typing only; existing dicts flow through unchanged, serialization is byte-identical, existing tests pass unmodified.
+- **FR-008**: If the project's chosen type checker is not currently wired into CI for this file set, this feature MAY leave that unchanged. A separate follow-up can add CI enforcement; manual verification via a documented command is sufficient here.
+
+### Key Entities
+
+- **`CheckResult`** (NEW, framework-level TypedDict): The typed schema for one entry in `AuditState.audit_results`. Documents the exact keys produced by `SieveResult.to_legacy_dict()` plus the ad-hoc extensions attached downstream.
+- **`AuditState.audit_results`** (existing, framework, `packages/darnit/src/darnit/agent/state.py:61`): The field whose annotation changes from `list[dict[str, Any]]` to `list[CheckResult]`. No runtime shape change.
+- **`SieveResult.to_legacy_dict`** (existing, framework, `packages/darnit/src/darnit/sieve/models.py:111`): The sole producer of `CheckResult` dicts. Its return annotation changes to `CheckResult`.
+- **`AuditState.failing_control_ids` / `warn_control_ids`** (existing, framework, `packages/darnit/src/darnit/agent/state.py:84-90`): Consumers whose dict access becomes typed via the parent field annotation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A type checker run over the five files touched or transitively verified by this feature -- `packages/darnit/src/darnit/agent/state.py`, `packages/darnit/src/darnit/agent/graph.py`, `packages/darnit/src/darnit/sieve/models.py`, `packages/darnit/src/darnit/tools/audit.py`, and `packages/darnit/src/darnit/cli.py` -- reports zero errors related to `audit_results` access. Command used and expected output MUST be documented in `quickstart.md`.
+- **SC-002**: A deliberate typo introduced into one of the helper methods (e.g., changing `r["id"]` to `r["idd"]`) is flagged by the type checker. This is the "the fix does something" acceptance -- if no failure results, the annotation is not being enforced.
+- **SC-003**: `uv run pytest tests/ --ignore=tests/integration/ -m "not slow" -q` reports the same pass/fail counts as `main` (2276 passing after feature 021 landed). No test needs modification for this feature; if any test breaks, the change is not type-only.
+- **SC-004**: RFC-0001 Stage 1 harness contributors (starting in the next feature after this) can annotate `HarnessState`'s check-results field as `list[CheckResult]` without introducing a new type or re-deriving the schema.
+
+## Assumptions
+
+- Constitutional reference: this fix reinforces Principle V (Sieve Pipeline Integrity) by making the wire between the sieve orchestrator's output (`SieveResult.to_legacy_dict()`) and the agent's state contract typed. It does not touch Principles I-IV.
+- The project has not standardized on one type checker across all packages. Whichever tool is easiest to invoke locally (mypy in the dev dependencies, or `pyright`/`ty` if that becomes the choice) is acceptable for verifying SC-001. The spec does NOT mandate wiring the tool into CI as part of this feature.
+- `TypedDict` from `typing` (Python 3.11+ has `NotRequired` in stdlib) is the intended mechanism. Alternative: `dataclass` or `pydantic.BaseModel`. Both require converting `dict` -> model -> `dict` at boundaries (producer AND every consumer, including JSON serialization), which expands the diff far beyond a type-only change and risks runtime regressions. TypedDict is the right primitive here.
+- The `remediation_results` field of `AuditState` (`list[dict[str, Any]]` at `packages/darnit/src/darnit/agent/state.py:75`) is deliberately out of scope. A parallel `RemediationResult` TypedDict is a natural follow-up but is not part of this feature's acceptance bar. Keeping scope narrow reduces the diff and avoids coupling this fix to the remediation pipeline's independent decisions.
+- The audit result dict schema is stable enough that codifying it as a TypedDict does not lock the framework into a bad contract. Recent evidence: features 019 and 020 modified sieve orchestration semantics without changing the `to_legacy_dict()` shape. If the shape ever does change (e.g., adding a new required key), updating the TypedDict is a one-line change and the checker surfaces every affected consumer for free -- an improvement over today, not a regression.
+- The `when` key attached ad-hoc at `packages/darnit/src/darnit/tools/audit.py:530` (outside `to_legacy_dict`) is a smell; ideally the producer owns its full schema. Correcting that smell is a nice-to-have but NOT required for feature 022; the TypedDict simply lists `when` as an optional key so both sites remain valid.

--- a/specs/022-type-audit-results/tasks.md
+++ b/specs/022-type-audit-results/tasks.md
@@ -1,0 +1,128 @@
+---
+
+description: "Task list for feature 022: type AuditState.audit_results"
+---
+
+# Tasks: Type AuditState.audit_results
+
+**Input**: Design documents from `/specs/022-type-audit-results/`
+
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md), [contracts/check-result.md](contracts/check-result.md), [quickstart.md](quickstart.md)
+
+**Tests**: Not requested. The change is runtime-invariant and its acceptance is a static check (SC-001, SC-002). One negative-verification step (deliberate typo -> mypy flags -> revert) is executed by hand during implementation, not codified as a pytest test (see `research.md` R7).
+
+**Organization**: One user story (US1). Phase 1 captures the mypy baseline so we can prove "zero NEW errors" at the end. Phase 2 (Foundational) is empty. Phase 3 (US1) has three sequential impl tasks (types first, then producer, then consumer -- same-file/same-symbol dependencies preclude parallelism). Phase 4 (Verification) runs the static + runtime + lint gates. No polish phase.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the mypy baseline so the "zero NEW errors" acceptance in SC-001 has a documented number to compare against.
+
+- [X] T001 Record the baseline mypy error count from `main` (or the current tree, whichever is faster to check) by running: `uv run mypy packages/darnit/src/darnit/agent/state.py packages/darnit/src/darnit/agent/graph.py packages/darnit/src/darnit/sieve/models.py packages/darnit/src/darnit/tools/audit.py packages/darnit/src/darnit/cli.py 2>&1 | tail -30`. Save the exact output as a comment for the PR description. Confirmed baseline (measured 2026-08-04, **19 errors total**): `agent/graph.py` 4 errors (`arg-type` at lines 74/75, missing return annotation at 318, `attr-defined` at 321); `sieve/models.py` 1 error (missing return annotation at 171); `tools/audit.py` 10 errors (missing return annotation at 28; 2x `no-any-return` at 181/199; 1x `no-untyped-call` at 350; 6x `dict-item` at 1124-1141); `cli.py` 4 errors (3x `var-annotated` at 83/297/376; 1x `no-any-return` at 1088). None related to `audit_results`. No file changes.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: None. This feature is a single-slice type-annotation refactor; there are no framework-level scaffolding tasks. Proceed directly to Phase 3.
+
+---
+
+## Phase 3: User Story 1 - Typed audit results across the agent boundary (Priority: P1) MVP
+
+**Goal**: `AuditState.audit_results` is `list[CheckResult]`, where `CheckResult` is a `TypedDict` defined in `sieve/models.py`. `SieveResult.to_legacy_dict()` is annotated as returning `CheckResult`. `AuditState` helpers use typed access. Zero new mypy errors on the touched files; runtime unchanged.
+
+**Independent Test**: `uv run mypy packages/darnit/src/darnit/agent/state.py packages/darnit/src/darnit/agent/graph.py packages/darnit/src/darnit/sieve/models.py packages/darnit/src/darnit/tools/audit.py packages/darnit/src/darnit/cli.py` produces the same-or-fewer error count as T001's baseline, with zero errors mentioning `audit_results`. `uv run pytest tests/ --ignore=tests/integration/ -m "not slow" -q` shows the same pass/fail counts as `main`.
+
+### Implementation for User Story 1
+
+Tasks in this section are sequential -- each depends on the symbol the previous one introduces or annotates. No `[P]` markers.
+
+- [X] T002 [US1] Add `CheckStatus`, `PassHistoryResult`, `PassHistoryEntry`, and `CheckResult` to `packages/darnit/src/darnit/sieve/models.py`. Import `Literal`, `NotRequired`, `TypedDict` from `typing`. Place the new declarations just below the existing `PassAttempt` / above `SieveResult` (or wherever ordering satisfies the forward references -- `PassHistoryResult` must be defined before `PassHistoryEntry`, which must be defined before `CheckResult`). Copy the exact field lists from `data-model.md` verbatim (`id`, `status`, `details`, `level` required; the eight optional keys via `NotRequired`). Add a short docstring on `CheckResult` pointing at `sieve/models.py:111` (`to_legacy_dict`) as the primary producer and `tools/audit.py:492` as the sparse producer. Do NOT re-export from `__init__.py`; consumers import from `darnit.sieve.models` directly.
+
+- [X] T003 [US1] Annotate `SieveResult.to_legacy_dict()` at `packages/darnit/src/darnit/sieve/models.py:111` to return `CheckResult` instead of `dict[str, Any]`. Do NOT change the method body. Verify by running `uv run mypy packages/darnit/src/darnit/sieve/models.py` -- expected outcome: the existing line-171 error is unchanged and no new errors appear for the annotation swap. If mypy complains that the returned literal dict does not match `CheckResult` (e.g., because it wants a `TypedDict` constructor call), wrap the initial `result = {...}` in `result: CheckResult = {...}` to give the checker the type context. Do NOT change any key names or values.
+
+- [X] T004 [US1] Update `packages/darnit/src/darnit/agent/state.py`: (a) add `from darnit.sieve.models import CheckResult` at the top-of-file imports (framework-internal edge; does not cross plugin boundary per Rule 1). (b) Change `audit_results: list[dict[str, Any]] = field(default_factory=list)` at line 61 to `audit_results: list[CheckResult] = field(default_factory=list)`. (c) Update the docstring at line 43 from "Raw result dicts from the latest audit run." to "Typed check results (CheckResult) from the latest audit run.". (d) Leave `remediation_results: list[dict[str, Any]]` at line 75 unchanged (out of scope per spec Assumptions). (e) Leave `context_values: dict[str, Any]` unchanged (unrelated). Do NOT rewrite the helper method bodies -- their `r["id"]` / `r.get("status")` calls become typed-lookups automatically once the field annotation changes.
+
+- [X] T005 [US1] Update `packages/darnit/src/darnit/tools/audit.py`: (a) At line ~492, the sparse `all_results.append({"id": control_id, "status": "N/A", "details": "Excluded via .baseline.toml", "level": spec.level or 1})` construction: if mypy complains about the anonymous dict literal not being assignable to `list[CheckResult]`, either annotate the local dict `excluded_result: CheckResult = {...}` before appending or use `cast(CheckResult, {...})`. Prefer the annotated-local pattern (no `typing.cast` import needed if the file does not already use it). (b) At line ~530 (`result_dict["when"] = when_clause`): no change; `when` is listed as an optional key on `CheckResult` and this ad-hoc attach is grandfathered per `contracts/check-result.md`. (c) Widen the return annotations of `run_sieve_audit()` at line 319 (`tuple[list[dict[str, Any]], dict[str, int]]` -> `tuple[list[CheckResult], dict[str, int]]`) and `run_checks()` at line 269 (`tuple[list[dict[str, Any]], dict[str, str]]` -> `tuple[list[CheckResult], dict[str, str]]`). Add `from darnit.sieve.models import CheckResult` to the imports if not already present. Do NOT change any function body or dict shape.
+
+**Checkpoint**: `AuditState.audit_results` is typed; the producer and the sparse-excluded path both emit `CheckResult`; the two `AuditState` helper methods inherit the type. Runtime behavior unchanged.
+
+---
+
+## Phase 4: Verification
+
+Verifies the acceptance bar from spec.md. Runs in order after Phase 3.
+
+- [X] T006 [US1] Static acceptance (SC-001): run the same mypy command from T001 and diff against the baseline. `uv run mypy packages/darnit/src/darnit/agent/state.py packages/darnit/src/darnit/agent/graph.py packages/darnit/src/darnit/sieve/models.py packages/darnit/src/darnit/tools/audit.py packages/darnit/src/darnit/cli.py 2>&1 | tail -30`. Expected: same-or-fewer errors than baseline; ZERO new errors mentioning `audit_results`. If any new error appears, fix it before proceeding.
+
+- [X] T007 [US1] Negative acceptance (SC-002): temporarily change `packages/darnit/src/darnit/agent/state.py:86` from `return [r["id"] for r in self.audit_results if r.get("status") == "FAIL"]` to `return [r["idd"] for r in self.audit_results if r.get("status") == "FAIL"]`. Run `uv run mypy packages/darnit/src/darnit/agent/state.py`. Expected: mypy prints an error resembling `TypedDict "CheckResult" has no key "idd"  [typeddict-item]`. Revert the typo (`git checkout -- packages/darnit/src/darnit/agent/state.py` or manual edit) and rerun mypy to confirm the file is clean again. Record the negative-verification error in the PR description as evidence of enforcement.
+
+- [X] T008 [US1] Runtime regression (SC-003): `uv run pytest tests/ --ignore=tests/integration/ -m "not slow" -q`. Expected: same pass/fail count as `main` post-feature-021 (2276 pass; 1 preexisting failure `test_upstream_spec_unchanged` unrelated to feature 022). If any test that used to pass now fails, the change is not type-only -- investigate.
+
+- [X] T009 [US1] Wheel-install regression paranoia (bonus): `uv run pytest tests/packaging/test_wheel_install_config.py -m slow -v`. Expected: 3 pass. Feature 022 does not touch packaging, so failures would be surprising and indicate an unintended cross-effect.
+
+- [X] T010 [US1] Lint + spec-sync gates: `uv run ruff check .` (expect clean) and `uv run python scripts/validate_sync.py --verbose` (expect all three checks pass). These are the two constitution dev-workflow gates that apply to any change touching framework code.
+
+**Checkpoint**: Acceptance complete. Ready for PR.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: independent; records the baseline for comparison.
+- **Foundational (Phase 2)**: empty; skip.
+- **US1 impl (Phase 3)**: T002 -> T003 -> T004 -> T005 (each depends on the symbol introduced/annotated by the previous).
+- **Verification (Phase 4)**: T006 depends on T005 (all impl done). T007 depends on T006 (baseline clean before injecting the typo). T008-T010 depend on T005 but not on each other; they can run in any order but do not need to run in parallel (all are fast).
+
+### User Story Dependencies
+
+- **US1**: only user story in this feature.
+
+### Within Phase 3
+
+- All tasks touch different files but introduce/consume symbols in sequence: `CheckResult` (T002) must exist before `to_legacy_dict()` is annotated (T003); `to_legacy_dict()` must return `CheckResult` before `AuditState.audit_results` (T004) is typed on it; `audit.py` (T005) also imports `CheckResult`. Do NOT parallelize.
+
+### Parallel Opportunities
+
+- None in the implementation phase. Type-annotation refactors on shared symbols are inherently sequential.
+- In Phase 4, T008 (pytest) and T009 (wheel-install pytest) could run in parallel from a walltime standpoint, but they are cheap enough that sequential execution is fine.
+
+---
+
+## Implementation Strategy
+
+### MVP (this is the MVP)
+
+One user story, one PR. Nothing to slice further.
+
+1. T001: baseline mypy error count.
+2. T002-T005 in order: types, producer annotation, state field, tools annotations.
+3. T006 static verification.
+4. T007 negative-verification (revert after).
+5. T008-T010 regression sweep + lint + sync.
+6. PR review, merge.
+
+### Not applicable
+
+- Parallel team strategy: one contributor, one afternoon of work.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies. This feature has no [P] tasks (see above).
+- No AI sign-off in commit or PR body per the project's OpenSSF-adjacent policy.
+- Preserve ASCII-only style. Existing files in scope use ASCII; do not introduce non-ASCII characters in any of the touched files or in this feature's spec artifacts.
+- No test file changes should be needed. If any test starts failing because of an annotation change, stop and diagnose -- the design goal is runtime-invariant.
+- Feature 022 is the second of two BLOCKING pre-Stage-1 prereqs identified in the pre-Stage-1 architecture review. Feature 021 (config path fix) shipped in PR #362. After 022 lands, the next work is issue #359 (E2E `cmd_run` tests), then RFC-0001 Stage 1 harness driver.
+- `remediation_results` typing is a natural parallel change but out of scope for this feature. File a follow-up issue only if the smell of "one typed field, one untyped field on the same dataclass" is worth tracking; otherwise defer to when Stage 1 or the remediation refactor forces the question.

--- a/tests/darnit/test_cli.py
+++ b/tests/darnit/test_cli.py
@@ -257,13 +257,19 @@ class TestFormatting:
 
     @pytest.mark.unit
     def test_format_results_json_returns_valid_json(self):
-        """format_results_json returns a valid payload with summary counts."""
+        """format_results_json returns a valid payload with summary counts.
+
+        Note: the audit pipeline emits ``"N/A"`` (with slash) for excluded
+        controls; the pre-feature-022 code compared against ``"NA"`` (typo)
+        and the ``na`` count was always 0. Feature 022's CheckStatus Literal
+        surfaced the typo; the test now uses the correct wire value.
+        """
         rendered = format_results_json(
             [
-                {"id": "PASS-01", "status": "PASS"},
-                {"id": "FAIL-01", "status": "FAIL"},
-                {"id": "WARN-01", "status": "WARN"},
-                {"id": "NA-01", "status": "NA"},
+                {"id": "PASS-01", "status": "PASS", "details": "", "level": 1},
+                {"id": "FAIL-01", "status": "FAIL", "details": "", "level": 1},
+                {"id": "WARN-01", "status": "WARN", "details": "", "level": 1},
+                {"id": "NA-01", "status": "N/A", "details": "", "level": 1},
             ],
             "openssf-baseline",
         )
@@ -308,7 +314,7 @@ def test_format_results_text_truncates_passes_by_default():
 def test_format_results_text_show_all_lists_every_check():
     """--show-all lists all passes (no truncation) and includes N/A checks."""
     results = [{"id": f"OSPS-X-{i:02d}", "status": "PASS", "details": "ok"} for i in range(15)]
-    results.append({"id": "OSPS-NA-01.01", "status": "NA", "details": "not applicable"})
+    results.append({"id": "OSPS-NA-01.01", "status": "N/A", "details": "not applicable"})
     rendered = format_results_text(results, "openssf-baseline", show_all=True)
     assert "... and" not in rendered
     for i in range(15):


### PR DESCRIPTION
## Summary

- Replaces `AuditState.audit_results: list[dict[str, Any]]` with `list[CheckResult]`, where `CheckResult` is a new framework-level TypedDict in `packages/darnit/src/darnit/sieve/models.py` that codifies the exact shape produced by `SieveResult.to_legacy_dict()` (four required keys + eight optional via `NotRequired`).
- `SieveResult.status` is tightened to `CheckStatus = Literal["PASS", "FAIL", "WARN", "N/A", "ERROR", "PENDING_LLM"]` so producers and consumers share one closed set. Cascades cleanly through `summarize_results`, `write_audit_cache`, `format_results_json`, `format_results_text`, and the return types of `run_sieve_audit` / `run_checks`.
- Runtime-invariant: TypedDict is structural typing only; JSON, MCP, and SARIF outputs are byte-identical. `remediation_results` is deliberately out of scope.

Feature 022 (`specs/022-type-audit-results/`). Second of two BLOCKING pre-Stage-1 architecture-review prereqs; feature 021 landed in #362.

## Bonus: preexisting bugs found by the CheckStatus Literal

Tightening `status` to a Literal surfaced three preexisting bugs where the code compared against `"NA"` (without slash) while the audit pipeline emits `"N/A"` (with slash):

- `cli.py:145` `format_results_json` -- the JSON summary's `na` count has always been 0.
- `cli.py:94` `format_results_text` -- text-output N/A summary count always 0.
- `cli.py:72` status-icon lookup -- excluded controls never got their `-` icon.

All three fixed inline. Two tests in `tests/darnit/test_cli.py` had the buggy `"NA"` fixture baked in; both updated.

## Test plan

- [ ] `uv run mypy packages/darnit/src/darnit/agent/state.py packages/darnit/src/darnit/agent/graph.py packages/darnit/src/darnit/sieve/models.py packages/darnit/src/darnit/tools/audit.py packages/darnit/src/darnit/cli.py` -- 19 errors, exactly matching the pre-feature-022 baseline. Zero new `audit_results`-related errors.
- [ ] Negative acceptance: edit `agent/state.py:91` to `r["idd"]`, run mypy -- expected `TypedDict "CheckResult" has no key "idd"  [typeddict-item]` with `Did you mean "id"?` hint. Revert.
- [ ] `uv run pytest tests/ --ignore=tests/integration/ -m "not slow" -q` -- 2276 pass (matches `main`); the single failing `test_upstream_spec_unchanged` is a preexisting CNCF `.project` drift unrelated to this PR.
- [ ] `uv run pytest tests/packaging/test_wheel_install_config.py -m slow -v` -- 3 pass (paranoia; feature 022 does not touch packaging).
- [ ] `uv run ruff check .` -- clean.
- [ ] `uv run python scripts/validate_sync.py --verbose` -- TOML schema + handler-name registry + SARIF source all pass.