### PR TITLE
fix: specify utf-8 encoding for all text file I/O

### DIFF
--- a/packages/darnit-baseline/src/darnit_baseline/attestation/generator.py
+++ b/packages/darnit-baseline/src/darnit_baseline/attestation/generator.py
@@ -135,7 +135,7 @@ def generate_attestation_from_results(
     # Save the attestation
     try:
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
-        with open(output_path, 'w') as f:
+        with open(output_path, 'w', encoding="utf-8") as f:
             f.write(output)
         logger.info(f"Attestation saved to: {output_path}")
     except OSError as e:

--- a/packages/darnit-baseline/src/darnit_baseline/threat_model/dependencies.py
+++ b/packages/darnit-baseline/src/darnit_baseline/threat_model/dependencies.py
@@ -189,7 +189,7 @@ def _parse_go_mod(repo_path: str, declared: set[str]) -> None:
 
 
 def _read_file(path: str) -> str:
-    with open(path, errors="ignore") as f:
+    with open(path, errors="ignore", encoding="utf-8") as f:
         return f.read()
 
 

--- a/packages/darnit-baseline/src/darnit_baseline/tools.py
+++ b/packages/darnit-baseline/src/darnit_baseline/tools.py
@@ -1089,7 +1089,7 @@ def generate_threat_model(
 
             target = repo_path / output_path
             target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(content)
+            target.write_text(content, encoding="utf-8")
             return (
                 f"Threat model written to {output_path} ({len(content)} bytes, "
                 f"{len(emitted)} findings, {overflow.total} trimmed)"

--- a/packages/darnit-testchecks/src/darnit_testchecks/adapters/builtin.py
+++ b/packages/darnit-testchecks/src/darnit_testchecks/adapters/builtin.py
@@ -98,7 +98,7 @@ def check_pattern_not_found(
         for file_path in repo.glob(file_pattern):
             if file_path.is_file():
                 try:
-                    content = file_path.read_text(errors="ignore")
+                    content = file_path.read_text(errors="ignore", encoding="utf-8")
                     for pattern_name, regex in regex_patterns.items():
                         matches = re.findall(regex, content, re.MULTILINE)
                         if matches:
@@ -134,7 +134,7 @@ def check_pattern_found(
         for file_path in repo.glob(file_pattern):
             if file_path.is_file():
                 try:
-                    content = file_path.read_text(errors="ignore")
+                    content = file_path.read_text(errors="ignore", encoding="utf-8")
                     for pattern_name, regex in regex_patterns.items():
                         if re.search(regex, content, re.MULTILINE):
                             found[pattern_name] = True
@@ -589,7 +589,7 @@ See [LICENSE](LICENSE) for details.
                 source="testchecks",
             )
 
-        readme_path.write_text(content)
+        readme_path.write_text(content, encoding="utf-8")
         return RemediationResult(
             control_id="TEST-DOC-01",
             success=True,
@@ -641,7 +641,7 @@ Thumbs.db
                 source="testchecks",
             )
 
-        gitignore_path.write_text(content)
+        gitignore_path.write_text(content, encoding="utf-8")
         return RemediationResult(
             control_id="TEST-IGN-01",
             success=True,

--- a/packages/darnit/src/darnit/cli.py
+++ b/packages/darnit/src/darnit/cli.py
@@ -429,7 +429,7 @@ timeout = 300
 # check = {{ adapter = "kusari" }}
 '''
 
-    baseline_path.write_text(template)
+    baseline_path.write_text(template, encoding="utf-8")
     logger.info(f"✓ Created {baseline_path}")
     return 0
 
@@ -570,7 +570,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     config = {}
     if settings_path.exists():
         try:
-            config = json.loads(settings_path.read_text())
+            config = json.loads(settings_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in settings file: {settings_path}: {e}")
             return 1
@@ -594,7 +594,7 @@ def cmd_install(args: argparse.Namespace) -> int:
 
     try:
         json.dumps(config)  # validate before write
-        settings_path.write_text(json.dumps(config, indent=2) + "\n")
+        settings_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
     except Exception as e:
         logger.error(f"Failed to write settings file: {e}")
         return 1
@@ -765,7 +765,7 @@ def cmd_harness(args: argparse.Namespace) -> int:
             )
             return int(HarnessExitCode.SETUP_ERROR)
         try:
-            _tty_probe = open("/dev/tty", "r+", buffering=1)  # noqa: SIM115
+            _tty_probe = open("/dev/tty", "r+", buffering=1, encoding="utf-8")  # noqa: SIM115
             _tty_probe.close()
         except OSError as exc:
             _emit_exit_summary(

--- a/packages/darnit/src/darnit/config/discovery.py
+++ b/packages/darnit/src/darnit/config/discovery.py
@@ -141,7 +141,7 @@ def discover_project_name(local_path: str) -> str | None:
     try:
         pkg_path = os.path.join(local_path, "package.json")
         if os.path.exists(pkg_path):
-            with open(pkg_path) as f:
+            with open(pkg_path, encoding="utf-8") as f:
                 data = json.load(f)
                 if "name" in data:
                     return data["name"]
@@ -176,7 +176,7 @@ def discover_project_name(local_path: str) -> str | None:
     try:
         go_mod_path = os.path.join(local_path, "go.mod")
         if os.path.exists(go_mod_path):
-            with open(go_mod_path) as f:
+            with open(go_mod_path, encoding="utf-8") as f:
                 first_line = f.readline().strip()
                 if first_line.startswith("module "):
                     module_path = first_line[7:].strip()

--- a/packages/darnit/src/darnit/context/dot_project.py
+++ b/packages/darnit/src/darnit/context/dot_project.py
@@ -364,7 +364,7 @@ class DotProjectReader:
             yaml = YAML()
             yaml.preserve_quotes = True
 
-            with open(self.project_yaml) as f:
+            with open(self.project_yaml, encoding="utf-8") as f:
                 data = yaml.load(f)
 
             if data is None:
@@ -405,7 +405,7 @@ class DotProjectReader:
             from ruamel.yaml import YAML
 
             yaml = YAML()
-            with open(self.maintainers_yaml) as f:
+            with open(self.maintainers_yaml, encoding="utf-8") as f:
                 data = yaml.load(f)
 
             if data is None:
@@ -905,7 +905,7 @@ class DotProjectWriter:
 
         # Read existing content or create new
         if self.project_yaml.exists():
-            with open(self.project_yaml) as f:
+            with open(self.project_yaml, encoding="utf-8") as f:
                 data = yaml.load(f)
             if data is None:
                 data = {}
@@ -918,7 +918,7 @@ class DotProjectWriter:
         self._deep_update(data, updates)
 
         # Write back
-        with open(self.project_yaml, "w") as f:
+        with open(self.project_yaml, "w", encoding="utf-8") as f:
             yaml.dump(data, f)
 
         logger.info("Updated .project/project.yaml")

--- a/packages/darnit/src/darnit/context/dot_project_org.py
+++ b/packages/darnit/src/darnit/context/dot_project_org.py
@@ -168,7 +168,7 @@ class OrgProjectResolver:
                 )
 
             if project_content:
-                (project_dir / "project.yaml").write_text(project_content)
+                (project_dir / "project.yaml").write_text(project_content, encoding="utf-8")
             else:
                 logger.debug("No project.yaml found in %s/.project", owner)
                 return None
@@ -182,7 +182,7 @@ class OrgProjectResolver:
                     owner, ".project/maintainers.yaml"
                 )
             if maintainers_content:
-                (project_dir / "maintainers.yaml").write_text(maintainers_content)
+                (project_dir / "maintainers.yaml").write_text(maintainers_content, encoding="utf-8")
 
             # Parse using existing reader
             reader = DotProjectReader(tmpdir)

--- a/packages/darnit/src/darnit/context/sieve.py
+++ b/packages/darnit/src/darnit/context/sieve.py
@@ -232,7 +232,7 @@ class ContextSieve:
             filepath = path / filename
             if filepath.exists():
                 try:
-                    content = filepath.read_text()
+                    content = filepath.read_text(encoding="utf-8")
                     maintainers = self._parse_maintainers_file(content)
                     if maintainers:
                         signals.append(ContextSignal(
@@ -251,7 +251,7 @@ class ContextSieve:
             filepath = path / codeowners_path
             if filepath.exists():
                 try:
-                    content = filepath.read_text()
+                    content = filepath.read_text(encoding="utf-8")
                     owners = self._parse_codeowners(content)
                     if owners:
                         signals.append(ContextSignal(
@@ -282,7 +282,7 @@ class ContextSieve:
         package_json = path / "package.json"
         if package_json.exists():
             try:
-                data = json.loads(package_json.read_text())
+                data = json.loads(package_json.read_text(encoding="utf-8"))
                 authors = []
 
                 # Get author
@@ -332,7 +332,7 @@ class ContextSieve:
 
             if tomllib:
                 try:
-                    data = tomllib.loads(pyproject.read_text())
+                    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
                     authors = []
 
                     # Get authors from [project] section
@@ -437,7 +437,7 @@ class ContextSieve:
             filepath = path / filename
             if filepath.exists():
                 try:
-                    content = filepath.read_text()
+                    content = filepath.read_text(encoding="utf-8")
                     contact = self._parse_security_contact(content)
                     if contact:
                         signals.append(ContextSignal(
@@ -462,7 +462,7 @@ class ContextSieve:
             filepath = path / filename
             if filepath.exists():
                 try:
-                    content = filepath.read_text()
+                    content = filepath.read_text(encoding="utf-8")
                     # Look for security section
                     security_section = re.search(
                         r"(?:^|\n)#+\s*Security[^\n]*\n([\s\S]*?)(?=\n#+|\Z)",
@@ -498,7 +498,7 @@ class ContextSieve:
             filepath = path / filename
             if filepath.exists():
                 try:
-                    content = filepath.read_text()
+                    content = filepath.read_text(encoding="utf-8")
                     model = self._parse_governance_model(content)
                     if model:
                         signals.append(ContextSignal(

--- a/packages/darnit/src/darnit/core/audit_cache.py
+++ b/packages/darnit/src/darnit/core/audit_cache.py
@@ -135,7 +135,7 @@ def write_audit_cache(
     # Atomic write: write to temp file in same directory, then rename.
     fd, tmp_path = tempfile.mkstemp(dir=str(cache_dir), suffix=".tmp", prefix="audit-cache-")
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(envelope, f, indent=2)
         os.replace(tmp_path, str(cache_path))
         logger.debug("Wrote audit cache to %s", cache_path)
@@ -167,7 +167,7 @@ def read_audit_cache(local_path: str, ttl_seconds: int = 3600) -> dict[str, Any]
 
     # Parse JSON
     try:
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             data = json.load(f)
     except (json.JSONDecodeError, OSError) as exc:
         logger.debug("Corrupt or unreadable audit cache: %s", exc)

--- a/packages/darnit/src/darnit/core/handlers.py
+++ b/packages/darnit/src/darnit/core/handlers.py
@@ -101,7 +101,7 @@ class TemplateInfo:
     def load_content(self) -> str:
         """Load template content from file."""
         if self.content is None:
-            self.content = self.path.read_text()
+            self.content = self.path.read_text(encoding="utf-8")
         return self.content
 
 

--- a/packages/darnit/src/darnit/core/verification.py
+++ b/packages/darnit/src/darnit/core/verification.py
@@ -223,7 +223,7 @@ class VerificationCache:
             return None
 
         try:
-            with open(cache_path) as f:
+            with open(cache_path, encoding="utf-8") as f:
                 data = json.load(f)
 
             # Check expiration
@@ -298,7 +298,7 @@ class VerificationCache:
                 "version": version,
             }
 
-            with open(cache_path, "w") as f:
+            with open(cache_path, "w", encoding="utf-8") as f:
                 json.dump(data, f)
 
             logger.debug(f"Cached verification result for {package_name}:{version}")

--- a/packages/darnit/src/darnit/harness/interactive_resolver.py
+++ b/packages/darnit/src/darnit/harness/interactive_resolver.py
@@ -71,7 +71,7 @@ class InteractiveTerminalResolver:
             from darnit.harness.driver import HarnessSetupError
 
             try:
-                self._tty = open("/dev/tty", "r+", buffering=1)  # noqa: SIM115
+                self._tty = open("/dev/tty", "r+", buffering=1, encoding="utf-8")  # noqa: SIM115
             except OSError as exc:
                 raise HarnessSetupError(
                     "interactive channel unavailable (/dev/tty not openable): "

--- a/packages/darnit/src/darnit/remediation/executor.py
+++ b/packages/darnit/src/darnit/remediation/executor.py
@@ -338,7 +338,7 @@ class RemediationExecutor:
                 ) from err
 
             try:
-                with open(resolved) as f:
+                with open(resolved, encoding="utf-8") as f:
                     return f.read()
             except OSError as e:
                 logger.warning(f"Failed to read template file {resolved}: {e}")

--- a/packages/darnit/src/darnit/remediation/helpers.py
+++ b/packages/darnit/src/darnit/remediation/helpers.py
@@ -50,7 +50,7 @@ def write_file_safe(path: str, content: str) -> tuple[bool, str]:
         Tuple of (success: bool, message: str)
     """
     try:
-        with open(path, 'w') as f:
+        with open(path, 'w', encoding="utf-8") as f:
             f.write(content)
         return True, f"Successfully wrote {path}"
     except OSError as e:

--- a/packages/darnit/src/darnit/server/tools/test_repository.py
+++ b/packages/darnit/src/darnit/server/tools/test_repository.py
@@ -55,7 +55,7 @@ def create_test_repository_impl(
   }
 }
 """
-    with open(os.path.join(repo_path, "package.json"), "w") as f:
+    with open(os.path.join(repo_path, "package.json"), "w", encoding="utf-8") as f:
         f.write(package_json)
 
     # Create src/index.js
@@ -67,7 +67,7 @@ console.log('');
 console.log('Run an OpenSSF Baseline audit to see what is missing:');
 console.log(chalk.cyan('  audit_openssf_baseline(local_path=".")'));
 """
-    with open(os.path.join(repo_path, "src", "index.js"), "w") as f:
+    with open(os.path.join(repo_path, "src", "index.js"), "w", encoding="utf-8") as f:
         f.write(index_js)
 
     # Create minimal .gitignore (intentionally missing security exclusions)
@@ -75,7 +75,7 @@ console.log(chalk.cyan('  audit_openssf_baseline(local_path=".")'));
 # This is MISSING important security exclusions!
 node_modules/
 """
-    with open(os.path.join(repo_path, ".gitignore"), "w") as f:
+    with open(os.path.join(repo_path, ".gitignore"), "w", encoding="utf-8") as f:
         f.write(gitignore)
 
     # Initialize git

--- a/scripts/create-example-test-repo.py
+++ b/scripts/create-example-test-repo.py
@@ -71,7 +71,7 @@ name = "hygiene-test"
 version = "0.0.1"
 requires-python = ">=3.10"
 """
-    (repo_path / "pyproject.toml").write_text(pyproject)
+    (repo_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
 
     # -- src/main.py ----------------------------------------------------------
     main_py = """\
@@ -84,7 +84,7 @@ def main():
 if __name__ == "__main__":
     main()
 """
-    (repo_path / "src" / "main.py").write_text(main_py)
+    (repo_path / "src" / "main.py").write_text(main_py, encoding="utf-8")
 
     # -- .mcp.json (points back to darnit workspace) -------------------------
     mcp_config = {
@@ -103,7 +103,7 @@ if __name__ == "__main__":
             }
         }
     }
-    (repo_path / ".mcp.json").write_text(json.dumps(mcp_config, indent=2) + "\n")
+    (repo_path / ".mcp.json").write_text(json.dumps(mcp_config, indent=2) + "\n", encoding="utf-8")
 
     # -- CLAUDE.md (instructions for Claude Code) -----------------------------
     claude_md = """\
@@ -133,7 +133,7 @@ then fix each failing control.
 | PH-QA-01 | CONTRIBUTING.md |
 | PH-CI-01 | .github/workflows/*.yml |
 """
-    (repo_path / "CLAUDE.md").write_text(claude_md)
+    (repo_path / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
 
     # -- Initialize git -------------------------------------------------------
     try:
@@ -209,42 +209,45 @@ def remediate_repo(repo_path_str: str) -> None:
     if not readme.exists():
         readme.write_text(
             "# hygiene-test-repo\n\n"
-            "A test project for the Project Hygiene Standard demo.\n"
+            "A test project for the Project Hygiene Standard demo.\n",
+            encoding="utf-8",
         )
         created.append("README.md")
 
     # PH-DOC-02: LICENSE
     license_file = repo_path / "LICENSE"
     if not license_file.exists():
-        license_file.write_text("MIT License - test project for demo purposes.\n")
+        license_file.write_text("MIT License - test project for demo purposes.\n", encoding="utf-8")
         created.append("LICENSE")
 
     # PH-SEC-01: SECURITY.md
     security = repo_path / "SECURITY.md"
     if not security.exists():
         security.write_text(
-            "# Security Policy\n\nTo report a vulnerability, open an issue.\n"
+            "# Security Policy\n\nTo report a vulnerability, open an issue.\n",
+            encoding="utf-8",
         )
         created.append("SECURITY.md")
 
     # PH-CFG-01: .gitignore
     gitignore = repo_path / ".gitignore"
     if not gitignore.exists():
-        gitignore.write_text("*.pyc\n__pycache__/\n")
+        gitignore.write_text("*.pyc\n__pycache__/\n", encoding="utf-8")
         created.append(".gitignore")
 
     # PH-CFG-02: .editorconfig
     editorconfig = repo_path / ".editorconfig"
     if not editorconfig.exists():
         editorconfig.write_text(
-            "root = true\n\n[*]\nindent_style = space\nindent_size = 4\n"
+            "root = true\n\n[*]\nindent_style = space\nindent_size = 4\n",
+            encoding="utf-8",
         )
         created.append(".editorconfig")
 
     # PH-QA-01: CONTRIBUTING.md
     contributing = repo_path / "CONTRIBUTING.md"
     if not contributing.exists():
-        contributing.write_text("# Contributing\n\nOpen a pull request.\n")
+        contributing.write_text("# Contributing\n\nOpen a pull request.\n", encoding="utf-8")
         created.append("CONTRIBUTING.md")
 
     # PH-CI-01: CI config
@@ -259,7 +262,8 @@ def remediate_repo(repo_path_str: str) -> None:
             "  check:\n"
             "    runs-on: ubuntu-latest\n"
             "    steps:\n"
-            "      - uses: actions/checkout@v4\n"
+            "      - uses: actions/checkout@v4\n",
+            encoding="utf-8",
         )
         created.append(".github/workflows/ci.yml")
 

--- a/scripts/validate_sync.py
+++ b/scripts/validate_sync.py
@@ -121,7 +121,7 @@ def validate_pass_types_sync() -> ValidationResult:
             message="Cannot validate handler names: spec not found",
         )
 
-    spec_content = SPEC_PATH.read_text()
+    spec_content = SPEC_PATH.read_text(encoding="utf-8")
 
     # Expected built-in handler names from spec (registered handler names only)
     spec_handler_names = set()
@@ -138,7 +138,7 @@ def validate_pass_types_sync() -> ValidationResult:
             details=str(handlers_file),
         )
 
-    code_content = handlers_file.read_text()
+    code_content = handlers_file.read_text(encoding="utf-8")
 
     missing_in_code = []
     for handler_name in spec_handler_names:
@@ -173,7 +173,7 @@ def validate_sarif_reads_from_toml() -> ValidationResult:
             details=str(sarif_path),
         )
 
-    content = sarif_path.read_text()
+    content = sarif_path.read_text(encoding="utf-8")
 
     # Check for TOML loading
     if "_load_framework_config" not in content:

--- a/tests/darnit/remediation/test_helpers.py
+++ b/tests/darnit/remediation/test_helpers.py
@@ -83,7 +83,7 @@ class TestWriteFileSafe:
         content = "Hello, 世界! 🌍"
         success, msg = write_file_safe(str(filepath), content)
         assert success is True
-        assert filepath.read_text() == content
+        assert filepath.read_text(encoding="utf-8") == content
 
     @pytest.mark.unit
     def test_invalid_path(self, temp_dir: Path):


### PR DESCRIPTION
## Summary

Text-mode file I/O across `packages/*/src` and `scripts/` relied on Python's platform-default encoding. On Linux/macOS that's UTF-8, so this is invisible in CI. On Windows it's the locale codepage (cp1252), and any character outside it raises `UnicodeEncodeError` on write or `UnicodeDecodeError` on read.

51 call sites across 18 files now pass `encoding="utf-8"` explicitly. Binary-mode opens and `urlopen` are untouched.

Why this is a bug, not a style change:

- **`write_file_safe` crashed callers instead of returning an error.** It catches `OSError`, but `UnicodeEncodeError` subclasses `ValueError` — so on Windows, remediation writing a template containing a curly quote, em dash, or emoji raised through the safety net rather than returning `(False, msg)`.
- **`scripts/validate_sync.py` silently skipped two thirds of its checks.** On Windows it died at the first `read_text()`, so the handler-name registry and SARIF-source validations never ran at all. All three now complete
- **Cache files were non-portable.** `audit_cache.py` and `verification.py` wrote JSON with the platform codepage and read it back the same way

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist
If this PR modifies the darnit framework (`packages/darnit/`):
- [ ] Updated framework spec (`docs/architecture/framework-design.md`) if behavior changed — n/a, no behavior change
- [x] Ran `uv run python scripts/validate_sync.py --verbose` and it passes

## Control/TOML Changes Checklist
If this PR modifies controls or TOML configuration:
- [ ] n/a — no controls or TOML touched

## Testing
- [x] Tests pass locally
- [ ] Added tests for new functionality (if applicable) — n/a, existing test now passes
- [x] Linting passes (`uv run ruff check .`)

Windows 11, Python 3.12.13. Baseline measured on `4da483a` before the change; `tests/integration` excluded and the CNCF `.project/` hash canary deselected in both runs.

- Before: 30 failed, 2679 passed
- After: **29 failed**, 2681 passed — `TestWriteFileSafe::test_writes_unicode` now passes
- `uv run ruff check .` — clean
- `uv run python scripts/validate_sync.py --verbose` — PASS (previously crashed at the first check):

```
✓ TOML Schema: TOML schema valid (66 controls)
✓ Pass Types Sync: Handler names in sync (7 handlers)
✓ SARIF Source: SARIF formatter reads from TOML (no catalog references)
PASSED: All validations successful
```

## Additional Notes
Remaining Windows failures are pre-existing and out of scope: path-separator assertions, `TestExecHandler` shelling out to `sleep`, and symlink privileges. Happy to take those in follow-ups.