### PR TITLE
fix(config): use [metadata] section header in gittuf and hello TOMLs

### DIFF
--- a/packages/darnit-gittuf/src/darnit_gittuf/gittuf.toml
+++ b/packages/darnit-gittuf/src/darnit_gittuf/gittuf.toml
@@ -1,4 +1,4 @@
-[framework]
+[metadata]
 name = "gittuf"
 display_name = "Gittuf Policy Checks"
 version = "0.1.0"

--- a/packages/darnit-hello/src/darnit_hello/hello.toml
+++ b/packages/darnit-hello/src/darnit_hello/hello.toml
@@ -13,7 +13,7 @@
 # Framework identity. Mirrors what HelloImplementation reports via its
 # `name`, `display_name`, `version`, and `spec_version` properties.
 # -----------------------------------------------------------------------------
-[framework]
+[metadata]
 name = "hello"
 display_name = "Hello — Minimal Darnit Plugin"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Both plugin TOMLs used `[framework]` where `FrameworkConfig` requires `[metadata]`, so both failed schema validation once the packaging fix made them loadable.

- `packages/darnit-gittuf/src/darnit_gittuf/gittuf.toml:1`
- `packages/darnit-hello/src/darnit_hello/hello.toml:16`

Two lines, header rename only. 

Fixes #361

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Framework Changes Checklist
If this PR modifies the darnit framework (`packages/darnit/`):
- [ ] n/a — no changes under `packages/darnit/`, only two plugin TOMLs

## Control/TOML Changes Checklist
If this PR modifies controls or TOML configuration:
- [x] Control metadata defined in TOML (not Python code) — unchanged, headers only
- [ ] SARIF fields (description, severity, help_url) included where appropriate — n/a, no control definitions touched
- [x] Ran validation to confirm TOML schema compliance

## Testing
- [x] Tests pass locally
- [ ] Added tests for new functionality (if applicable) — n/a
- [x] Linting passes (`uv run ruff check .`)
```
- gittuf
  Display: Gittuf Policy Checks
  Version: 0.1.0
  Spec: gittuf v0.1
  Controls: 3
- hello
  Display: Hello — Minimal Darnit Plugin
  Version: 0.1.0
  Spec: hello v0.1
  Controls: 1
```

Also confirmed directly:

```
>>> load_framework_by_name('gittuf').metadata
name='gittuf' display_name='Gittuf Policy Checks' version='0.1.0'
schema_version='0.1.0-alpha' spec_version='gittuf v0.1' ... url=None
```

`uv run pytest tests/darnit_gittuf -q` passes. There is no `tests/darnit_hello` directory.

## Additional Notes